### PR TITLE
Add range limiting to card effects

### DIFF
--- a/src/main/java/nomadrealms/game/card/expression/CardExpression.java
+++ b/src/main/java/nomadrealms/game/card/expression/CardExpression.java
@@ -11,4 +11,8 @@ public interface CardExpression {
 
 	public List<Intent> intents(World world, Target target, CardPlayer source);
 
+	default boolean isInRange(World world, Target target, CardPlayer source, int range) {
+		int distance = world.calculateDistance(source.tile(), target.tile());
+		return distance <= range;
+	}
 }

--- a/src/main/java/nomadrealms/game/card/expression/CreateStructureExpression.java
+++ b/src/main/java/nomadrealms/game/card/expression/CreateStructureExpression.java
@@ -22,7 +22,10 @@ public class CreateStructureExpression implements CardExpression {
 
     @Override
     public List<Intent> intents(World world, Target target, CardPlayer source) {
-        return singletonList(new CreateStructureIntent(source, (Tile) target, structureType));
+        if (isInRange(world, target, source, source.tile().range())) {
+            return singletonList(new CreateStructureIntent(source, (Tile) target, structureType));
+        }
+        return List.of();
     }
 
 }

--- a/src/main/java/nomadrealms/game/card/expression/DamageExpression.java
+++ b/src/main/java/nomadrealms/game/card/expression/DamageExpression.java
@@ -20,7 +20,10 @@ public class DamageExpression implements CardExpression {
 
 	@Override
 	public List<Intent> intents(World world, Target target, CardPlayer source) {
-		return singletonList(new DamageIntent(target, source, amount));
+		if (isInRange(world, target, source, source.tile().range())) {
+			return singletonList(new DamageIntent(target, source, amount));
+		}
+		return List.of();
 	}
 
 }

--- a/src/main/java/nomadrealms/game/card/expression/EditTileExpression.java
+++ b/src/main/java/nomadrealms/game/card/expression/EditTileExpression.java
@@ -22,7 +22,10 @@ public class EditTileExpression implements CardExpression {
 
     @Override
     public List<Intent> intents(World world, Target target, CardPlayer source) {
-        return singletonList(new EditTileIntent(source, (Tile) target, tileType));
+        if (isInRange(world, target, source, source.tile().range())) {
+            return singletonList(new EditTileIntent(source, (Tile) target, tileType));
+        }
+        return List.of();
     }
 
 }

--- a/src/main/java/nomadrealms/game/card/expression/GatherExpression.java
+++ b/src/main/java/nomadrealms/game/card/expression/GatherExpression.java
@@ -20,7 +20,10 @@ public class GatherExpression implements CardExpression {
 
     @Override
     public List<Intent> intents(World world, Target target, CardPlayer source) {
-        return singletonList(new GatherIntent(source, source.tile(), range));
+        if (isInRange(world, target, source, range)) {
+            return singletonList(new GatherIntent(source, source.tile(), range));
+        }
+        return List.of();
     }
 
 }

--- a/src/main/java/nomadrealms/game/card/expression/MoveExpression.java
+++ b/src/main/java/nomadrealms/game/card/expression/MoveExpression.java
@@ -15,7 +15,10 @@ public class MoveExpression implements CardExpression {
 
 	@Override
 	public List<Intent> intents(World world, Target target, CardPlayer source) {
-		return singletonList(new MoveIntent(source, (Tile) target));
+		if (isInRange(world, target, source, source.tile().range())) {
+			return singletonList(new MoveIntent(source, (Tile) target));
+		}
+		return List.of();
 	}
 
 }

--- a/src/main/java/nomadrealms/game/card/intent/GatherIntent.java
+++ b/src/main/java/nomadrealms/game/card/intent/GatherIntent.java
@@ -7,7 +7,6 @@ import nomadrealms.game.world.map.area.Tile;
 
 public class GatherIntent implements Intent {
 
-
     private final CardPlayer source;
     private final Tile tile;
     private final int range;
@@ -21,10 +20,12 @@ public class GatherIntent implements Intent {
     @Override
     public void resolve(World world) {
         System.out.println("Ranged harvest not yet implemented");
-        while (!tile.items().isEmpty()) {
-            WorldItem item = tile.items().get(0);
-            tile.removeItem(item);
-            source.inventory().add(item);
+        for (Tile t : world.getTilesInRange(tile, range)) {
+            while (!t.items().isEmpty()) {
+                WorldItem item = t.items().get(0);
+                t.removeItem(item);
+                source.inventory().add(item);
+            }
         }
     }
 


### PR DESCRIPTION
Related to #17

Implement range limiting for card effects.

* Add `isInRange` method in `CardExpression.java` to check if the target is within range.
* Modify `intents` method in `DamageExpression.java`, `CreateStructureExpression.java`, `EditTileExpression.java`, `GatherExpression.java`, and `MoveExpression.java` to check if the target is within range before creating intents.
* Implement range-based gathering logic in `GatherIntent.java`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/virtual-cardboard/nomad-realms/issues/17?shareId=170b9650-dd88-44cf-8e52-9acc80b0988a).