### PR TITLE
Fix Tile 'dl' downleft function to change chunk on correct x parity and add tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
   "tasks": {
-    "test": "mvn test"
+    "test": "mvn test",
+    "build": "mvn install"
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "test": "mvn test"
+  }
+}

--- a/src/main/java/nomadrealms/game/world/map/area/coordinate/TileCoordinate.java
+++ b/src/main/java/nomadrealms/game/world/map/area/coordinate/TileCoordinate.java
@@ -64,14 +64,14 @@ public class TileCoordinate extends Coordinate {
 
 	// Down Left
 	public TileCoordinate dl() {
-		int tileY = posMod(x() % 2 == 0? y() : y() + 1, CHUNK_SIZE);
-		int tileX = posMod(x() - 1, CHUNK_SIZE);
+		int newTileY = posMod(x() % 2 == 0? y() : y() + 1, CHUNK_SIZE);
+		int newTileX = posMod(x() - 1, CHUNK_SIZE);
 
 		ChunkCoordinate chunkCoord = chunk;
-		chunkCoord = y() == CHUNK_SIZE - 1 ? chunkCoord.down() : chunkCoord;
-		chunkCoord = x() == 0 ? chunkCoord.left() : chunkCoord;
+		chunkCoord = (y() == CHUNK_SIZE - 1 && (x() % 2 == 1)) ? chunkCoord.down() : chunkCoord;
+		chunkCoord = (x() == 0) ? chunkCoord.left() : chunkCoord;
 
-		return new TileCoordinate(chunkCoord, tileX, tileY);
+		return new TileCoordinate(chunkCoord, newTileX, newTileY);
 	}
 
 	// Down Middle

--- a/src/test/java/nomadrealms/game/world/map/area/coordinate/TileCoordinateTest.java
+++ b/src/test/java/nomadrealms/game/world/map/area/coordinate/TileCoordinateTest.java
@@ -7,51 +7,83 @@ import org.junit.jupiter.api.Test;
 import common.math.Vector2i;
 
 public class TileCoordinateTest {
-	ChunkCoordinate chunk=createChunk(0,0);
+	ChunkCoordinate chunk = createChunk(0, 0);
 
 	@Test
 	void testDr() {
-		assertTileDownRight(0,0,   1, 8,  0,0,  2,  9);
-		assertTileDownRight(0,0,   2, 9,  0,0,  3,  9);    //X is even -> x increase y keep the same 
-		assertTileDownRight(0,0,   3, 9,  0,0,  4, 10);	   //X is odd  -> x increass, y increase 
-		assertTileDownRight(0,0,   4,10,  0,0,  5, 10);
-		
-		assertTileDownRight(0,0,  14, 4,  0,0, 15,  4);
-		assertTileDownRight(0,0,  15, 4,  1,0,  0,  5);
-		
-		assertTileDownRight(0,0,   4,14,  0,0,  5, 14);
-		assertTileDownRight(0,0,   5,14,  0,0,  6, 15);
-		assertTileDownRight(0,0,   6,15,  0,0,  7, 15);
-		assertTileDownRight(0,0,   7,15,  0,1,  8,  0);
+		assertTileDownRight(0, 0, 1, 8, 0, 0, 2, 9);
+		assertTileDownRight(0, 0, 2, 9, 0, 0, 3, 9);  // x is even -> x increase, y stays the same
+		assertTileDownRight(0, 0, 3, 9, 0, 0, 4, 10); // x is odd -> x increase, y increase
+		assertTileDownRight(0, 0, 4, 10, 0, 0, 5, 10);
 
-		assertTileDownRight(0,0,  14,15,  0,0, 15, 15);
-		assertTileDownRight(0,0,  15,15,  1,1,  0,  0);
+		assertTileDownRight(0, 0, 14, 4, 0, 0, 15, 4);
+		assertTileDownRight(0, 0, 15, 4, 1, 0, 0, 5);
 
+		assertTileDownRight(0, 0, 4, 14, 0, 0, 5, 14);
+		assertTileDownRight(0, 0, 5, 14, 0, 0, 6, 15);
+		assertTileDownRight(0, 0, 6, 15, 0, 0, 7, 15);
+		assertTileDownRight(0, 0, 7, 15, 0, 1, 8, 0);
+
+		assertTileDownRight(0, 0, 14, 15, 0, 0, 15, 15);
+		assertTileDownRight(0, 0, 15, 15, 1, 1, 0, 0);
 	}
 
-	private void assertTileDownRight( int currChunkX, int currChunkY, int currTileX, int currTileY,
-			                          int nextChunkX, int nextChunkY, int nextTileX, int nextTileY) {
-		TileCoordinate currTile=createTile(currTileX,  currTileY,  currChunkX,  currChunkY);
-		TileCoordinate expectedDrTile=createTile(nextTileX,  nextTileY,  nextChunkX,  nextChunkY);
+	@Test
+	void testDl() {
+		assertTileDownLeft(0, 0, 1, 8, 0, 0, 0, 9);
+		assertTileDownLeft(0, 0, 2, 9, 0, 0, 1, 9);  // x is even -> x decrease, y stays the same
+		assertTileDownLeft(0, 0, 3, 9, 0, 0, 2, 10); // x is odd -> x decrease, y increase
+		assertTileDownLeft(0, 0, 4, 10, 0, 0, 3, 10);
+
+		assertTileDownLeft(0, 0, 14, 4, 0, 0, 13, 4);
+		assertTileDownLeft(0, 0, 15, 4, 0, 0, 14, 5);
+
+		assertTileDownLeft(0, 0, 4, 14, 0, 0, 3, 14);
+		assertTileDownLeft(0, 0, 5, 14, 0, 0, 4, 15);
+		assertTileDownLeft(0, 0, 6, 15, 0, 0, 5, 15);
+		assertTileDownLeft(0, 0, 7, 15, 0, 1, 6, 0);
+
+		assertTileDownLeft(0, 0, 14, 15, 0, 0, 13, 15);
+		assertTileDownLeft(0, 0, 15, 15, 0, 1, 14, 0);
+	}
+
+	private void assertTileDownRight(int currChunkX, int currChunkY, int currTileX, int currTileY, int nextChunkX,
+			int nextChunkY, int nextTileX, int nextTileY) {
+		TileCoordinate currTile = createTile(currTileX, currTileY, currChunkX, currChunkY);
+		TileCoordinate expectedDrTile = createTile(nextTileX, nextTileY, nextChunkX, nextChunkY);
 		System.out.println("");
-		TileCoordinate calculatedDrTile=currTile.dr();
-		System.out.println("Checking down right of tile "+currTile);
-		System.out.println("                   Expected  "+expectedDrTile);
-		System.out.println("                 Calculated  "+calculatedDrTile);
+		TileCoordinate calculatedDrTile = currTile.dr();
+		System.out.println("Checking down right of tile " + currTile);
+		System.out.println("                   Expected  " + expectedDrTile);
+		System.out.println("                 Calculated  " + calculatedDrTile);
 		assertEquals(expectedDrTile.x(), calculatedDrTile.x());
 		assertEquals(expectedDrTile.y(), calculatedDrTile.y());
 		assertEquals(expectedDrTile.chunk().x(), calculatedDrTile.chunk().x());
 		assertEquals(expectedDrTile.chunk().y(), calculatedDrTile.chunk().y());
 	}
-	
-	private TileCoordinate createTile(int currTileX, int currTileY, int currChunkX, int currChunkY ) {
-		return new TileCoordinate(createChunk(currChunkX, currChunkY), new Vector2i(currTileX,currTileY ));
+
+	private void assertTileDownLeft(int currChunkX, int currChunkY, int currTileX, int currTileY, int nextChunkX,
+			int nextChunkY, int nextTileX, int nextTileY) {
+		TileCoordinate currTile = createTile(currTileX, currTileY, currChunkX, currChunkY);
+		TileCoordinate expectedDlTile = createTile(nextTileX, nextTileY, nextChunkX, nextChunkY);
+		System.out.println("");
+		TileCoordinate calculatedDlTile = currTile.dl();
+		System.out.println("Checking down left of tile " + currTile);
+		System.out.println("                   Expected  " + expectedDlTile);
+		System.out.println("                 Calculated  " + calculatedDlTile);
+		assertEquals(expectedDlTile.x(), calculatedDlTile.x());
+		assertEquals(expectedDlTile.y(), calculatedDlTile.y());
+		assertEquals(expectedDlTile.chunk().x(), calculatedDlTile.chunk().x());
+		assertEquals(expectedDlTile.chunk().y(), calculatedDlTile.chunk().y());
+	}
+
+	private TileCoordinate createTile(int currTileX, int currTileY, int currChunkX, int currChunkY) {
+		return new TileCoordinate(createChunk(currChunkX, currChunkY), new Vector2i(currTileX, currTileY));
 	}
 
 	private ChunkCoordinate createChunk(int chunkX, int chunkY) {
-		RegionCoordinate region=new RegionCoordinate(new Vector2i(0,0));
-		ZoneCoordinate zone=new ZoneCoordinate(region, 0,0);
-		return new ChunkCoordinate(zone, chunkX,chunkY);
+		RegionCoordinate region = new RegionCoordinate(new Vector2i(0, 0));
+		ZoneCoordinate zone = new ZoneCoordinate(region, 0, 0);
+		return new ChunkCoordinate(zone, chunkX, chunkY);
 	}
-
 }


### PR DESCRIPTION
Fix the `dl` function in `TileCoordinate.java` to correctly change the chunk on the correct x parity.

* **TileCoordinate.java**
  - Update the `dl` function to correctly calculate new tile coordinates and handle chunk changes based on x parity.
  - Use the `dr` function as a reference for fixing the `dl` function.

* **.devcontainer/devcontainer.json**
  - Add a devcontainer configuration file with a test task to run Maven tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/virtual-cardboard/nomad-realms/pull/25?shareId=5605166a-d09f-4b6e-ae74-852561b698bc).