### PR TITLE
Implement BFS for path function in GameMap

### DIFF
--- a/src/main/java/nomadrealms/app/context/MainContext.java
+++ b/src/main/java/nomadrealms/app/context/MainContext.java
@@ -1,6 +1,7 @@
 package nomadrealms.app.context;
 
 import static common.colour.Colour.rgb;
+import static nomadrealms.game.world.map.area.Tile.showTileCoordinates;
 import static nomadrealms.game.world.map.generation.status.biome.nomenclature.BiomeCategory.HUMIDITY_CEIL;
 import static nomadrealms.game.world.map.generation.status.biome.nomenclature.BiomeCategory.HUMIDITY_FLOOR;
 import static nomadrealms.game.world.map.generation.status.biome.nomenclature.BiomeCategory.TEMPERATURE_CEIL;
@@ -8,6 +9,7 @@ import static nomadrealms.game.world.map.generation.status.biome.nomenclature.Bi
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_A;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_D;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_E;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_F3;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_M;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_S;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_W;
@@ -101,6 +103,8 @@ public class MainContext extends GameContext {
 			case GLFW_KEY_D:
 				re.camera.right(true);
 				break;
+			case GLFW_KEY_F3:
+				showTileCoordinates = true;
 			default:
 				System.out.println("second context key pressed: " + key);
 		}
@@ -121,6 +125,8 @@ public class MainContext extends GameContext {
 			case GLFW_KEY_D:
 				re.camera.right(false);
 				break;
+			case GLFW_KEY_F3:
+				showTileCoordinates = false;
 			default:
 				System.out.println("second context key released: " + key);
 		}

--- a/src/main/java/nomadrealms/game/card/action/MoveAction.java
+++ b/src/main/java/nomadrealms/game/card/action/MoveAction.java
@@ -19,6 +19,9 @@ public class MoveAction implements Action {
 	@Override
 	public void update(World world) {
 		List<Tile> path = world.map().path(source.tile(), target);
+		if (!path.isEmpty()) {
+			source.move(path.get(0));
+		}
 	}
 
 	@Override

--- a/src/main/java/nomadrealms/game/world/GameMap.java
+++ b/src/main/java/nomadrealms/game/world/GameMap.java
@@ -1,13 +1,12 @@
 package nomadrealms.game.world;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import common.math.Vector2f;
 import nomadrealms.game.world.map.area.Region;
 import nomadrealms.game.world.map.area.Tile;
 import nomadrealms.game.world.map.area.coordinate.RegionCoordinate;
+import nomadrealms.game.world.map.area.coordinate.TileCoordinate;
 import nomadrealms.game.world.map.generation.MapGenerationStrategy;
 import nomadrealms.render.RenderingEnvironment;
 
@@ -43,7 +42,52 @@ public class GameMap {
 	}
 
 	public List<Tile> path(Tile source, Tile target) {
-		throw new UnsupportedOperationException("Not yet implemented");
+		if (source.equals(target)) {
+			return Collections.singletonList(source);
+		}
+
+		Map<Tile, Tile> cameFrom = new HashMap<>();
+		Queue<Tile> frontier = new LinkedList<>();
+		frontier.add(source);
+
+		while (!frontier.isEmpty()) {
+			Tile current = frontier.poll();
+
+			for (Tile next : getNeighbors(current)) {
+				if (!cameFrom.containsKey(next)) {
+					frontier.add(next);
+					cameFrom.put(next, current);
+
+					if (next.equals(target)) {
+						return reconstructPath(cameFrom, source, target);
+					}
+				}
+			}
+		}
+
+		return Collections.emptyList();
 	}
 
+	private List<Tile> getNeighbors(Tile tile) {
+		List<Tile> neighbors = new ArrayList<>();
+		neighbors.add(tile.ul(world));
+		neighbors.add(tile.um(world));
+		neighbors.add(tile.ur(world));
+		neighbors.add(tile.dl(world));
+		neighbors.add(tile.dm(world));
+		neighbors.add(tile.dr(world));
+		return neighbors;
+	}
+
+	private List<Tile> reconstructPath(Map<Tile, Tile> cameFrom, Tile start, Tile goal) {
+		List<Tile> path = new ArrayList<>();
+		Tile current = goal;
+		while (!current.equals(start)) {
+			path.add(current);
+			current = cameFrom.get(current);
+		}
+		path.add(start);
+		Collections.reverse(path);
+		return path;
+	}
 }

--- a/src/main/java/nomadrealms/game/world/GameMap.java
+++ b/src/main/java/nomadrealms/game/world/GameMap.java
@@ -1,12 +1,17 @@
 package nomadrealms.game.world;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
 
 import common.math.Vector2f;
 import nomadrealms.game.world.map.area.Region;
 import nomadrealms.game.world.map.area.Tile;
 import nomadrealms.game.world.map.area.coordinate.RegionCoordinate;
-import nomadrealms.game.world.map.area.coordinate.TileCoordinate;
 import nomadrealms.game.world.map.generation.MapGenerationStrategy;
 import nomadrealms.render.RenderingEnvironment;
 
@@ -90,4 +95,5 @@ public class GameMap {
 		Collections.reverse(path);
 		return path;
 	}
+
 }

--- a/src/main/java/nomadrealms/game/world/map/area/Tile.java
+++ b/src/main/java/nomadrealms/game/world/map/area/Tile.java
@@ -25,6 +25,8 @@ import visuals.lwjgl.render.meta.DrawFunction;
  */
 public class Tile implements Target {
 
+	public static boolean showTileCoordinates = true;
+
 	public static final float TILE_RADIUS = 40;
 	private static final float ITEM_SIZE = TILE_RADIUS * 0.6f;
 	public static final float TILE_HORIZONTAL_SPACING = TILE_RADIUS * SIDE_LENGTH * 1.5f;
@@ -91,6 +93,20 @@ public class Tile implements Target {
 								re.imageMap.get(item.item().image()),
 								screenPosition.x() - ITEM_SIZE * 0.5f, screenPosition.y() - ITEM_SIZE * 0.5f,
 								ITEM_SIZE, ITEM_SIZE);
+					}
+					if (showTileCoordinates) {
+						re.textRenderer.alignCenterHorizontal();
+						re.textRenderer.alignCenterVertical();
+						re.textRenderer.render(
+								screenPosition.x(), screenPosition.y(),
+								coord.x() + ", " + coord.y(),
+								0,
+								re.font,
+								0.35f * TILE_RADIUS,
+								rgb(255, 255, 255)
+						);
+						re.textRenderer.alignLeft();
+						re.textRenderer.alignTop();
 					}
 				});
 	}

--- a/src/test/java/nomadrealms/game/world/GameMapTest.java
+++ b/src/test/java/nomadrealms/game/world/GameMapTest.java
@@ -1,0 +1,61 @@
+package nomadrealms.game.world;
+
+import nomadrealms.game.world.map.area.Tile;
+import nomadrealms.game.world.map.area.coordinate.TileCoordinate;
+import nomadrealms.game.world.map.generation.MapGenerationStrategy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GameMapTest {
+
+    private GameMap gameMap;
+    private World world;
+
+    @BeforeEach
+    void setUp() {
+        world = new World(null, 0);
+        MapGenerationStrategy strategy = new MapGenerationStrategy() {
+            @Override
+            public Tile[][] generateChunk(Zone zone, Chunk chunk, ChunkCoordinate coord) {
+                Tile[][] tiles = new Tile[16][16];
+                for (int i = 0; i < 16; i++) {
+                    for (int j = 0; j < 16; j++) {
+                        tiles[i][j] = new Tile(chunk, new TileCoordinate(coord, i, j));
+                    }
+                }
+                return tiles;
+            }
+
+            @Override
+            public Chunk[][] generateZone(World world, Zone zone) {
+                Chunk[][] chunks = new Chunk[16][16];
+                for (int i = 0; i < 16; i++) {
+                    for (int j = 0; j < 16; j++) {
+                        Chunk chunk = new Chunk(zone, new ChunkCoordinate(zone.coord(), i, j));
+                        chunk.tiles(generateChunk(zone, chunk, new ChunkCoordinate(zone.coord(), i, j)));
+                        chunks[i][j] = chunk;
+                    }
+                }
+                return chunks;
+            }
+        };
+        gameMap = new GameMap(world, strategy);
+    }
+
+    @Test
+    void testPathFinding() {
+        Tile source = world.getTile(new TileCoordinate(new ChunkCoordinate(new ZoneCoordinate(new RegionCoordinate(0, 0), 0, 0), 0, 0), 0, 0));
+        Tile target = world.getTile(new TileCoordinate(new ChunkCoordinate(new ZoneCoordinate(new RegionCoordinate(0, 0), 0, 0), 0, 1), 15, 15));
+
+        List<Tile> path = gameMap.path(source, target);
+
+        assertNotNull(path);
+        assertFalse(path.isEmpty());
+        assertEquals(source, path.get(0));
+        assertEquals(target, path.get(path.size() - 1));
+    }
+}

--- a/src/test/java/nomadrealms/game/world/GameMapTest.java
+++ b/src/test/java/nomadrealms/game/world/GameMapTest.java
@@ -1,7 +1,6 @@
 package nomadrealms.game.world;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
@@ -54,15 +53,16 @@ class GameMapTest {
 	}
 
 	@Test
-	void testPathFinding() {
-		Tile source = world.getTile(new TileCoordinate(new ChunkCoordinate(new ZoneCoordinate(new RegionCoordinate(0, 0), 0, 0), 0, 0), 0, 0));
-		Tile target = world.getTile(new TileCoordinate(new ChunkCoordinate(new ZoneCoordinate(new RegionCoordinate(0, 0), 0, 0), 0, 1), 15, 15));
+	void testSimplePathFinding() {
+		Tile source = world.getTile(new TileCoordinate(new ChunkCoordinate(new ZoneCoordinate(new RegionCoordinate(0, 0), 0, 0), 0, 1), 13, 0));
+		Tile target = world.getTile(new TileCoordinate(new ChunkCoordinate(new ZoneCoordinate(new RegionCoordinate(0, 0), 0, 0), 0, 0), 15, 15));
 
 		List<Tile> path = gameMap.path(source, target);
 
 		assertNotNull(path);
-		assertFalse(path.isEmpty());
+		assertEquals(3, path.size());
 		assertEquals(source, path.get(0));
+		assertEquals(source.ur(world), path.get(1));
 		assertEquals(target, path.get(path.size() - 1));
 	}
 

--- a/src/test/java/nomadrealms/game/world/GameMapTest.java
+++ b/src/test/java/nomadrealms/game/world/GameMapTest.java
@@ -1,61 +1,69 @@
 package nomadrealms.game.world;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import nomadrealms.game.world.map.area.Chunk;
 import nomadrealms.game.world.map.area.Tile;
+import nomadrealms.game.world.map.area.Zone;
+import nomadrealms.game.world.map.area.coordinate.ChunkCoordinate;
+import nomadrealms.game.world.map.area.coordinate.RegionCoordinate;
 import nomadrealms.game.world.map.area.coordinate.TileCoordinate;
+import nomadrealms.game.world.map.area.coordinate.ZoneCoordinate;
 import nomadrealms.game.world.map.generation.MapGenerationStrategy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 class GameMapTest {
 
-    private GameMap gameMap;
-    private World world;
+	private GameMap gameMap;
+	private World world;
 
-    @BeforeEach
-    void setUp() {
-        world = new World(null, 0);
-        MapGenerationStrategy strategy = new MapGenerationStrategy() {
-            @Override
-            public Tile[][] generateChunk(Zone zone, Chunk chunk, ChunkCoordinate coord) {
-                Tile[][] tiles = new Tile[16][16];
-                for (int i = 0; i < 16; i++) {
-                    for (int j = 0; j < 16; j++) {
-                        tiles[i][j] = new Tile(chunk, new TileCoordinate(coord, i, j));
-                    }
-                }
-                return tiles;
-            }
+	@BeforeEach
+	void setUp() {
+		world = new World(null, 0);
+		MapGenerationStrategy strategy = new MapGenerationStrategy() {
+			@Override
+			public Tile[][] generateChunk(Zone zone, Chunk chunk, ChunkCoordinate coord) {
+				Tile[][] tiles = new Tile[16][16];
+				for (int i = 0; i < 16; i++) {
+					for (int j = 0; j < 16; j++) {
+						tiles[i][j] = new Tile(chunk, new TileCoordinate(coord, i, j));
+					}
+				}
+				return tiles;
+			}
 
-            @Override
-            public Chunk[][] generateZone(World world, Zone zone) {
-                Chunk[][] chunks = new Chunk[16][16];
-                for (int i = 0; i < 16; i++) {
-                    for (int j = 0; j < 16; j++) {
-                        Chunk chunk = new Chunk(zone, new ChunkCoordinate(zone.coord(), i, j));
-                        chunk.tiles(generateChunk(zone, chunk, new ChunkCoordinate(zone.coord(), i, j)));
-                        chunks[i][j] = chunk;
-                    }
-                }
-                return chunks;
-            }
-        };
-        gameMap = new GameMap(world, strategy);
-    }
+			@Override
+			public Chunk[][] generateZone(World world, Zone zone) {
+				Chunk[][] chunks = new Chunk[16][16];
+				for (int i = 0; i < 16; i++) {
+					for (int j = 0; j < 16; j++) {
+						Chunk chunk = new Chunk(zone, new ChunkCoordinate(zone.coord(), i, j));
+						chunk.tiles(generateChunk(zone, chunk, new ChunkCoordinate(zone.coord(), i, j)));
+						chunks[i][j] = chunk;
+					}
+				}
+				return chunks;
+			}
+		};
+		gameMap = new GameMap(world, strategy);
+	}
 
-    @Test
-    void testPathFinding() {
-        Tile source = world.getTile(new TileCoordinate(new ChunkCoordinate(new ZoneCoordinate(new RegionCoordinate(0, 0), 0, 0), 0, 0), 0, 0));
-        Tile target = world.getTile(new TileCoordinate(new ChunkCoordinate(new ZoneCoordinate(new RegionCoordinate(0, 0), 0, 0), 0, 1), 15, 15));
+	@Test
+	void testPathFinding() {
+		Tile source = world.getTile(new TileCoordinate(new ChunkCoordinate(new ZoneCoordinate(new RegionCoordinate(0, 0), 0, 0), 0, 0), 0, 0));
+		Tile target = world.getTile(new TileCoordinate(new ChunkCoordinate(new ZoneCoordinate(new RegionCoordinate(0, 0), 0, 0), 0, 1), 15, 15));
 
-        List<Tile> path = gameMap.path(source, target);
+		List<Tile> path = gameMap.path(source, target);
 
-        assertNotNull(path);
-        assertFalse(path.isEmpty());
-        assertEquals(source, path.get(0));
-        assertEquals(target, path.get(path.size() - 1));
-    }
+		assertNotNull(path);
+		assertFalse(path.isEmpty());
+		assertEquals(source, path.get(0));
+		assertEquals(target, path.get(path.size() - 1));
+	}
+
 }


### PR DESCRIPTION
Implement breadth-first search (BFS) for pathfinding in `GameMap`.

* **GameMap.java**
  - Implement the `path` method using BFS to find the shortest path between source and target tiles.
  - Add helper methods `getNeighbors` and `reconstructPath` to support BFS.
* **MoveAction.java**
  - Update the `update` method to call the updated `GameMap.path` method and move the source to the first tile in the path if a path is found.
* **GameMapTest.java**
  - Add a test class to verify the `path` method in `GameMap` returns a valid path between source and target tiles.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/virtual-cardboard/nomad-realms/pull/33?shareId=588ad491-fef3-409d-8ddb-23759b674e02).