### PR TITLE
Add health and location print statements to FeralMonkeyTest

### DIFF
--- a/src/test/java/nomadrealms/game/FeralMonkeyTest.java
+++ b/src/test/java/nomadrealms/game/FeralMonkeyTest.java
@@ -36,6 +36,12 @@ public class FeralMonkeyTest {
 			}
 		}
 		System.out.println("Ticks taken for feral monkey to kill farmer: " + ticks);
+		if (farmer.health() > 0) {
+			System.out.println("Farmer health: " + farmer.health());
+			System.out.println("Feral Monkey health: " + feralMonkey.health());
+			System.out.println("Farmer location: " + farmer.tile().coord());
+			System.out.println("Feral Monkey location: " + feralMonkey.tile().coord());
+		}
 		assertTrue(farmer.health() <= 0, "Feral monkey did not kill the farmer within 400 ticks");
 	}
 


### PR DESCRIPTION
Add print statements to `testFeralMonkeyKillsFarmerWithin400Ticks` to print health and locations of monkey and farmer if the test fails.

* Print farmer's health if the test fails.
* Print feral monkey's health if the test fails.
* Print farmer's location if the test fails.
* Print feral monkey's location if the test fails.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/virtual-cardboard/nomad-realms/pull/36?shareId=08a11403-2a44-41f1-96e8-63ddb53e757a).