### PR TITLE
Add melee attack action and intent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>virtual-cardboard</groupId>
 			<artifactId>nengen</artifactId>
-			<version>0.0.4</version>
+			<version>0.0.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/src/main/java/nomadrealms/game/actor/HasPosition.java
+++ b/src/main/java/nomadrealms/game/actor/HasPosition.java
@@ -9,14 +9,8 @@ public interface HasPosition extends Target {
 		tile(target);
 	}
 
-	public default void move(Tile target, int animationTime) {
-		tile(target, animationTime);
-	}
-
 	public Tile tile();
 
 	public void tile(Tile tile);
-
-	public void tile(Tile tile, int animationTime);
 
 }

--- a/src/main/java/nomadrealms/game/actor/ai/FeralMonkeyAI.java
+++ b/src/main/java/nomadrealms/game/actor/ai/FeralMonkeyAI.java
@@ -1,7 +1,7 @@
 package nomadrealms.game.actor.ai;
 
-import static nomadrealms.game.card.GameCard.MELEE_ATTACK;
 import static nomadrealms.game.card.GameCard.MEANDER;
+import static nomadrealms.game.card.GameCard.MELEE_ATTACK;
 
 import java.util.Comparator;
 import java.util.Optional;
@@ -70,7 +70,7 @@ public class FeralMonkeyAI extends CardPlayerAI {
 
 	@Override
 	protected int resetThinkingTime() {
-		return (int) (Math.random() * 4) + 10;
+		return (int) (Math.random() * 2) + 10;
 	}
 
 }

--- a/src/main/java/nomadrealms/game/actor/ai/FeralMonkeyAI.java
+++ b/src/main/java/nomadrealms/game/actor/ai/FeralMonkeyAI.java
@@ -1,6 +1,6 @@
 package nomadrealms.game.actor.ai;
 
-import static nomadrealms.game.card.GameCard.ATTACK;
+import static nomadrealms.game.card.GameCard.MELEE_ATTACK;
 import static nomadrealms.game.card.GameCard.MEANDER;
 
 import java.util.Comparator;
@@ -42,7 +42,7 @@ public class FeralMonkeyAI extends CardPlayerAI {
 
 		// If there is an actor, go towards it if it's out of range
 		// If it's within range, attack it
-		if (nearestCardPlayer.tile().coord().distanceTo(self.tile().coord()) > ATTACK.targetingInfo().range()) {
+		if (nearestCardPlayer.tile().coord().distanceTo(self.tile().coord()) > MELEE_ATTACK.targetingInfo().range()) {
 			// For each 6 directions, check if the tile in that direction is closer to the target
 			Optional<Tile> closestTile = Stream
 					.of(
@@ -63,7 +63,7 @@ public class FeralMonkeyAI extends CardPlayerAI {
 			self.addNextPlay(new CardPlayedEvent(cardToPlay, self, closestTile.get()));
 		} else {
 			WorldCard cardToPlay = self.deckCollection().deck2().peek();
-			assert cardToPlay.card() == ATTACK;
+			assert cardToPlay.card() == MELEE_ATTACK;
 			self.addNextPlay(new CardPlayedEvent(cardToPlay, self, nearestCardPlayer));
 		}
 	}

--- a/src/main/java/nomadrealms/game/actor/ai/FeralMonkeyAI.java
+++ b/src/main/java/nomadrealms/game/actor/ai/FeralMonkeyAI.java
@@ -33,6 +33,7 @@ public class FeralMonkeyAI extends CardPlayerAI {
 				.filter(actor -> !(actor instanceof FeralMonkey))
 				.filter(actor -> actor instanceof CardPlayer)
 				.map(actor -> (CardPlayer) actor)
+				.filter(actor -> !actor.isDestroyed())
 				.filter(actor -> actor.tile().coord().distanceTo(self.tile().coord()) < 20)
 				.min(Comparator.comparingInt(a -> a.tile().coord().distanceTo(self.tile().coord())))
 				.orElse(null);

--- a/src/main/java/nomadrealms/game/actor/cardplayer/CardPlayer.java
+++ b/src/main/java/nomadrealms/game/actor/cardplayer/CardPlayer.java
@@ -25,11 +25,6 @@ public abstract class CardPlayer implements Actor {
 	private CardPlayerAI ai;
 	private transient Tile tile;
 	private int health;
-
-	private transient Tile previousTile;
-	private transient long movementStart = 0;
-	private transient int movementAnimationTime = 1;
-
 	/**
 	 * This is a list because theoretically an actor can make two input actions in the same frame if they're fast
 	 * enough.
@@ -95,21 +90,12 @@ public abstract class CardPlayer implements Actor {
 
 	@Override
 	public void tile(Tile tile) {
-		this.previousTile = this.tile;
 		this.tile = tile;
-	}
-
-	@Override
-	public void tile(Tile tile, int animationTime) {
-		this.previousTile = this.tile;
-		this.tile = tile;
-		this.movementStart = System.currentTimeMillis();
-		this.movementAnimationTime = animationTime;
 	}
 
 	public Vector2f getScreenPosition(RenderingEnvironment re) {
 		long time = System.currentTimeMillis();
-		
+
 //		float progress = (time - movementStart) / (float) (movementAnimationTime * re.config.getTickRate());
 //		if (tile == previousTile || progress > 1) {
 //			return tile.getScreenPosition(re);

--- a/src/main/java/nomadrealms/game/actor/cardplayer/FeralMonkey.java
+++ b/src/main/java/nomadrealms/game/actor/cardplayer/FeralMonkey.java
@@ -8,8 +8,8 @@ import static nomadrealms.game.actor.cardplayer.appendage.Appendage.HEAD;
 import static nomadrealms.game.actor.cardplayer.appendage.Appendage.LEG;
 import static nomadrealms.game.actor.cardplayer.appendage.Appendage.TAIL;
 import static nomadrealms.game.actor.cardplayer.appendage.Appendage.TORSO;
-import static nomadrealms.game.card.GameCard.ATTACK;
 import static nomadrealms.game.card.GameCard.MEANDER;
+import static nomadrealms.game.card.GameCard.MELEE_ATTACK;
 import static nomadrealms.game.world.map.area.Tile.TILE_RADIUS;
 
 import java.util.List;
@@ -40,7 +40,7 @@ public class FeralMonkey extends CardPlayer {
 		this.tile(tile);
 		this.health(10);
 		this.deckCollection().deck1().addCards(Stream.of(MEANDER).map(WorldCard::new));
-		this.deckCollection().deck2().addCards(Stream.of(ATTACK).map(WorldCard::new));
+		this.deckCollection().deck2().addCards(Stream.of(MELEE_ATTACK).map(WorldCard::new));
 	}
 
 	public void render(RenderingEnvironment re) {

--- a/src/main/java/nomadrealms/game/actor/cardplayer/FeralMonkey.java
+++ b/src/main/java/nomadrealms/game/actor/cardplayer/FeralMonkey.java
@@ -47,7 +47,7 @@ public class FeralMonkey extends CardPlayer {
 		float scale = 0.6f * TILE_RADIUS;
 		DefaultFrameBuffer.instance().render(
 				() -> {
-					Vector2f screenPosition = tile().getScreenPosition(re);
+					Vector2f screenPosition = getScreenPosition(re);
 					re.textureRenderer.render(
 							re.imageMap.get("feral_monkey"),
 							screenPosition.x() - 0.5f * scale,

--- a/src/main/java/nomadrealms/game/actor/cardplayer/Nomad.java
+++ b/src/main/java/nomadrealms/game/actor/cardplayer/Nomad.java
@@ -8,9 +8,9 @@ import static nomadrealms.game.actor.cardplayer.appendage.Appendage.EYE;
 import static nomadrealms.game.actor.cardplayer.appendage.Appendage.HEAD;
 import static nomadrealms.game.actor.cardplayer.appendage.Appendage.LEG;
 import static nomadrealms.game.actor.cardplayer.appendage.Appendage.TORSO;
-import static nomadrealms.game.card.GameCard.ATTACK;
 import static nomadrealms.game.card.GameCard.GATHER;
 import static nomadrealms.game.card.GameCard.HEAL;
+import static nomadrealms.game.card.GameCard.MELEE_ATTACK;
 import static nomadrealms.game.card.GameCard.MOVE;
 import static nomadrealms.game.world.map.area.Tile.TILE_RADIUS;
 
@@ -54,7 +54,7 @@ public class Nomad extends CardPlayer {
 				.addCard(new WorldCard(MOVE))
 				.addCard(new WorldCard(HEAL))
 				// .addCard(new WorldCard(ELECTROSTATIC_ZAPPER))
-				.addCard(new WorldCard(ATTACK))
+				.addCard(new WorldCard(MELEE_ATTACK))
 				.addCard(new WorldCard(GATHER));
 		deck.shuffle();
 	}

--- a/src/main/java/nomadrealms/game/actor/structure/Structure.java
+++ b/src/main/java/nomadrealms/game/actor/structure/Structure.java
@@ -76,11 +76,6 @@ public class Structure implements Actor {
 		this.tile = tile;
 	}
 
-	@Override
-	public void tile(Tile tile, int animationTime) {
-		this.tile = tile;
-	}
-
 	public Intent modify(World world, Intent intent) {
 		return intent;
 	}

--- a/src/main/java/nomadrealms/game/card/GameCard.java
+++ b/src/main/java/nomadrealms/game/card/GameCard.java
@@ -62,7 +62,12 @@ public enum GameCard implements Card {
 			"Electrostatic Zapper",
 			"Whenever a card is played within range 5, deal 2 to the source",
 			new CreateStructureExpression(StructureType.ELECTROSTATIC_ZAPPER),
-			new TargetingInfo(HEXAGON, 1));
+			new TargetingInfo(HEXAGON, 1)),
+	MELEE_ATTACK(
+			"Melee Attack",
+			"Deal 2 melee damage to target character",
+			new DamageExpression(2),
+			new TargetingInfo(CARD_PLAYER, 1));
 
 	private final String title;
 	private final String description;

--- a/src/main/java/nomadrealms/game/card/GameCard.java
+++ b/src/main/java/nomadrealms/game/card/GameCard.java
@@ -32,7 +32,7 @@ public enum GameCard implements Card {
 	MOVE(
 			"Move",
 			"Move to target hexagon",
-			new MoveExpression(20),
+			new MoveExpression(10),
 			new TargetingInfo(HEXAGON, 2)),
 	HEAL(
 			"Heal",

--- a/src/main/java/nomadrealms/game/card/GameCard.java
+++ b/src/main/java/nomadrealms/game/card/GameCard.java
@@ -21,7 +21,7 @@ public enum GameCard implements Card {
 	MEANDER(
 			"Meander",
 			"Move to target hexagon",
-			new MoveExpression(),
+			new MoveExpression(10),
 			new TargetingInfo(HEXAGON, 1)),
 	ATTACK(
 			"Attack",
@@ -31,7 +31,7 @@ public enum GameCard implements Card {
 	MOVE(
 			"Move",
 			"Move to target hexagon",
-			new MoveExpression(),
+			new MoveExpression(20),
 			new TargetingInfo(HEXAGON, 2)),
 	HEAL(
 			"Heal",

--- a/src/main/java/nomadrealms/game/card/GameCard.java
+++ b/src/main/java/nomadrealms/game/card/GameCard.java
@@ -11,6 +11,7 @@ import nomadrealms.game.card.expression.CreateStructureExpression;
 import nomadrealms.game.card.expression.DamageExpression;
 import nomadrealms.game.card.expression.EditTileExpression;
 import nomadrealms.game.card.expression.GatherExpression;
+import nomadrealms.game.card.expression.MeleeDamageExpression;
 import nomadrealms.game.card.expression.MoveExpression;
 import nomadrealms.game.card.expression.SelfHealExpression;
 import nomadrealms.game.card.target.TargetingInfo;
@@ -66,7 +67,7 @@ public enum GameCard implements Card {
 	MELEE_ATTACK(
 			"Melee Attack",
 			"Deal 2 melee damage to target character",
-			new DamageExpression(2),
+			new MeleeDamageExpression(2),
 			new TargetingInfo(CARD_PLAYER, 1));
 
 	private final String title;

--- a/src/main/java/nomadrealms/game/card/action/Action.java
+++ b/src/main/java/nomadrealms/game/card/action/Action.java
@@ -10,6 +10,9 @@ public interface Action {
 
 	public boolean isComplete();
 
+	public default void init(World world) {
+	}
+
 	public int preDelay();
 
 	public int postDelay();

--- a/src/main/java/nomadrealms/game/card/action/MeleeAttackAction.java
+++ b/src/main/java/nomadrealms/game/card/action/MeleeAttackAction.java
@@ -1,0 +1,41 @@
+package nomadrealms.game.card.action;
+
+import nomadrealms.game.actor.cardplayer.CardPlayer;
+import nomadrealms.game.card.intent.DamageIntent;
+import nomadrealms.game.world.World;
+
+public class MeleeAttackAction implements Action {
+
+    private final CardPlayer source;
+    private final CardPlayer target;
+    private boolean isComplete;
+
+    public MeleeAttackAction(CardPlayer source, CardPlayer target) {
+        this.source = source;
+        this.target = target;
+        this.isComplete = false;
+    }
+
+    @Override
+    public void update(World world) {
+        if (!isComplete) {
+            new DamageIntent(target, source, 2).resolve(world);
+            isComplete = true;
+        }
+    }
+
+    @Override
+    public boolean isComplete() {
+        return isComplete;
+    }
+
+    @Override
+    public int preDelay() {
+        return 0;
+    }
+
+    @Override
+    public int postDelay() {
+        return 5;
+    }
+}

--- a/src/main/java/nomadrealms/game/card/action/MeleeAttackAction.java
+++ b/src/main/java/nomadrealms/game/card/action/MeleeAttackAction.java
@@ -15,7 +15,7 @@ public class MeleeAttackAction implements Action {
 	private final int damage;
 	private boolean isComplete;
 
-	private int preDelay = 10;
+	private int preDelay = 7;
 	private int postDelay = 5;
 
 	/**
@@ -57,14 +57,15 @@ public class MeleeAttackAction implements Action {
 	}
 
 	public Vector2f getScreenOffset(RenderingEnvironment re, long currentTimeMillis) {
-		Vector2f dir = target.tile().coord().sub(source.tile().coord()).toVector2f();
+		Vector2f dir = target.tile().coord().sub(source.tile().coord()).toVector2f().scale(0.6f);
 		long time = System.currentTimeMillis();
-		if (time - actionStart < (long) preDelay() * re.config.getTickRate()) { // windup
-			float progress = (time - actionStart) / (float) (preDelay() * re.config.getTickRate());
+		if (time - actionStart < (long) preDelay() * re.config.getMillisPerTick()) { // windup
+			float progress = (time - actionStart) / (float) (preDelay() * re.config.getMillisPerTick());
 			float fx = 7 * progress * progress * progress - 6 * progress * progress; // 7x^{3}-6x^{2}
 			return dir.scale(fx);
 		} else {
-			float progress = (time - actionStart - preDelay() * re.config.getTickRate()) / (float) (postDelay() * re.config.getTickRate());
+			float progress =
+					(time - actionStart - preDelay() * re.config.getMillisPerTick()) / (float) (postDelay() * re.config.getMillisPerTick());
 			return dir.scale(max(1 - progress, 0));
 		}
 	}

--- a/src/main/java/nomadrealms/game/card/action/MoveAction.java
+++ b/src/main/java/nomadrealms/game/card/action/MoveAction.java
@@ -15,9 +15,18 @@ public class MoveAction implements Action {
 	private final HasPosition source;
 	private final TileCoordinate target;
 
+	/**
+	 * The number of ticks that have passed since the last jump. It is reset to 0 once it equals the delay.
+	 */
 	private int counter = 0;
 
+	/**
+	 * The previous tile the entity was on. Updated when the entity jumps.
+	 */
 	private transient Tile previousTile = null;
+	/**
+	 * The start timestamp of the jump
+	 */
 	private transient long movementStart = 0;
 
 	/**
@@ -80,6 +89,7 @@ public class MoveAction implements Action {
 		return 5;
 	}
 
+	// TODO: make it so that the delay is split between preDelay and postDelay, and the animation is split between the two
 	public Vector2f getScreenOffset(RenderingEnvironment re, long currentTimeMillis) {
 		if (previousTile == null) {
 			return new Vector2f(0, 0);
@@ -89,7 +99,6 @@ public class MoveAction implements Action {
 		if (source.tile() == previousTile || progress > 1) {
 			return new Vector2f(0, 0);
 		}
-		System.out.println(progress);
 		float vertical = 40 * progress * (1 - progress);
 		Vector2f dir = previousTile.coord().sub(source.tile().coord()).toVector2f();
 		return dir.scale(1 - progress).sub(0, vertical);

--- a/src/main/java/nomadrealms/game/card/action/MoveAction.java
+++ b/src/main/java/nomadrealms/game/card/action/MoveAction.java
@@ -39,7 +39,7 @@ public class MoveAction implements Action {
 	}
 
 	public MoveAction(HasPosition source, Tile target) {
-		this(source, target, 20);
+		this(source, target, 10);
 	}
 
 	/**
@@ -68,7 +68,7 @@ public class MoveAction implements Action {
 			if (path.size() > 1) {
 				previousTile = source.tile();
 				movementStart = System.currentTimeMillis();
-				source.move(path.get(1), delay - 1);
+				source.move(path.get(1));
 			}
 		}
 		counter++;
@@ -86,7 +86,7 @@ public class MoveAction implements Action {
 
 	@Override
 	public int postDelay() {
-		return 5;
+		return delay;
 	}
 
 	// TODO: make it so that the delay is split between preDelay and postDelay, and the animation is split between the two
@@ -95,7 +95,7 @@ public class MoveAction implements Action {
 			return new Vector2f(0, 0);
 		}
 		long time = System.currentTimeMillis();
-		float progress = (time - movementStart) / (float) (delay * re.config.getTickRate());
+		float progress = (time - movementStart) / (float) (delay * re.config.getMillisPerTick());
 		if (source.tile() == previousTile || progress > 1) {
 			return new Vector2f(0, 0);
 		}

--- a/src/main/java/nomadrealms/game/card/action/scheduler/CardPlayerActionScheduler.java
+++ b/src/main/java/nomadrealms/game/card/action/scheduler/CardPlayerActionScheduler.java
@@ -63,6 +63,7 @@ public class CardPlayerActionScheduler {
 			if (counter == postDelay + preDelay) {
 				currentAction = actionQueue.poll();
 				counter = 0;
+				currentAction.init(world);
 			}
 			if (counter > postDelay + preDelay) {
 				throw new IllegalStateException("Counter exceeded delay. Pre-delay: " + preDelay + ", Post-delay: "

--- a/src/main/java/nomadrealms/game/card/expression/MeleeDamageExpression.java
+++ b/src/main/java/nomadrealms/game/card/expression/MeleeDamageExpression.java
@@ -1,0 +1,24 @@
+package nomadrealms.game.card.expression;
+
+import java.util.Collections;
+import java.util.List;
+
+import nomadrealms.game.actor.cardplayer.CardPlayer;
+import nomadrealms.game.card.intent.Intent;
+import nomadrealms.game.card.intent.MeleeDamageIntent;
+import nomadrealms.game.event.Target;
+import nomadrealms.game.world.World;
+
+public class MeleeDamageExpression implements CardExpression {
+
+    private final int amount;
+
+    public MeleeDamageExpression(int amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public List<Intent> intents(World world, Target target, CardPlayer source) {
+        return Collections.singletonList(new MeleeDamageIntent(target, source, amount));
+    }
+}

--- a/src/main/java/nomadrealms/game/card/expression/MeleeDamageExpression.java
+++ b/src/main/java/nomadrealms/game/card/expression/MeleeDamageExpression.java
@@ -11,14 +11,15 @@ import nomadrealms.game.world.World;
 
 public class MeleeDamageExpression implements CardExpression {
 
-    private final int amount;
+	private final int amount;
 
-    public MeleeDamageExpression(int amount) {
-        this.amount = amount;
-    }
+	public MeleeDamageExpression(int amount) {
+		this.amount = amount;
+	}
 
-    @Override
-    public List<Intent> intents(World world, Target target, CardPlayer source) {
-        return Collections.singletonList(new MeleeDamageIntent(target, source, amount));
-    }
+	@Override
+	public List<Intent> intents(World world, Target target, CardPlayer source) {
+		return Collections.singletonList(new MeleeDamageIntent(target, source, amount));
+	}
+
 }

--- a/src/main/java/nomadrealms/game/card/expression/MoveExpression.java
+++ b/src/main/java/nomadrealms/game/card/expression/MoveExpression.java
@@ -1,21 +1,27 @@
 package nomadrealms.game.card.expression;
 
-import nomadrealms.game.card.intent.Intent;
-import nomadrealms.game.card.intent.MoveIntent;
-import nomadrealms.game.event.Target;
-import nomadrealms.game.actor.cardplayer.CardPlayer;
-import nomadrealms.game.world.World;
-import nomadrealms.game.world.map.area.Tile;
+import static java.util.Collections.singletonList;
 
 import java.util.List;
 
-import static java.util.Collections.singletonList;
+import nomadrealms.game.actor.cardplayer.CardPlayer;
+import nomadrealms.game.card.intent.Intent;
+import nomadrealms.game.card.intent.MoveIntent;
+import nomadrealms.game.event.Target;
+import nomadrealms.game.world.World;
+import nomadrealms.game.world.map.area.Tile;
 
 public class MoveExpression implements CardExpression {
 
+	int delay = 0;
+
+	public MoveExpression(int delay) {
+		this.delay = delay;
+	}
+
 	@Override
 	public List<Intent> intents(World world, Target target, CardPlayer source) {
-		return singletonList(new MoveIntent(source, (Tile) target));
+		return singletonList(new MoveIntent(source, (Tile) target, delay));
 	}
 
 }

--- a/src/main/java/nomadrealms/game/card/intent/MeleeDamageIntent.java
+++ b/src/main/java/nomadrealms/game/card/intent/MeleeDamageIntent.java
@@ -1,6 +1,6 @@
 package nomadrealms.game.card.intent;
 
-import nomadrealms.game.actor.HasHealth;
+import nomadrealms.game.actor.Actor;
 import nomadrealms.game.actor.cardplayer.CardPlayer;
 import nomadrealms.game.card.action.MeleeAttackAction;
 import nomadrealms.game.event.Target;
@@ -8,21 +8,23 @@ import nomadrealms.game.world.World;
 
 public class MeleeDamageIntent implements Intent {
 
-    private final Target target;
-    private final Target source;
-    private final int amount;
+	private final Actor target;
+	private final Target source;
+	private final int amount;
 
-    public MeleeDamageIntent(Target target, Target source, int amount) {
-        this.target = target;
-        this.source = source;
-        this.amount = amount;
-    }
+	public MeleeDamageIntent(Target target, Target source, int amount) {
+		this.target = (Actor) target;
+		this.source = source;
+		this.amount = amount;
+	}
 
-    @Override
-    public void resolve(World world) {
-        ((HasHealth) target).damage(amount);
-        if (source instanceof CardPlayer && target instanceof CardPlayer) {
-            ((CardPlayer) source).queueAction(new MeleeAttackAction((CardPlayer) source, (CardPlayer) target));
-        }
-    }
+	@Override
+	public void resolve(World world) {
+		if (source instanceof CardPlayer) {
+			((CardPlayer) source).queueAction(new MeleeAttackAction((CardPlayer) source, target, amount));
+		} else {
+			target.damage(amount);
+		}
+	}
+
 }

--- a/src/main/java/nomadrealms/game/card/intent/MeleeDamageIntent.java
+++ b/src/main/java/nomadrealms/game/card/intent/MeleeDamageIntent.java
@@ -1,0 +1,28 @@
+package nomadrealms.game.card.intent;
+
+import nomadrealms.game.actor.HasHealth;
+import nomadrealms.game.actor.cardplayer.CardPlayer;
+import nomadrealms.game.card.action.MeleeAttackAction;
+import nomadrealms.game.event.Target;
+import nomadrealms.game.world.World;
+
+public class MeleeDamageIntent implements Intent {
+
+    private final Target target;
+    private final Target source;
+    private final int amount;
+
+    public MeleeDamageIntent(Target target, Target source, int amount) {
+        this.target = target;
+        this.source = source;
+        this.amount = amount;
+    }
+
+    @Override
+    public void resolve(World world) {
+        ((HasHealth) target).damage(amount);
+        if (source instanceof CardPlayer && target instanceof CardPlayer) {
+            ((CardPlayer) source).queueAction(new MeleeAttackAction((CardPlayer) source, (CardPlayer) target));
+        }
+    }
+}

--- a/src/main/java/nomadrealms/game/card/intent/MoveIntent.java
+++ b/src/main/java/nomadrealms/game/card/intent/MoveIntent.java
@@ -9,15 +9,17 @@ public class MoveIntent implements Intent {
 
 	private final CardPlayer source;
 	private final Tile target;
+	int delay = 0;
 
-	public MoveIntent(CardPlayer source, Tile target) {
+	public MoveIntent(CardPlayer source, Tile target, int delay) {
 		this.source = source;
 		this.target = target;
+		this.delay = delay;
 	}
 
 	@Override
 	public void resolve(World world) {
-		source.queueAction(new MoveAction(source, target));
+		source.queueAction(new MoveAction(source, target, delay));
 	}
 
 }


### PR DESCRIPTION
Add melee attack functionality to the game.

* **MeleeAttackAction**: Create a new class `MeleeAttackAction` implementing the `Action` interface to handle melee attacks.
* **GameCard**: Add a new `MELEE_ATTACK` card with appropriate targeting info and description.
* **FeralMonkey**: Update the constructor to use the new `MELEE_ATTACK` card for its attack behavior.
* **FeralMonkeyAI**: Update the `update` method to handle the logic for the new `MELEE_ATTACK` card.
* **MeleeDamageExpression**: Create a new class `MeleeDamageExpression` implementing the `CardExpression` interface to handle melee damage.
* **MeleeDamageIntent**: Create a new class `MeleeDamageIntent` implementing the `Intent` interface to handle melee damage and create a melee action.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/virtual-cardboard/nomad-realms/pull/39?shareId=bc3a76b2-3383-4f2f-8596-da189e43c76f).