### PR TITLE
Add a wooden chest structure card

### DIFF
--- a/src/main/java/nomadrealms/game/actor/cardplayer/Nomad.java
+++ b/src/main/java/nomadrealms/game/actor/cardplayer/Nomad.java
@@ -12,6 +12,7 @@ import static nomadrealms.game.card.GameCard.GATHER;
 import static nomadrealms.game.card.GameCard.HEAL;
 import static nomadrealms.game.card.GameCard.MELEE_ATTACK;
 import static nomadrealms.game.card.GameCard.MOVE;
+import static nomadrealms.game.card.GameCard.WOODEN_CHEST;
 import static nomadrealms.game.world.map.area.Tile.TILE_RADIUS;
 
 import java.util.Collections;
@@ -54,6 +55,7 @@ public class Nomad extends CardPlayer {
 				.addCard(new WorldCard(MOVE))
 				.addCard(new WorldCard(HEAL))
 				// .addCard(new WorldCard(ELECTROSTATIC_ZAPPER))
+				.addCard(new WorldCard(WOODEN_CHEST).ephemeral(true))
 				.addCard(new WorldCard(MELEE_ATTACK))
 				.addCard(new WorldCard(GATHER));
 		deck.shuffle();

--- a/src/main/java/nomadrealms/game/card/GameCard.java
+++ b/src/main/java/nomadrealms/game/card/GameCard.java
@@ -68,7 +68,12 @@ public enum GameCard implements Card {
 			"Melee Attack",
 			"Deal 2 melee damage to target character",
 			new MeleeDamageExpression(2),
-			new TargetingInfo(CARD_PLAYER, 1));
+			new TargetingInfo(CARD_PLAYER, 1)),
+	WOODEN_CHEST(
+			"Wooden Chest",
+			"Create a chest on target tile",
+			new CreateStructureExpression(StructureType.CHEST),
+			new TargetingInfo(HEXAGON, 1));
 
 	private final String title;
 	private final String description;

--- a/src/main/java/nomadrealms/game/card/WorldCard.java
+++ b/src/main/java/nomadrealms/game/card/WorldCard.java
@@ -13,6 +13,8 @@ public class WorldCard implements Card {
 	GameCard card;
 	CardMemory memory = new CardMemory();
 
+	private boolean ephemeral = false;
+
 	/**
 	 * No-arg constructor for serialization.
 	 */
@@ -34,6 +36,15 @@ public class WorldCard implements Card {
 
 	public void zone(WorldCardZone zone) {
 		this.zone = zone;
+	}
+
+	public boolean ephemeral() {
+		return ephemeral;
+	}
+
+	public WorldCard ephemeral(boolean ephemeral) {
+		this.ephemeral = ephemeral;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/nomadrealms/game/world/World.java
+++ b/src/main/java/nomadrealms/game/world/World.java
@@ -137,7 +137,9 @@ public class World {
 		Deck deck = (Deck) event.card().zone();
 		deck.removeCard(event.card());
 		procChains.add(event.procChain(this));
-		deck.addCard(event.card());
+		if (!event.card().ephemeral()) {
+			deck.addCard(event.card());
+		}
 		state.uiEventChannel.add(event);
 	}
 


### PR DESCRIPTION
Add a new card for creating a Wooden Chest structure.

* Add `WOODEN_CHEST` card to `GameCard.java`
* Set title to "Wooden Chest" and description to "Create a chest on target tile"
* Use `CreateStructureExpression` with `StructureType.CHEST`
* Set targeting info to `new TargetingInfo(HEXAGON, 1)`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/virtual-cardboard/nomad-realms/pull/45?shareId=c240b2ec-095d-4727-bdc4-d74506c1c7d7).