### PR TITLE
Walkable Structures and Puffcap Implementation

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/Actor.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/Actor.java
@@ -80,11 +80,11 @@ public interface Actor extends HasPosition, HasHealth, HasInventory, Target, Ren
 
 	@Override
 	default boolean move(Tile target) {
-		if (target.actor() != null) {
+		if (!target.isWalkable(this)) {
 			return false;
 		}
 		if (tile() != null) {
-			tile().clearActor();
+			tile().removeActor(this);
 		}
 		if (!HasPosition.super.move(target)) {
 			return false;

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/FeralMonkeyAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/FeralMonkeyAI.java
@@ -73,7 +73,7 @@ public class FeralMonkeyAI extends CardPlayerAI {
 							self.tile().um(state.world),
 							self.tile().ur(state.world)
 					)
-					.filter(tile -> tile.actor() == null)
+					.filter(tile -> tile.isWalkable(self))
 					.min(comparingInt(t -> t.coord().distanceTo(nearestCardPlayer.tile().coord())));
 			if (!closestTile.isPresent()) {
 				return;

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/VillageLumberjackAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/VillageLumberjackAI.java
@@ -83,7 +83,7 @@ public class VillageLumberjackAI extends CardPlayerAI {
 						self.tile().um(state.world),
 						self.tile().ur(state.world)
 				)
-					.filter(tile -> tile != null && tile.actor() == null)
+					.filter(tile -> tile != null && tile.isWalkable(self))
 					.findAny();
 			randomTile.ifPresent(tile -> self.addNextPlay(new CardPlayedEvent(meanderCard, self, tile)));
 		}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/WolfAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/WolfAI.java
@@ -72,7 +72,7 @@ public class WolfAI extends CardPlayerAI {
 							self.tile().um(state.world),
 							self.tile().ur(state.world)
 					)
-					.filter(tile -> tile.actor() == null)
+					.filter(tile -> tile.isWalkable(self))
 					.min(comparingInt(t -> t.coord().distanceTo(nearestCardPlayer.tile().coord())));
 			if (!closestTile.isPresent()) {
 				return;

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/PuffcapStructure.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/PuffcapStructure.java
@@ -1,0 +1,23 @@
+package nomadrealms.context.game.actor.types.structure;
+
+import nomadrealms.context.game.actor.types.structure.factory.StructureType;
+
+import static nomadrealms.context.game.actor.types.structure.factory.StructureType.PUFFCAP;
+
+public class PuffcapStructure extends Structure {
+
+	public PuffcapStructure() {
+		super("puffcap", "grass_2", 1, 10);
+	}
+
+	@Override
+	public StructureType structureType() {
+		return PUFFCAP;
+	}
+
+	@Override
+	public boolean walkable() {
+		return true;
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/Structure.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/Structure.java
@@ -154,4 +154,9 @@ public abstract class Structure implements Actor {
 	}
 
 	public abstract StructureType structureType();
+
+	public boolean walkable() {
+		return false;
+	}
+
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/factory/StructureFactory.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/factory/StructureFactory.java
@@ -3,6 +3,7 @@ package nomadrealms.context.game.actor.types.structure.factory;
 import nomadrealms.context.game.actor.types.structure.ChestStructure;
 import nomadrealms.context.game.actor.types.structure.ElectrostaticZapperStructure;
 import nomadrealms.context.game.actor.types.structure.FenceStructure;
+import nomadrealms.context.game.actor.types.structure.PuffcapStructure;
 import nomadrealms.context.game.actor.types.structure.RockStructure;
 import nomadrealms.context.game.actor.types.structure.Structure;
 import nomadrealms.context.game.actor.types.structure.TreeStructure;
@@ -21,6 +22,8 @@ public class StructureFactory {
 				return new FenceStructure();
 			case ELECTROSTATIC_ZAPPER:
 				return new ElectrostaticZapperStructure();
+			case PUFFCAP:
+				return new PuffcapStructure();
 			default:
 				throw new RuntimeException("No structure case in StructureFactory for structure type " + type);
 		}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/factory/StructureType.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/factory/StructureType.java
@@ -6,6 +6,7 @@ public enum StructureType {
 	FENCE,
 	CHEST,
 	TREE,
-	ELECTROSTATIC_ZAPPER
+	ELECTROSTATIC_ZAPPER,
+	PUFFCAP
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/action/WalkToAdjacentAction.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/action/WalkToAdjacentAction.java
@@ -51,7 +51,7 @@ public class WalkToAdjacentAction extends Action {
 		Tile bestTile = null;
 		int minDistance = Integer.MAX_VALUE;
 		for (Tile neighbor : neighbors) {
-			if (neighbor != null && (neighbor.actor() == null || neighbor.actor() == source)) {
+			if (neighbor != null && (neighbor.isWalkable(source) || neighbor.actor() == source)) {
 				int distance = source.tile().coord().distanceTo(neighbor.coord());
 				if (distance < minDistance) {
 					minDistance = distance;
@@ -71,7 +71,7 @@ public class WalkToAdjacentAction extends Action {
 		}
 		if (counter >= delay) {
 			counter = 0;
-			List<Tile> path = world.map().path(source.tile(), world.getTile(adjacentTarget));
+			List<Tile> path = world.map().path(source, source.tile(), world.getTile(adjacentTarget));
 			if (path.size() > 1) {
 				previousTile = source.tile();
 				movementStart = System.currentTimeMillis();

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/GameMap.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/GameMap.java
@@ -52,6 +52,10 @@ public class GameMap {
 	}
 
 	public List<Tile> path(Tile source, Tile target) {
+		return path(source.actor(), source, target);
+	}
+
+	public List<Tile> path(nomadrealms.context.game.actor.Actor sourceActor, Tile source, Tile target) {
 		if (source.equals(target)) {
 			return singletonList(source);
 		}
@@ -64,7 +68,7 @@ public class GameMap {
 			Tile current = frontier.poll();
 
 			for (Tile next : getNeighbors(current)) {
-				if ((next.actor() == null || next.equals(target)) && !cameFrom.containsKey(next)) {
+				if ((next.isWalkable(sourceActor) || next.equals(target)) && !cameFrom.containsKey(next)) {
 					frontier.add(next);
 					cameFrom.put(next, current);
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/GameMap.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/GameMap.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Queue;
 
 import engine.common.math.Vector2f;
+import nomadrealms.context.game.actor.Actor;
 import nomadrealms.context.game.world.map.area.Region;
 import nomadrealms.context.game.world.map.area.Tile;
 import nomadrealms.context.game.world.map.area.coordinate.RegionCoordinate;
@@ -55,7 +56,7 @@ public class GameMap {
 		return path(source.actor(), source, target);
 	}
 
-	public List<Tile> path(nomadrealms.context.game.actor.Actor sourceActor, Tile source, Tile target) {
+	public List<Tile> path(Actor sourceActor, Tile source, Tile target) {
 		if (source.equals(target)) {
 			return singletonList(source);
 		}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -111,8 +111,11 @@ public class World {
 		for (Chunk chunk : chunksToRender) {
 			for (Tile tile : chunk.tiles()) {
 				// TODO: eventually remove destroyed entities after a delay. not here, but in update()
-				if (tile.actor() != null && !tile.actor().isDestroyed()) {
-					tile.actor().render(re);
+				if (tile.structure() != null && !tile.structure().isDestroyed()) {
+					tile.structure().render(re);
+				}
+				if (tile.occupant() != null && !tile.occupant().isDestroyed()) {
+					tile.occupant().render(re);
 				}
 			}
 		}
@@ -197,7 +200,7 @@ public class World {
 		}
 		actors.add(actor);
 		if (forced) {
-			actor.tile().clearActor();
+			actor.tile().removeActor(actor);
 		}
 		// TODO: figure out to do when tile is already occupied
 		actor.tile().actor(actor);

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import nomadrealms.context.game.actor.Actor;
 import nomadrealms.context.game.actor.types.HasTooltip;
+import nomadrealms.context.game.actor.types.structure.Structure;
 import nomadrealms.context.game.actor.types.cardplayer.appendage.Appendage;
 import nomadrealms.context.game.event.Target;
 import nomadrealms.context.game.item.WorldItem;
@@ -42,7 +43,7 @@ public abstract class Tile implements Target, HasTooltip {
 	private TileCoordinate coord;
 
 	private Actor occupant;
-	private Actor structure;
+	private Structure structure;
 	private final List<WorldItem> items = new ArrayList<>();
 	private WorldItem buried;
 
@@ -130,7 +131,7 @@ public abstract class Tile implements Target, HasTooltip {
 		return occupant;
 	}
 
-	public Actor structure() {
+	public Structure structure() {
 		return structure;
 	}
 
@@ -138,8 +139,8 @@ public abstract class Tile implements Target, HasTooltip {
 		if (actor == null) {
 			throw new IllegalArgumentException("Actor cannot be null. Use clearActor() or removeActor(Actor) instead.");
 		}
-		if (actor instanceof nomadrealms.context.game.actor.types.structure.Structure) {
-			nomadrealms.context.game.actor.types.structure.Structure s = (nomadrealms.context.game.actor.types.structure.Structure) actor;
+		if (actor instanceof Structure) {
+			Structure s = (Structure) actor;
 			if (this.structure != null) {
 				throw new IllegalStateException("Tile " + coord + " already has a structure: " + this.structure);
 			}
@@ -148,7 +149,7 @@ public abstract class Tile implements Target, HasTooltip {
 			if (this.occupant != null) {
 				throw new IllegalStateException("Tile " + coord + " already has an occupant: " + this.occupant);
 			}
-			if (this.structure != null && !((nomadrealms.context.game.actor.types.structure.Structure) this.structure).walkable()) {
+			if (this.structure != null && !this.structure.walkable()) {
 				throw new IllegalStateException("Tile " + coord + " is occupied by a non-walkable structure: " + this.structure);
 			}
 			this.occupant = actor;
@@ -178,13 +179,13 @@ public abstract class Tile implements Target, HasTooltip {
 	}
 
 	public boolean isWalkable(Actor mover) {
-		if (mover instanceof nomadrealms.context.game.actor.types.structure.Structure) {
+		if (mover instanceof Structure) {
 			return structure == null;
 		}
 		if (occupant != null) {
 			return false;
 		}
-		return structure == null || ((nomadrealms.context.game.actor.types.structure.Structure) structure).walkable();
+		return structure == null || structure.walkable();
 	}
 
 	public void addItem(WorldItem item) {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/structure/StructureGenerationStep.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/structure/StructureGenerationStep.java
@@ -14,6 +14,7 @@ import nomadrealms.context.game.world.map.area.coordinate.TileCoordinate;
 import nomadrealms.context.game.world.map.generation.MapGenerationStrategy;
 import nomadrealms.context.game.world.map.generation.overworld.GenerationStep;
 import nomadrealms.context.game.world.map.generation.overworld.biome.BiomeParameters;
+import nomadrealms.context.game.world.map.generation.overworld.structure.config.PuffcapGenerationConfig;
 import nomadrealms.context.game.world.map.generation.overworld.structure.config.RockGenerationConfig;
 import nomadrealms.context.game.world.map.generation.overworld.structure.config.TreeGenerationConfig;
 
@@ -35,7 +36,8 @@ public class StructureGenerationStep extends GenerationStep {
 		super(zone, strategy.parameters().seed());
 		structureParameters = new ArrayList<>(asList(
 				new TreeGenerationConfig(strategy.parameters()),
-				new RockGenerationConfig(strategy.parameters())
+				new RockGenerationConfig(strategy.parameters()),
+				new PuffcapGenerationConfig(strategy.parameters())
 		));
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/structure/config/PuffcapGenerationConfig.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/structure/config/PuffcapGenerationConfig.java
@@ -1,0 +1,48 @@
+package nomadrealms.context.game.world.map.generation.overworld.structure.config;
+
+import nomadrealms.context.game.actor.types.structure.PuffcapStructure;
+import nomadrealms.context.game.actor.types.structure.Structure;
+import nomadrealms.context.game.world.map.area.coordinate.TileCoordinate;
+import nomadrealms.context.game.world.map.generation.MapGenerationParameters;
+import nomadrealms.context.game.world.map.generation.overworld.biome.BiomeParameters;
+import nomadrealms.context.game.world.map.generation.overworld.biome.noise.BiomeNoiseGenerator;
+import nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType;
+import nomadrealms.context.game.world.map.generation.overworld.structure.StructureGenerationConfig;
+import nomadrealms.math.generation.map.LayeredNoise;
+import nomadrealms.math.generation.map.NoiseOctave;
+import nomadrealms.math.generation.map.OpenSimplexNoise;
+
+public class PuffcapGenerationConfig extends StructureGenerationConfig {
+
+	private final BiomeNoiseGenerator noise;
+
+	/**
+	 * No-arg constructor for serialization.
+	 */
+	protected PuffcapGenerationConfig() {
+		this.noise = null;
+	}
+
+	public PuffcapGenerationConfig(MapGenerationParameters mapParameters) {
+		OpenSimplexNoise base = new OpenSimplexNoise(mapParameters.seed() + 100);
+		this.noise = new BiomeNoiseGenerator(new LayeredNoise(
+				new NoiseOctave(base, 0.05, 0.4, 0),
+				new NoiseOctave(base, 2, 0.02, 1),
+				new NoiseOctave(base, 1, 0.3, 2),
+				new NoiseOctave(base, 0.5, 0.18, 3),
+				new NoiseOctave(base, 0.25, 0.1, 4),
+				new NoiseOctave(base, 0.1, 0.05, 5),
+				new NoiseOctave(base, 0.05, 0.02, 6)),
+				1);
+	}
+
+	@Override
+	public Structure placeStructure(TileCoordinate coord, BiomeParameters biome) {
+		if (biome.calculateBiomeVariant() == BiomeVariantType.PLAINS) {
+			if (noise.eval(coord) > 0.35f) {
+				return new PuffcapStructure();
+			}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
This change introduces a distinction between "occupants" (like players and AI actors) and "structures" on a tile. Tiles can now hold both simultaneously, provided the structure is marked as walkable. The Puffcap structure was implemented as a walkable structure that generates naturally in Plains biomes. Movement and pathfinding systems were updated to respect these new rules, and rendering was adjusted to ensure characters appear on top of walkable structures.

---
*PR created automatically by Jules for task [14778032974736588120](https://jules.google.com/task/14778032974736588120) started by @Lunkle*