### PR TITLE
Implement Discard Zone and Animations in DeckTab

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/CardPhysics.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/CardPhysics.java
@@ -42,7 +42,11 @@ public class CardPhysics {
 		if (pauseRestoration) {
 			return;
 		}
-		currentTransform = currentTransform.interpolate(targetTransform, 0.1f);
+		interpolate(0.1f);
+	}
+
+	public void interpolate(float t) {
+		currentTransform = currentTransform.interpolate(targetTransform, t);
 	}
 
 	public void tilt(Vector2f velocity) {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
@@ -43,11 +43,10 @@ import nomadrealms.render.ui.custom.indicator.ManaIndicator;
 public class DeckTab implements UI, CardZoneListener<WorldCard> {
 
 	ConstraintBox constraintBox;
-	ConstraintBox discardArea;
+	DiscardUI discardUI;
 	Map<WorldCardZone, ConstraintBox> deckConstraints = new HashMap<>();
 	Map<WorldCardZone, Map<WorldCard, UICard>> deckUICards = new HashMap<>();
 	Map<WorldCardZone, UnrevealedCardUI> deckUnrevealedUICards = new HashMap<>();
-	List<UICard> discardUICards = new ArrayList<>();
 
 	private static class RestockTask {
 		WorldCard card;
@@ -97,12 +96,12 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 				constraintBox.w(),
 				constraintBox.h().multiply(0.7f)
 		);
-		this.discardArea = new ConstraintBox(
+		this.discardUI = new DiscardUI(new ConstraintBox(
 				constraintBox.x(),
 				constraintBox.y().add(deckArea.h()),
 				constraintBox.w(),
 				constraintBox.h().multiply(0.3f)
-		);
+		));
 
 		ConstraintPair size = UICard.cardSize(2.5f);
 		Constraint xPadding = deckArea.w().add(size.x().multiply(2).neg()).multiply(0.25f);
@@ -136,17 +135,7 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 			deckUnrevealedUICards.put(deck, new UnrevealedCardUI(deck, deckConstraints.get(deck)));
 			deck.events().subscribe(this);
 		}
-		for (WorldCard card : owner.deckCollection().discardZone().getCards()) {
-			ConstraintPair cardSize = UICard.cardSize(2.5f);
-			ConstraintBox cardBox = new ConstraintBox(
-					discardArea.center().add(cardSize.scale(-0.5f)),
-					cardSize
-			);
-			UICard ui = new UICard(card, cardBox);
-			ui.physics().rotate(new Vector3f(0, 0, 1), (float) (Math.random() * 40 - 20));
-			ui.physics().snap();
-			discardUICards.add(ui);
-		}
+		discardUI.addInitialCards(owner.deckCollection().discardZone().getCards());
 		owner.deckCollection().discardZone().events().subscribe(this);
 
 		addCallbacks(registry);
@@ -227,24 +216,13 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 				.set("color", toRangedVector(rgb(210, 180, 140)))
 				.set("transform", new Matrix4f(constraintBox, re.glContext))
 				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
-		re.defaultShaderProgram
-				.set("color", toRangedVector(rgb(180, 150, 110)))
-				.set("transform", new Matrix4f(discardArea, re.glContext))
-				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
+		discardUI.render(re);
 		manaIndicator.render(re);
 		targetingArrow.render(re);
 		deckUnrevealedUICards.values().forEach(ui -> ui.render(re));
 		cards().forEach(card -> card.render(re));
-		discardUICards.forEach(card -> card.render(re));
-		discardUICards.forEach(card -> {
-			float targetY = discardArea.center().y().get() - card.physics().cardBox().h().multiply(0.5f).get();
-			float t = (targetY != 0) ? card.position().y().get() / targetY : 1;
-			t = Math.max(0, Math.min(1, t));
-			card.physics().targetTransform().size(UICard.cardSize(2.5f).scale(1 + 2 * (1 - t)));
-			card.physics().interpolate(0.2f);
-		});
 		cards().forEach(card -> {
-			if (discardArea.contains(card.position().vector())) {
+			if (discardUI.discardArea().contains(card.position().vector())) {
 				// Card is still in discard area, keep its size
 				card.physics().interpolate(0.1f);
 			} else {
@@ -260,27 +238,7 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 
 	public void deleteUI(WorldCard card) {
 		deckUICards.get(card.deck()).remove(card);
-		ConstraintPair cardSize = UICard.cardSize(2.5f);
-		ConstraintBox targetBox = new ConstraintBox(
-				discardArea.center().add(cardSize.scale(-0.5f)),
-				cardSize
-		);
-		ConstraintBox tempBox = new ConstraintBox(
-				discardArea.center().add(cardSize.scale(-1.5f)),
-				cardSize.scale(3)
-		);
-		ConstraintBox startBox = new ConstraintBox(
-				tempBox.x(), absolute(-tempBox.h().get()),
-				tempBox.w(), tempBox.h()
-		);
-
-		UICard ui = new UICard(card, startBox);
-		ui.physics().rotate(new Vector3f((float) Math.random(), (float) Math.random(), (float) Math.random()), (float) (Math.random() * 360));
-		ui.physics().targetTransform(new CardTransform(
-				new engine.common.math.UnitQuaternion().rotateBy(new Vector3f(0, 0, 1), (float) (Math.random() * 40 - 20)),
-				targetBox
-		));
-		discardUICards.add(ui);
+		discardUI.addCard(card);
 	}
 
 	public void addUI(WorldCard card) {
@@ -324,10 +282,10 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 	public void handle(RestockCardZoneEvent<WorldCard> event) {
 		if (event.zone() instanceof Deck && owner.deckCollection().contains((Deck) event.zone())) {
 			Deck deck = (Deck) event.zone();
-			List<UICard> toRestock = discardUICards.stream()
+			List<UICard> toRestock = discardUI.discardUICards().stream()
 					.filter(ui -> ui.card().deck() == deck)
 					.collect(Collectors.toList());
-			discardUICards.removeAll(toRestock);
+			discardUI.discardUICards().removeAll(toRestock);
 			long startTime = System.currentTimeMillis();
 			for (int i = 0; i < toRestock.size(); i++) {
 				UICard ui = toRestock.get(i);

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
@@ -19,11 +19,10 @@ import engine.visuals.lwjgl.render.meta.DrawFunction;
 import engine.visuals.rendering.text.HorizontalAlign;
 import engine.visuals.rendering.text.VerticalAlign;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import nomadrealms.context.game.GameState;
@@ -46,9 +45,25 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 	ConstraintBox constraintBox;
 	ConstraintBox discardArea;
 	Map<WorldCardZone, ConstraintBox> deckConstraints = new HashMap<>();
-	Map<WorldCardZone, ConcurrentHashMap<WorldCard, UICard>> deckUICards = new HashMap<>();
+	Map<WorldCardZone, Map<WorldCard, UICard>> deckUICards = new HashMap<>();
 	Map<WorldCardZone, UnrevealedCardUI> deckUnrevealedUICards = new HashMap<>();
-	List<UICard> discardUICards = Collections.synchronizedList(new ArrayList<>());
+	List<UICard> discardUICards = new ArrayList<>();
+
+	private static class RestockTask {
+		WorldCard card;
+		UICard ui;
+		Deck deck;
+		long executeTime;
+
+		public RestockTask(WorldCard card, UICard ui, Deck deck, long executeTime) {
+			this.card = card;
+			this.ui = ui;
+			this.deck = deck;
+			this.executeTime = executeTime;
+		}
+	}
+
+	private final List<RestockTask> restockTasks = new ArrayList<>();
 
 	transient CardPlayer owner;
 
@@ -113,7 +128,7 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 		deckConstraints.put(owner.deckCollection().deck3(), deck3Position);
 		deckConstraints.put(owner.deckCollection().deck4(), deck4Position);
 		for (Deck deck : owner.deckCollection().decks()) {
-			ConcurrentHashMap<WorldCard, UICard> uiCards = new ConcurrentHashMap<>();
+			Map<WorldCard, UICard> uiCards = new HashMap<>();
 			if (deck.size() > 0) {
 				uiCards.put(deck.peek(), new UICard(deck.peek(), deckConstraints.get(deck)));
 			}
@@ -198,6 +213,16 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 
 	@Override
 	public void render(RenderingEnvironment re) {
+		long currentTime = System.currentTimeMillis();
+		Iterator<RestockTask> taskIterator = restockTasks.iterator();
+		while (taskIterator.hasNext()) {
+			RestockTask task = taskIterator.next();
+			if (currentTime >= task.executeTime) {
+				deckUICards.get(task.deck).put(task.card, task.ui);
+				taskIterator.remove();
+			}
+		}
+
 		re.defaultShaderProgram
 				.set("color", toRangedVector(rgb(210, 180, 140)))
 				.set("transform", new Matrix4f(constraintBox, re.glContext))
@@ -278,7 +303,7 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 	}
 
 	private void refresh(Deck deck) {
-		ConcurrentHashMap<WorldCard, UICard> uiCards = deckUICards.get(deck);
+		Map<WorldCard, UICard> uiCards = deckUICards.get(deck);
 		if (uiCards == null) {
 			return;
 		}
@@ -303,22 +328,14 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 					.filter(ui -> ui.card().deck() == deck)
 					.collect(Collectors.toList());
 			discardUICards.removeAll(toRestock);
+			long startTime = System.currentTimeMillis();
 			for (int i = 0; i < toRestock.size(); i++) {
 				UICard ui = toRestock.get(i);
 				ui.physics().targetTransform(new CardTransform(
 						new engine.common.math.UnitQuaternion(),
 						deckConstraints.get(deck)
 				));
-				long delay = i * 100;
-				new Thread(() -> {
-					try {
-						Thread.sleep(delay);
-					} catch (InterruptedException e) {
-						e.printStackTrace();
-					}
-					ConcurrentHashMap<WorldCard, UICard> deckMap = deckUICards.get(deck);
-					deckMap.put(ui.card(), ui);
-				}).start();
+				restockTasks.add(new RestockTask(ui.card(), ui, deck, startTime + i * 100));
 			}
 		}
 	}

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
@@ -18,8 +18,13 @@ import engine.visuals.constraint.box.ConstraintPair;
 import engine.visuals.lwjgl.render.meta.DrawFunction;
 import engine.visuals.rendering.text.HorizontalAlign;
 import engine.visuals.rendering.text.VerticalAlign;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.actor.types.cardplayer.CardPlayer;
@@ -39,9 +44,11 @@ import nomadrealms.render.ui.custom.indicator.ManaIndicator;
 public class DeckTab implements UI, CardZoneListener<WorldCard> {
 
 	ConstraintBox constraintBox;
+	ConstraintBox discardArea;
 	Map<WorldCardZone, ConstraintBox> deckConstraints = new HashMap<>();
-	Map<WorldCardZone, Map<WorldCard, UICard>> deckUICards = new HashMap<>();
+	Map<WorldCardZone, ConcurrentHashMap<WorldCard, UICard>> deckUICards = new HashMap<>();
 	Map<WorldCardZone, UnrevealedCardUI> deckUnrevealedUICards = new HashMap<>();
+	List<UICard> discardUICards = Collections.synchronizedList(new ArrayList<>());
 
 	transient CardPlayer owner;
 
@@ -68,23 +75,37 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 		);
 		this.manaIndicator = new ManaIndicator(owner, constraintBox);
 		this.targetingArrow = new TargetingArrow(state, owner).mouse(mouse);
+
+		ConstraintBox deckArea = new ConstraintBox(
+				constraintBox.x(),
+				constraintBox.y(),
+				constraintBox.w(),
+				constraintBox.h().multiply(0.7f)
+		);
+		this.discardArea = new ConstraintBox(
+				constraintBox.x(),
+				constraintBox.y().add(deckArea.h()),
+				constraintBox.w(),
+				constraintBox.h().multiply(0.3f)
+		);
+
 		ConstraintPair size = UICard.cardSize(2.5f);
-		Constraint xPadding = constraintBox.w().add(size.x().multiply(2).neg()).multiply(0.25f);
-		Constraint yPadding = constraintBox.h().add(size.y().multiply(2).neg()).multiply(0.25f);
+		Constraint xPadding = deckArea.w().add(size.x().multiply(2).neg()).multiply(0.25f);
+		Constraint yPadding = deckArea.h().add(size.y().multiply(2).neg()).multiply(0.25f);
 		ConstraintBox deck1Position = new ConstraintBox(
-				constraintBox.center().add(size.x().neg(), size.y().neg()).add(xPadding.neg(), yPadding.neg()),
+				deckArea.center().add(size.x().neg(), size.y().neg()).add(xPadding.neg(), yPadding.neg()),
 				size
 		);
 		ConstraintBox deck2Position = new ConstraintBox(
-				constraintBox.center().add(zero(), size.y().neg()).add(xPadding, yPadding.neg()),
+				deckArea.center().add(zero(), size.y().neg()).add(xPadding, yPadding.neg()),
 				size
 		);
 		ConstraintBox deck3Position = new ConstraintBox(
-				constraintBox.center().add(size.x().neg(), zero()).add(xPadding.neg(), yPadding),
+				deckArea.center().add(size.x().neg(), zero()).add(xPadding.neg(), yPadding),
 				size
 		);
 		ConstraintBox deck4Position = new ConstraintBox(
-				constraintBox.center().add(zero(), zero()).add(xPadding, yPadding),
+				deckArea.center().add(zero(), zero()).add(xPadding, yPadding),
 				size
 		);
 		deckConstraints.put(owner.deckCollection().deck1(), deck1Position);
@@ -92,7 +113,7 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 		deckConstraints.put(owner.deckCollection().deck3(), deck3Position);
 		deckConstraints.put(owner.deckCollection().deck4(), deck4Position);
 		for (Deck deck : owner.deckCollection().decks()) {
-			Map<WorldCard, UICard> uiCards = new HashMap<>();
+			ConcurrentHashMap<WorldCard, UICard> uiCards = new ConcurrentHashMap<>();
 			if (deck.size() > 0) {
 				uiCards.put(deck.peek(), new UICard(deck.peek(), deckConstraints.get(deck)));
 			}
@@ -100,6 +121,18 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 			deckUnrevealedUICards.put(deck, new UnrevealedCardUI(deck, deckConstraints.get(deck)));
 			deck.events().subscribe(this);
 		}
+		for (WorldCard card : owner.deckCollection().discardZone().getCards()) {
+			ConstraintPair cardSize = UICard.cardSize(2.5f);
+			ConstraintBox cardBox = new ConstraintBox(
+					discardArea.center().add(cardSize.scale(-0.5f)),
+					cardSize
+			);
+			UICard ui = new UICard(card, cardBox);
+			ui.physics().rotate(new Vector3f(0, 0, 1), (float) (Math.random() * 40 - 20));
+			ui.physics().snap();
+			discardUICards.add(ui);
+		}
+		owner.deckCollection().discardZone().events().subscribe(this);
 
 		addCallbacks(registry);
 	}
@@ -169,11 +202,31 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 				.set("color", toRangedVector(rgb(210, 180, 140)))
 				.set("transform", new Matrix4f(constraintBox, re.glContext))
 				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
+		re.defaultShaderProgram
+				.set("color", toRangedVector(rgb(180, 150, 110)))
+				.set("transform", new Matrix4f(discardArea, re.glContext))
+				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
 		manaIndicator.render(re);
 		targetingArrow.render(re);
 		deckUnrevealedUICards.values().forEach(ui -> ui.render(re));
+		discardUICards.forEach(card -> card.render(re));
 		cards().forEach(card -> card.render(re));
-		cards().forEach(UICard::interpolate);
+		discardUICards.forEach(card -> {
+			float targetY = discardArea.center().y().get() - card.physics().cardBox().h().multiply(0.5f).get();
+			float t = (targetY != 0) ? card.position().y().get() / targetY : 1;
+			t = Math.max(0, Math.min(1, t));
+			card.physics().targetTransform().size(UICard.cardSize(2.5f).scale(1 + 2 * (1 - t)));
+			card.physics().interpolate(0.2f);
+		});
+		cards().forEach(card -> {
+			if (discardArea.contains(card.position().vector())) {
+				// Card is still in discard area, keep its size
+				card.physics().interpolate(0.1f);
+			} else {
+				// Card is flying back or in deck, use normal interpolation
+				card.physics().interpolate();
+			}
+		});
 	}
 
 	public Stream<UICard> cards() {
@@ -182,6 +235,27 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 
 	public void deleteUI(WorldCard card) {
 		deckUICards.get(card.deck()).remove(card);
+		ConstraintPair cardSize = UICard.cardSize(2.5f);
+		ConstraintBox targetBox = new ConstraintBox(
+				discardArea.center().add(cardSize.scale(-0.5f)),
+				cardSize
+		);
+		ConstraintBox tempBox = new ConstraintBox(
+				discardArea.center().add(cardSize.scale(-1.5f)),
+				cardSize.scale(3)
+		);
+		ConstraintBox startBox = new ConstraintBox(
+				tempBox.x(), absolute(-tempBox.h().get()),
+				tempBox.w(), tempBox.h()
+		);
+
+		UICard ui = new UICard(card, startBox);
+		ui.physics().rotate(new Vector3f((float) Math.random(), (float) Math.random(), (float) Math.random()), (float) (Math.random() * 360));
+		ui.physics().targetTransform(new CardTransform(
+				new engine.common.math.UnitQuaternion().rotateBy(new Vector3f(0, 0, 1), (float) (Math.random() * 40 - 20)),
+				targetBox
+		));
+		discardUICards.add(ui);
 	}
 
 	public void addUI(WorldCard card) {
@@ -204,7 +278,7 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 	}
 
 	private void refresh(Deck deck) {
-		Map<WorldCard, UICard> uiCards = deckUICards.get(deck);
+		ConcurrentHashMap<WorldCard, UICard> uiCards = deckUICards.get(deck);
 		if (uiCards == null) {
 			return;
 		}
@@ -224,7 +298,28 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 	@Override
 	public void handle(RestockCardZoneEvent<WorldCard> event) {
 		if (event.zone() instanceof Deck && owner.deckCollection().contains((Deck) event.zone())) {
-			refresh((Deck) event.zone());
+			Deck deck = (Deck) event.zone();
+			List<UICard> toRestock = discardUICards.stream()
+					.filter(ui -> ui.card().deck() == deck)
+					.collect(Collectors.toList());
+			discardUICards.removeAll(toRestock);
+			for (int i = 0; i < toRestock.size(); i++) {
+				UICard ui = toRestock.get(i);
+				ui.physics().targetTransform(new CardTransform(
+						new engine.common.math.UnitQuaternion(),
+						deckConstraints.get(deck)
+				));
+				long delay = i * 100;
+				new Thread(() -> {
+					try {
+						Thread.sleep(delay);
+					} catch (InterruptedException e) {
+						e.printStackTrace();
+					}
+					ConcurrentHashMap<WorldCard, UICard> deckMap = deckUICards.get(deck);
+					deckMap.put(ui.card(), ui);
+				}).start();
+			}
 		}
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
@@ -216,11 +216,13 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 				.set("color", toRangedVector(rgb(210, 180, 140)))
 				.set("transform", new Matrix4f(constraintBox, re.glContext))
 				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
-		discardUI.render(re);
+		discardUI.renderBackground(re);
 		manaIndicator.render(re);
 		targetingArrow.render(re);
 		deckUnrevealedUICards.values().forEach(ui -> ui.render(re));
 		cards().forEach(card -> card.render(re));
+		discardUI.renderCards(re);
+		discardUI.updateAnimations();
 		cards().forEach(card -> {
 			if (discardUI.discardArea().contains(card.position().vector())) {
 				// Card is still in discard area, keep its size

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
@@ -234,8 +234,8 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 		manaIndicator.render(re);
 		targetingArrow.render(re);
 		deckUnrevealedUICards.values().forEach(ui -> ui.render(re));
-		discardUICards.forEach(card -> card.render(re));
 		cards().forEach(card -> card.render(re));
+		discardUICards.forEach(card -> card.render(re));
 		discardUICards.forEach(card -> {
 			float targetY = discardArea.center().y().get() - card.physics().cardBox().h().multiply(0.5f).get();
 			float t = (targetY != 0) ? card.position().y().get() / targetY : 1;

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DiscardUI.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DiscardUI.java
@@ -72,13 +72,22 @@ public class DiscardUI implements UI {
 
 	@Override
 	public void render(RenderingEnvironment re) {
+		renderBackground(re);
+		renderCards(re);
+	}
+
+	public void renderBackground(RenderingEnvironment re) {
 		re.defaultShaderProgram
 				.set("color", toRangedVector(rgb(180, 150, 110)))
 				.set("transform", new Matrix4f(discardArea, re.glContext))
 				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
+	}
 
+	public void renderCards(RenderingEnvironment re) {
 		discardUICards.forEach(card -> card.render(re));
+	}
 
+	public void updateAnimations() {
 		discardUICards.forEach(card -> {
 			float targetY = discardArea.center().y().get() - card.physics().cardBox().h().multiply(0.5f).get();
 			float t = (targetY != 0) ? card.position().y().get() / targetY : 1;

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DiscardUI.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DiscardUI.java
@@ -1,0 +1,94 @@
+package nomadrealms.render.ui.custom.card;
+
+import static engine.common.colour.Colour.rgb;
+import static engine.common.colour.Colour.toRangedVector;
+import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
+
+import engine.common.math.Matrix4f;
+import engine.common.math.Vector3f;
+import engine.visuals.builtin.RectangleVertexArrayObject;
+import engine.visuals.constraint.box.ConstraintBox;
+import engine.visuals.constraint.box.ConstraintPair;
+import engine.visuals.lwjgl.render.meta.DrawFunction;
+import java.util.ArrayList;
+import java.util.List;
+import nomadrealms.context.game.card.UICard;
+import nomadrealms.context.game.card.WorldCard;
+import nomadrealms.render.RenderingEnvironment;
+import nomadrealms.render.ui.UI;
+
+public class DiscardUI implements UI {
+
+	private final ConstraintBox discardArea;
+	private final List<UICard> discardUICards = new ArrayList<>();
+
+	public DiscardUI(ConstraintBox discardArea) {
+		this.discardArea = discardArea;
+	}
+
+	public void addInitialCards(List<WorldCard> cards) {
+		for (WorldCard card : cards) {
+			ConstraintPair cardSize = UICard.cardSize(2.5f);
+			ConstraintBox cardBox = new ConstraintBox(
+					discardArea.x().add(absolute((float) Math.random() * (discardArea.w().get() - cardSize.x().get()))),
+					discardArea.y().add(absolute((float) Math.random() * (discardArea.h().get() - cardSize.y().get()))),
+					cardSize
+			);
+			UICard ui = new UICard(card, cardBox);
+			ui.physics().rotate(new Vector3f(0, 0, 1), (float) (Math.random() * 40 - 20));
+			ui.physics().snap();
+			discardUICards.add(ui);
+		}
+	}
+
+	public void addCard(WorldCard card) {
+		ConstraintPair cardSize = UICard.cardSize(2.5f);
+		ConstraintBox targetBox = new ConstraintBox(
+				discardArea.x().add(absolute((float) Math.random() * (discardArea.w().get() - cardSize.x().get()))),
+				discardArea.y().add(absolute((float) Math.random() * (discardArea.h().get() - cardSize.y().get()))),
+				cardSize
+		);
+		ConstraintBox tempBox = new ConstraintBox(
+				discardArea.center().add(cardSize.scale(-1.5f)),
+				cardSize.scale(3)
+		);
+		ConstraintBox startBox = new ConstraintBox(
+				tempBox.x(), absolute(-tempBox.h().get()),
+				tempBox.w(), tempBox.h()
+		);
+
+		UICard ui = new UICard(card, startBox);
+		ui.physics().rotate(new Vector3f((float) Math.random(), (float) Math.random(), (float) Math.random()), (float) (Math.random() * 360));
+		ui.physics().targetTransform(new CardTransform(
+				new engine.common.math.UnitQuaternion().rotateBy(new Vector3f(0, 0, 1), (float) (Math.random() * 40 - 20)),
+				targetBox
+		));
+		discardUICards.add(ui);
+	}
+
+	public List<UICard> discardUICards() {
+		return discardUICards;
+	}
+
+	@Override
+	public void render(RenderingEnvironment re) {
+		re.defaultShaderProgram
+				.set("color", toRangedVector(rgb(180, 150, 110)))
+				.set("transform", new Matrix4f(discardArea, re.glContext))
+				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
+
+		discardUICards.forEach(card -> card.render(re));
+
+		discardUICards.forEach(card -> {
+			float targetY = discardArea.center().y().get() - card.physics().cardBox().h().multiply(0.5f).get();
+			float t = (targetY != 0) ? card.position().y().get() / targetY : 1;
+			t = Math.max(0, Math.min(1, t));
+			card.physics().targetTransform().size(UICard.cardSize(2.5f).scale(1 + 2 * (1 - t)));
+			card.physics().interpolate(0.2f);
+		});
+	}
+
+	public ConstraintBox discardArea() {
+		return discardArea;
+	}
+}


### PR DESCRIPTION
Implemented the requested discard pile visualization and animations in the DeckTab. This includes a new discard zone at the bottom of the tab, a 'slap' animation for played cards, and a sequenced re-stocking animation.

---
*PR created automatically by Jules for task [8576241588912673281](https://jules.google.com/task/8576241588912673281) started by @Lunkle*