### PR TITLE
Add death particles for actors

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/query/actor/StaticTargetQuery.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/query/actor/StaticTargetQuery.java
@@ -1,0 +1,24 @@
+package nomadrealms.context.game.card.query.actor;
+
+import static java.util.Collections.singletonList;
+
+import java.util.List;
+
+import nomadrealms.context.game.card.query.Query;
+import nomadrealms.context.game.event.Target;
+import nomadrealms.event.game.effect.EffectContext;
+
+public class StaticTargetQuery<T extends Target> implements Query<T> {
+
+	private final T target;
+
+	public StaticTargetQuery(T target) {
+		this.target = target;
+	}
+
+	@Override
+	public List<T> find(EffectContext context) {
+		return singletonList(target);
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -1,13 +1,18 @@
 package nomadrealms.context.game.world;
 
+import static engine.visuals.constraint.misc.TimedConstraint.time;
+import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
+import static java.lang.Math.PI;
+import static java.lang.Math.cos;
+import static java.lang.Math.sin;
+import static java.util.Collections.singletonList;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_HORIZONTAL_SPACING;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_VERTICAL_SPACING;
 import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.CHUNK_SIZE;
 import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.chunkCoordinateOf;
 
-import static java.util.Collections.singletonList;
-
 import engine.common.math.Vector2f;
+import engine.visuals.constraint.box.ConstraintPair;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -19,6 +24,9 @@ import nomadrealms.context.game.actor.types.structure.Structure;
 import nomadrealms.context.game.card.effect.DropItemEffect;
 import nomadrealms.context.game.card.effect.Effect;
 import nomadrealms.context.game.card.effect.RestockEffect;
+import nomadrealms.context.game.card.effect.SpawnParticlesEffect;
+import nomadrealms.context.game.card.query.actor.SelfQuery;
+import nomadrealms.context.game.card.query.actor.StaticTargetQuery;
 import nomadrealms.context.game.event.CardPlayedEvent;
 import nomadrealms.context.game.event.DropItemEvent;
 import nomadrealms.context.game.event.InputEvent;
@@ -35,9 +43,11 @@ import nomadrealms.context.game.world.map.area.coordinate.TileCoordinate;
 import nomadrealms.context.game.world.map.area.coordinate.ZoneCoordinate;
 import nomadrealms.context.game.world.map.generation.MapGenerationStrategy;
 import nomadrealms.context.game.zone.Deck;
+import nomadrealms.event.game.effect.EffectContext;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.particle.ParticlePool;
 import nomadrealms.render.particle.context.game.CardParticle;
+import nomadrealms.render.particle.spawner.BasicParticleSpawner;
 
 /**
  * The world is the container for the map (to do: replace map with an object),
@@ -103,6 +113,39 @@ public class World {
 		}
 	}
 
+	public void spawnDeathParticles(Actor actor) {
+		Tile deathTile = actor.tile();
+		particlePool().addParticles(new SpawnParticlesEffect(
+				actor,
+				new BasicParticleSpawner(new StaticTargetQuery<>(deathTile), "pill")
+						.particleCount(8)
+						.size((i, s, t) -> new ConstraintPair(absolute(5), absolute(11)))
+						.rotation((i, s, t) -> absolute((float) (i * 2 * PI / 8)))
+						.position((i, s, t) -> {
+							float angle = (float) (i * 2 * PI / 8);
+							return new ConstraintPair(t.tile().pos().vector())
+									.add(time().multiply((float) sin(angle)).multiply(0.2f),
+											time().multiply((float) cos(angle)).multiply(-0.2f));
+						})
+						.lifetime((i, s, t) -> 1000L),
+				new EffectContext().source(actor).target(actor)
+		));
+		particlePool().addParticles(new SpawnParticlesEffect(
+				actor,
+				new BasicParticleSpawner(new StaticTargetQuery<>(deathTile), "text_pop")
+						.size((i, s, t) -> new ConstraintPair(absolute(10), absolute(10)))
+						.position((i, s, t) -> {
+							float v0x = 0.05f;
+							float v0y = -0.1f;
+							return new ConstraintPair(t.tile().pos().vector())
+									.add(time().multiply(v0x).add(time().multiply(time()).multiply(-v0x / 2000f)),
+											time().multiply(v0y).add(time().multiply(time()).multiply(-v0y / 2000f)));
+						})
+						.lifetime((i, s, t) -> 1000L),
+				new EffectContext().source(actor).target(actor)
+		));
+	}
+
 	public void renderActors(RenderingEnvironment re) {
 		if (re.camera.zoom().get() < 0.25) {
 			return;
@@ -133,6 +176,11 @@ public class World {
 		}
 		for (Actor actor : currentActors) {
 			if (actor.isDestroyed()) {
+				if (actor.tile() != null) {
+					spawnDeathParticles(actor);
+					actor.tile().clearActor();
+				}
+				actors.remove(actor);
 				continue;
 			}
 			actor.update(this.state);

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -2,14 +2,15 @@ package nomadrealms.context.game.world;
 
 import static engine.visuals.constraint.misc.TimedConstraint.time;
 import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
-import static java.lang.Math.PI;
-import static java.lang.Math.cos;
-import static java.lang.Math.sin;
-import static java.util.Collections.singletonList;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_HORIZONTAL_SPACING;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_VERTICAL_SPACING;
 import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.CHUNK_SIZE;
 import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.chunkCoordinateOf;
+
+import static java.lang.Math.PI;
+import static java.lang.Math.cos;
+import static java.lang.Math.sin;
+import static java.util.Collections.singletonList;
 
 import engine.common.math.Vector2f;
 import engine.visuals.constraint.box.ConstraintPair;
@@ -25,7 +26,6 @@ import nomadrealms.context.game.card.effect.DropItemEffect;
 import nomadrealms.context.game.card.effect.Effect;
 import nomadrealms.context.game.card.effect.RestockEffect;
 import nomadrealms.context.game.card.effect.SpawnParticlesEffect;
-import nomadrealms.context.game.card.query.actor.SelfQuery;
 import nomadrealms.context.game.card.query.actor.StaticTargetQuery;
 import nomadrealms.context.game.event.CardPlayedEvent;
 import nomadrealms.context.game.event.DropItemEvent;
@@ -124,16 +124,16 @@ public class World {
 						.position((i, s, t) -> {
 							float angle = (float) (i * 2 * PI / 8);
 							return new ConstraintPair(t.tile().pos().vector())
-									.add(time().multiply((float) sin(angle)).multiply(0.2f),
-											time().multiply((float) cos(angle)).multiply(-0.2f));
+									.add(time().multiply((float) sin(angle)).multiply(0.1f),
+											time().multiply((float) cos(angle)).multiply(-0.1f));
 						})
-						.lifetime((i, s, t) -> 1000L),
+						.lifetime((i, s, t) -> 500L),
 				new EffectContext().source(actor).target(actor)
 		));
 		particlePool().addParticles(new SpawnParticlesEffect(
 				actor,
 				new BasicParticleSpawner(new StaticTargetQuery<>(deathTile), "text_pop")
-						.size((i, s, t) -> new ConstraintPair(absolute(10), absolute(10)))
+						.size((i, s, t) -> new ConstraintPair(absolute(30), absolute(30)))
 						.position((i, s, t) -> {
 							float v0x = 0.05f;
 							float v0y = -0.1f;
@@ -141,7 +141,7 @@ public class World {
 									.add(time().multiply(v0x).add(time().multiply(time()).multiply(-v0x / 2000f)),
 											time().multiply(v0y).add(time().multiply(time()).multiply(-v0y / 2000f)));
 						})
-						.lifetime((i, s, t) -> 1000L),
+						.lifetime((i, s, t) -> 500L),
 				new EffectContext().source(actor).target(actor)
 		));
 	}
@@ -180,6 +180,7 @@ public class World {
 					spawnDeathParticles(actor);
 					actor.tile().clearActor();
 				}
+				actors.remove(actor);
 				continue;
 			}
 			actor.update(this.state);
@@ -191,7 +192,6 @@ public class World {
 		for (ProcChain chain : new ArrayList<>(procChains)) {
 			chain.update(this);
 		}
-		actors.removeIf(Actor::isDestroyed);
 	}
 
 	public void resolve(InputEvent event) {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -2,14 +2,15 @@ package nomadrealms.context.game.world;
 
 import static engine.visuals.constraint.misc.TimedConstraint.time;
 import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
-import static java.lang.Math.PI;
-import static java.lang.Math.cos;
-import static java.lang.Math.sin;
-import static java.util.Collections.singletonList;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_HORIZONTAL_SPACING;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_VERTICAL_SPACING;
 import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.CHUNK_SIZE;
 import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.chunkCoordinateOf;
+
+import static java.lang.Math.PI;
+import static java.lang.Math.cos;
+import static java.lang.Math.sin;
+import static java.util.Collections.singletonList;
 
 import engine.common.math.Vector2f;
 import engine.visuals.constraint.box.ConstraintPair;
@@ -25,7 +26,6 @@ import nomadrealms.context.game.card.effect.DropItemEffect;
 import nomadrealms.context.game.card.effect.Effect;
 import nomadrealms.context.game.card.effect.RestockEffect;
 import nomadrealms.context.game.card.effect.SpawnParticlesEffect;
-import nomadrealms.context.game.card.query.actor.SelfQuery;
 import nomadrealms.context.game.card.query.actor.StaticTargetQuery;
 import nomadrealms.context.game.event.CardPlayedEvent;
 import nomadrealms.context.game.event.DropItemEvent;
@@ -124,16 +124,16 @@ public class World {
 						.position((i, s, t) -> {
 							float angle = (float) (i * 2 * PI / 8);
 							return new ConstraintPair(t.tile().pos().vector())
-									.add(time().multiply((float) sin(angle)).multiply(0.2f),
-											time().multiply((float) cos(angle)).multiply(-0.2f));
+									.add(time().multiply((float) sin(angle)).multiply(0.1f),
+											time().multiply((float) cos(angle)).multiply(-0.1f));
 						})
-						.lifetime((i, s, t) -> 1000L),
+						.lifetime((i, s, t) -> 500L),
 				new EffectContext().source(actor).target(actor)
 		));
 		particlePool().addParticles(new SpawnParticlesEffect(
 				actor,
 				new BasicParticleSpawner(new StaticTargetQuery<>(deathTile), "text_pop")
-						.size((i, s, t) -> new ConstraintPair(absolute(10), absolute(10)))
+						.size((i, s, t) -> new ConstraintPair(absolute(30), absolute(30)))
 						.position((i, s, t) -> {
 							float v0x = 0.05f;
 							float v0y = -0.1f;
@@ -141,7 +141,7 @@ public class World {
 									.add(time().multiply(v0x).add(time().multiply(time()).multiply(-v0x / 2000f)),
 											time().multiply(v0y).add(time().multiply(time()).multiply(-v0y / 2000f)));
 						})
-						.lifetime((i, s, t) -> 1000L),
+						.lifetime((i, s, t) -> 500L),
 				new EffectContext().source(actor).target(actor)
 		));
 	}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -2,15 +2,14 @@ package nomadrealms.context.game.world;
 
 import static engine.visuals.constraint.misc.TimedConstraint.time;
 import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
-import static nomadrealms.context.game.world.map.area.Tile.TILE_HORIZONTAL_SPACING;
-import static nomadrealms.context.game.world.map.area.Tile.TILE_VERTICAL_SPACING;
-import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.CHUNK_SIZE;
-import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.chunkCoordinateOf;
-
 import static java.lang.Math.PI;
 import static java.lang.Math.cos;
 import static java.lang.Math.sin;
 import static java.util.Collections.singletonList;
+import static nomadrealms.context.game.world.map.area.Tile.TILE_HORIZONTAL_SPACING;
+import static nomadrealms.context.game.world.map.area.Tile.TILE_VERTICAL_SPACING;
+import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.CHUNK_SIZE;
+import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.chunkCoordinateOf;
 
 import engine.common.math.Vector2f;
 import engine.visuals.constraint.box.ConstraintPair;
@@ -26,6 +25,7 @@ import nomadrealms.context.game.card.effect.DropItemEffect;
 import nomadrealms.context.game.card.effect.Effect;
 import nomadrealms.context.game.card.effect.RestockEffect;
 import nomadrealms.context.game.card.effect.SpawnParticlesEffect;
+import nomadrealms.context.game.card.query.actor.SelfQuery;
 import nomadrealms.context.game.card.query.actor.StaticTargetQuery;
 import nomadrealms.context.game.event.CardPlayedEvent;
 import nomadrealms.context.game.event.DropItemEvent;
@@ -124,16 +124,16 @@ public class World {
 						.position((i, s, t) -> {
 							float angle = (float) (i * 2 * PI / 8);
 							return new ConstraintPair(t.tile().pos().vector())
-									.add(time().multiply((float) sin(angle)).multiply(0.1f),
-											time().multiply((float) cos(angle)).multiply(-0.1f));
+									.add(time().multiply((float) sin(angle)).multiply(0.2f),
+											time().multiply((float) cos(angle)).multiply(-0.2f));
 						})
-						.lifetime((i, s, t) -> 500L),
+						.lifetime((i, s, t) -> 1000L),
 				new EffectContext().source(actor).target(actor)
 		));
 		particlePool().addParticles(new SpawnParticlesEffect(
 				actor,
 				new BasicParticleSpawner(new StaticTargetQuery<>(deathTile), "text_pop")
-						.size((i, s, t) -> new ConstraintPair(absolute(30), absolute(30)))
+						.size((i, s, t) -> new ConstraintPair(absolute(10), absolute(10)))
 						.position((i, s, t) -> {
 							float v0x = 0.05f;
 							float v0y = -0.1f;
@@ -141,7 +141,7 @@ public class World {
 									.add(time().multiply(v0x).add(time().multiply(time()).multiply(-v0x / 2000f)),
 											time().multiply(v0y).add(time().multiply(time()).multiply(-v0y / 2000f)));
 						})
-						.lifetime((i, s, t) -> 500L),
+						.lifetime((i, s, t) -> 1000L),
 				new EffectContext().source(actor).target(actor)
 		));
 	}
@@ -180,7 +180,6 @@ public class World {
 					spawnDeathParticles(actor);
 					actor.tile().clearActor();
 				}
-				actors.remove(actor);
 				continue;
 			}
 			actor.update(this.state);
@@ -192,6 +191,7 @@ public class World {
 		for (ProcChain chain : new ArrayList<>(procChains)) {
 			chain.update(this);
 		}
+		actors.removeIf(Actor::isDestroyed);
 	}
 
 	public void resolve(InputEvent event) {

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/ParticlePool.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/ParticlePool.java
@@ -55,7 +55,7 @@ public class ParticlePool implements Renderable {
 	@Override
 	public void render(RenderingEnvironment re) {
 		List<SpawnParticlesEffect> newActiveEffects = new ArrayList<>();
-		for (SpawnParticlesEffect effect : activeEffects) {
+		for (SpawnParticlesEffect effect : new ArrayList<>(activeEffects)) {
 			for (Particle particle : effect.spawnParticles(re)) {
 				addParticle(particle);
 			}

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/ParticlePool.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/ParticlePool.java
@@ -55,7 +55,7 @@ public class ParticlePool implements Renderable {
 	@Override
 	public void render(RenderingEnvironment re) {
 		List<SpawnParticlesEffect> newActiveEffects = new ArrayList<>();
-		for (SpawnParticlesEffect effect : new ArrayList<>(activeEffects)) {
+		for (SpawnParticlesEffect effect : activeEffects) {
 			for (Particle particle : effect.spawnParticles(re)) {
 				addParticle(particle);
 			}

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/spawner/ParticleFactory.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/spawner/ParticleFactory.java
@@ -19,9 +19,9 @@ public class ParticleFactory {
 			case "text_blocked":
 				return new TextParticle("Blocked", 0xFFFFFFFF);
 			case "text_pop":
-				return new TextParticle("POP", 0x808080FF);
+				return new TextParticle("POP", 0xFFFFFFFF);
 			case "pill":
-				return new TextureParticle(re.glContext, 1000, null, null, "pill_blue");
+				return new TextureParticle(re.glContext, 100, null, null, "pill_blue");
 			case "ice_cube":
 				return new RectangleParticle(0, null, null, rgb(100, 200, 255));
 //			case "smoke":

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/spawner/ParticleFactory.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/spawner/ParticleFactory.java
@@ -6,6 +6,7 @@ import nomadrealms.event.game.effect.EffectContext;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.particle.Particle;
 import nomadrealms.render.particle.TextParticle;
+import nomadrealms.render.particle.TextureParticle;
 import nomadrealms.render.particle.context.game.DirectionalFireParticle;
 import nomadrealms.render.particle.geometry.RectangleParticle;
 
@@ -17,6 +18,10 @@ public class ParticleFactory {
 				return new DirectionalFireParticle(re, p);
 			case "text_blocked":
 				return new TextParticle("Blocked", 0xFFFFFFFF);
+			case "text_pop":
+				return new TextParticle("POP", 0x808080FF);
+			case "pill":
+				return new TextureParticle(re.glContext, 1000, null, null, "pill_blue");
 			case "ice_cube":
 				return new RectangleParticle(0, null, null, rgb(100, 200, 255));
 //			case "smoke":

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/spawner/ParticleFactory.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/spawner/ParticleFactory.java
@@ -19,9 +19,9 @@ public class ParticleFactory {
 			case "text_blocked":
 				return new TextParticle("Blocked", 0xFFFFFFFF);
 			case "text_pop":
-				return new TextParticle("POP", 0xFFFFFFFF);
+				return new TextParticle("POP", 0x808080FF);
 			case "pill":
-				return new TextureParticle(re.glContext, 100, null, null, "pill_blue");
+				return new TextureParticle(re.glContext, 1000, null, null, "pill_blue");
 			case "ice_cube":
 				return new RectangleParticle(0, null, null, rgb(100, 200, 255));
 //			case "smoke":


### PR DESCRIPTION
When an actor dies, 8 gray (currently blue) pill-shaped particles and a gray "POP" text particle emerge at the location of death. The pills fly out in a uniform circular pattern, and the "POP" text moves up and to the right with decreasing velocity. The actors are removed from the world and cleared from their tiles after death.

---
*PR created automatically by Jules for task [16425010653826780241](https://jules.google.com/task/16425010653826780241) started by @Lunkle*