### PR TITLE
Move tooltip to bottom-left corner

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/tooltip/Tooltip.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/tooltip/Tooltip.java
@@ -5,6 +5,9 @@ import static org.lwjgl.glfw.GLFW.GLFW_MOUSE_BUTTON_RIGHT;
 
 import engine.context.input.Mouse;
 import engine.context.input.event.InputCallbackRegistry;
+import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
+import static engine.visuals.constraint.posdim.CustomSupplierConstraint.custom;
+
 import engine.context.input.event.MouseMovedInputEvent;
 import engine.context.input.event.MousePressedInputEvent;
 import engine.visuals.constraint.box.ConstraintPair;
@@ -40,7 +43,9 @@ public class Tooltip implements UI {
 		registry.registerOnDrag(this::handleMouseOff);
 		containerContent = new DynamicGridLayoutContainerContent(
 				screenContainerContent,
-				new ConstraintPair(mouse::x, mouse::y),
+				new ConstraintPair(
+						absolute(0),
+						custom("tooltip_y", () -> re.glContext.height() - uiContainer().constraintBox().h().get())),
 				2)
 				.fill(rgb(255, 0, 0));
 	}


### PR DESCRIPTION
This change moves the game's tooltip from following the cursor to a fixed position in the bottom-left corner of the screen.

Key changes:
- Updated the `Tooltip` class constructor to use fixed constraints for positioning.
- The x-coordinate is anchored at 0 (left edge of the screen).
- The y-coordinate is dynamically calculated using a `CustomSupplierConstraint` that subtracts the tooltip's height from the screen's total height, effectively placing the tooltip's bottom at the screen's bottom.
- Maintained the existing right-click toggle and auto-close on mouse-off behavior as requested.
- Verified that the implementation correctly uses the engine's constraint system to handle dynamic screen and tooltip sizes.

---
*PR created automatically by Jules for task [10201325532353170474](https://jules.google.com/task/10201325532353170474) started by @Lunkle*