### PR TITLE
Introduce InteractionState for transient client-side data

### DIFF
--- a/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
+++ b/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
@@ -10,6 +10,7 @@ import engine.context.input.event.PacketReceivedInputEvent;
 import engine.networking.NetworkingReceiver;
 import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.event.InputEvent;
+import nomadrealms.context.game.interaction.InteractionState;
 import nomadrealms.context.game.world.map.generation.OverworldGenerationStrategy;
 import nomadrealms.event.networking.SyncedEvent;
 import nomadrealms.render.RenderingEnvironment;
@@ -17,6 +18,7 @@ import nomadrealms.render.RenderingEnvironment;
 public class ServerContext extends GameContext {
 
 	private RenderingEnvironment re;
+	private InteractionState is;
 	private GameState gameState;
 	private final Queue<InputEvent> uiEventChannel = new ArrayDeque<>();
 
@@ -24,7 +26,8 @@ public class ServerContext extends GameContext {
 
 	@Override
 	public void init() {
-		re = new RenderingEnvironment(glContext(), config(), mouse());
+		re = new RenderingEnvironment(glContext(), config());
+		is = new InteractionState(mouse());
 		gameState = new GameState("Server World", uiEventChannel, new OverworldGenerationStrategy(123456789));
 		networkingReceiver.init(44999);
 	}
@@ -53,7 +56,7 @@ public class ServerContext extends GameContext {
 	@Override
 	public void render(float alpha) {
 		background(gameState.weather.skyColor(gameState.frameNumber));
-		gameState.render(re);
+		gameState.render(re, is);
 	}
 
 }

--- a/nomad-realms/src/main/java/experimental/geometry/GeometryContext.java
+++ b/nomad-realms/src/main/java/experimental/geometry/GeometryContext.java
@@ -18,7 +18,7 @@ public class GeometryContext extends GameContext {
 
 	@Override
 	public void init() {
-		re = new RenderingEnvironment(glContext(), config(), mouse());
+		re = new RenderingEnvironment(glContext(), config());
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/experimental/shader/blur/BlurContext.java
+++ b/nomad-realms/src/main/java/experimental/shader/blur/BlurContext.java
@@ -21,7 +21,7 @@ public class BlurContext extends GameContext {
 
 	@Override
 	public void init() {
-		re = new RenderingEnvironment(glContext(), config(), mouse());
+		re = new RenderingEnvironment(glContext(), config());
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/app/context/CardSandboxContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/CardSandboxContext.java
@@ -20,12 +20,14 @@ import engine.visuals.constraint.box.ConstraintBox;
 import engine.visuals.constraint.box.ConstraintPair;
 import nomadrealms.context.game.card.UICard;
 import nomadrealms.context.game.card.WorldCard;
+import nomadrealms.context.game.interaction.InteractionState;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.ui.custom.card.CardTransform;
 
 public class CardSandboxContext extends GameContext {
 
 	private RenderingEnvironment re;
+	private InteractionState is;
 	private UICard uiCard;
 
 	private boolean keyControlEnabled = false;
@@ -38,7 +40,8 @@ public class CardSandboxContext extends GameContext {
 
 	@Override
 	public void init() {
-		re = new RenderingEnvironment(glContext(), config(), mouse());
+		re = new RenderingEnvironment(glContext(), config());
+		is = new InteractionState(mouse());
 		WorldCard worldCard = new WorldCard(null, ATTACK);
 		uiCard = new UICard(worldCard, baseTransform());
 		if (!"/audio/theme-song.mp3".equals(audioPlayer().currentAudio())) {
@@ -54,7 +57,7 @@ public class CardSandboxContext extends GameContext {
 	public void render(float alpha) {
 		background(rgb(100, 100, 100));
 		uiCard.interpolate();
-		uiCard.render(re);
+		uiCard.render(re, is);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/app/context/DeckEditingContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/DeckEditingContext.java
@@ -26,6 +26,7 @@ import nomadrealms.context.game.card.GameCard;
 import nomadrealms.context.game.card.UICard;
 import nomadrealms.context.game.card.WorldCard;
 import nomadrealms.context.game.card.collection.DeckList;
+import nomadrealms.context.game.interaction.InteractionState;
 import nomadrealms.context.game.zone.BeginnerDecks;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.ui.content.ButtonUIContent;
@@ -37,6 +38,7 @@ import nomadrealms.render.ui.content.UIContent;
 public class DeckEditingContext extends GameContext {
 
 	private RenderingEnvironment re;
+	private InteractionState is;
 	private ScreenContainerContent screen;
 
 	private final List<UICard> uiCards = new ArrayList<>();
@@ -71,7 +73,8 @@ public class DeckEditingContext extends GameContext {
 
 	@Override
 	public void init() {
-		re = new RenderingEnvironment(glContext(), config(), mouse());
+		re = new RenderingEnvironment(glContext(), config());
+		is = new InteractionState(mouse());
 
 		screen = new ScreenContainerContent(re);
 
@@ -147,10 +150,10 @@ public class DeckEditingContext extends GameContext {
 
 		background(rgb(100, 100, 100));
 		for (UICard uiCard : uiCards) {
-			uiCard.render(re);
+			uiCard.render(re, is);
 			uiCard.interpolate();
 		}
-		screen.render(re);
+		screen.render(re, is);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/app/context/HomeScreenContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/HomeScreenContext.java
@@ -14,6 +14,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
 import nomadrealms.context.game.GameState;
+import nomadrealms.context.game.interaction.InteractionState;
 import nomadrealms.context.game.world.map.generation.FileBasedGenerationStrategy;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.particle.ParticlePool;
@@ -25,6 +26,7 @@ import nomadrealms.user.data.GameData;
 public class HomeScreenContext extends GameContext {
 
 	private RenderingEnvironment re;
+	private InteractionState is;
 
 	private final GameData data = new GameData();
 	private final InputCallbackRegistry inputCallbackRegistry = new InputCallbackRegistry();
@@ -36,7 +38,8 @@ public class HomeScreenContext extends GameContext {
 
 	@Override
 	public void init() {
-		re = new RenderingEnvironment(glContext(), config(), mouse());
+		re = new RenderingEnvironment(glContext(), config());
+		is = new InteractionState(mouse());
 		gameState = new GameState("Main Menu", new LinkedList<>(), new FileBasedGenerationStrategy());
 		homeInterface = new HomeInterface(re, glContext(), inputCallbackRegistry);
 		homeInterface.initStartGameButton(() -> {
@@ -77,9 +80,9 @@ public class HomeScreenContext extends GameContext {
 	@Override
 	public void render(float alpha) {
 		background(rgb(100, 100, 100));
-		gameState.world.renderMap(re);
-		particlePool.render(re);
-		homeInterface.render(re);
+		gameState.world.renderMap(re, is);
+		particlePool.render(re, is);
+		homeInterface.render(re, is);
 	}
 
 	@Override
@@ -97,7 +100,7 @@ public class HomeScreenContext extends GameContext {
 	@Override
 	public void input(MouseScrolledInputEvent event) {
 		float amount = event.yAmount();
-		re.camera.zoom(re.camera.zoom().get() * (float) Math.pow(1.1f, amount), event.mouse());
+		is.camera.zoom(is.camera.zoom().get() * (float) Math.pow(1.1f, amount), event.mouse());
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import nomadrealms.context.game.GameState;
+import nomadrealms.context.game.interaction.InteractionState;
 import nomadrealms.context.game.actor.types.structure.Structure;
 import nomadrealms.context.game.event.InputEvent;
 import nomadrealms.context.game.world.map.area.Tile;
@@ -70,6 +71,7 @@ public class MainContext extends GameContext {
 	private final GameData data = new GameData();
 
 	private RenderingEnvironment re;
+	private InteractionState is;
 	private GameInterface ui;
 	private PlayerIndicator playerIndicator = new PlayerIndicator();
 	private Console console;
@@ -104,10 +106,11 @@ public class MainContext extends GameContext {
 
 	@Override
 	public void init() {
-		re = new RenderingEnvironment(glContext(), config(), mouse());
+		re = new RenderingEnvironment(glContext(), config());
+		is = new InteractionState(mouse());
 		localPlayer = new Player("Local Player", new PacketAddress()).cardPlayer(gameState.world.nomad);
-		re.localPlayer = localPlayer;
-		re.camera = new Camera(localPlayer.cardPlayer().tile().pos().sub(glContext().screen.dimensions().scale(0.5f * 0.6f, 0.5f)));
+		is.localPlayer = localPlayer;
+		is.camera = new Camera(localPlayer.cardPlayer().tile().pos().sub(glContext().screen.dimensions().scale(0.5f * 0.6f, 0.5f)));
 		ui = new GameInterface(re, localPlayer, stateToUiEventChannel, gameState, glContext(), mouse(), inputCallbackRegistry);
 		console = new Console(glContext().screen, gameState, re);
 		gameState.particlePool(new ParticlePool(glContext()));
@@ -127,13 +130,13 @@ public class MainContext extends GameContext {
 	@Override
 	public void render(float alpha) {
 		fpsCounter.update();
-		re.updateActorTextOpacity();
+		is.update();
 		// Render the scene to fbo1
 		re.fbo1.render(() -> {
 			background(0);
-			gameState.render(re);
-			playerIndicator.render(re, localPlayer.cardPlayer());
-			ui.render(re);
+			gameState.render(re, is);
+			playerIndicator.render(re, is, localPlayer.cardPlayer());
+			ui.render(re, is);
 		});
 
 		// Render the bright parts of the scene to fbo2
@@ -159,10 +162,10 @@ public class MainContext extends GameContext {
 			background(gameState.weather.skyColor(gameState.frameNumber));
 			re.textureRenderer.render(re.fbo1.texture(), new Matrix4f(glContext().screen, glContext()));
 			// re.textureRenderer.render(re.fbo2.texture(), new Matrix4f(glContext().screen, glContext())); // Bloom is currently broken
-			console.render(re);
-			ruler.render(re);
-			if (re.showDebugInfo) {
-				fpsText.render(re);
+			console.render(re, is);
+			ruler.render(re, is);
+			if (is.showDebugInfo) {
+				fpsText.render(re, is);
 			}
 		});
 //		re.bloomCombinationShaderProgram.use(glContext());
@@ -172,7 +175,7 @@ public class MainContext extends GameContext {
 //		re.bloomCombinationShaderProgram.uniforms().set("bloomTexture", 1);
 //		re.textureRenderer.render(re.fbo1.texture(), new Matrix4f().translate(-1, -1).scale(2, 2));
 
-		ui.particlePool.render(re);
+		ui.particlePool.render(re, is);
 	}
 
 	@Override
@@ -198,22 +201,22 @@ public class MainContext extends GameContext {
 				localPlayer.cardPlayer().inventory().toggle();
 				break;
 			case GLFW_KEY_M:
-				gameState.showMap = !gameState.showMap;
+				is.showMap = !is.showMap;
 				break;
 			case GLFW_KEY_W:
-				re.camera.up(true);
+				is.camera.up(true);
 				break;
 			case GLFW_KEY_A:
-				re.camera.left(true);
+				is.camera.left(true);
 				break;
 			case GLFW_KEY_S:
-				re.camera.down(true);
+				is.camera.down(true);
 				break;
 			case GLFW_KEY_D:
-				re.camera.right(true);
+				is.camera.right(true);
 				break;
 			case GLFW_KEY_F3:
-				re.showDebugInfo = true;
+				is.showDebugInfo = true;
 				break;
 			case GLFW_KEY_K:
 				ruler.toggle();
@@ -237,19 +240,19 @@ public class MainContext extends GameContext {
 		}
 		switch (key) {
 			case GLFW_KEY_W:
-				re.camera.up(false);
+				is.camera.up(false);
 				break;
 			case GLFW_KEY_A:
-				re.camera.left(false);
+				is.camera.left(false);
 				break;
 			case GLFW_KEY_S:
-				re.camera.down(false);
+				is.camera.down(false);
 				break;
 			case GLFW_KEY_D:
-				re.camera.right(false);
+				is.camera.right(false);
 				break;
 			case GLFW_KEY_F3:
-				re.showDebugInfo = false;
+				is.showDebugInfo = false;
 				break;
 			default:
 				break;
@@ -258,13 +261,13 @@ public class MainContext extends GameContext {
 
 	public void input(MouseScrolledInputEvent event) {
 		float amount = event.yAmount();
-		re.camera.zoom(re.camera.zoom().get() * (float) Math.pow(1.1f, amount), event.mouse());
+		is.camera.zoom(is.camera.zoom().get() * (float) Math.pow(1.1f, amount), event.mouse());
 	}
 
 	@Override
 	public void input(MouseMovedInputEvent event) {
 		if (event.mouse().x() < glContext().screen.w().get() * 0.6f) {
-			re.lastMouseMovedTime = System.currentTimeMillis();
+			is.lastMouseMovedTime = System.currentTimeMillis();
 		}
 		inputCallbackRegistry.triggerOnDrag(event);
 	}
@@ -273,7 +276,7 @@ public class MainContext extends GameContext {
 	public void input(MousePressedInputEvent event) {
 		switch (event.button()) {
 			case GLFW_MOUSE_BUTTON_LEFT:
-				Tile tile = gameState.getMouseHexagon(mouse(), re.camera);
+				Tile tile = gameState.getMouseHexagon(mouse(), is.camera);
 				if (tile != null && tile.actor() instanceof Structure) {
 					Structure structure = (Structure) tile.actor();
 					structure.maybeInteract(gameState, localPlayer.cardPlayer());

--- a/nomad-realms/src/main/java/nomadrealms/app/context/TerrainSandboxContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/TerrainSandboxContext.java
@@ -26,6 +26,7 @@ import engine.visuals.constraint.box.ConstraintPair;
 import engine.visuals.lwjgl.render.framebuffer.DefaultFrameBuffer;
 import java.util.LinkedList;
 import nomadrealms.context.game.GameState;
+import nomadrealms.context.game.interaction.InteractionState;
 import nomadrealms.context.game.world.map.generation.OverworldGenerationStrategy;
 import nomadrealms.context.game.world.map.generation.TerrainSandboxMapInitialization;
 import nomadrealms.render.RenderingEnvironment;
@@ -39,6 +40,7 @@ import nomadrealms.render.ui.custom.console.Console;
 public class TerrainSandboxContext extends GameContext {
 
 	private RenderingEnvironment re;
+	private InteractionState is;
 	private GameState gameState;
 	private Console console;
 	private final Ruler ruler = new Ruler();
@@ -53,9 +55,10 @@ public class TerrainSandboxContext extends GameContext {
 
 	@Override
 	public void init() {
-		re = new RenderingEnvironment(glContext(), config(), mouse());
-		re.camera = new Camera(0, 0);
-		re.camera.position(glContext().screen.dimensions().scale(-0.5f).vector());
+		re = new RenderingEnvironment(glContext(), config());
+		is = new InteractionState(mouse());
+		is.camera = new Camera(0, 0);
+		is.camera.position(glContext().screen.dimensions().scale(-0.5f).vector());
 
 		initGameState(123456789);
 
@@ -96,7 +99,7 @@ public class TerrainSandboxContext extends GameContext {
 
 	@Override
 	public void update() {
-		re.camera.update();
+		is.camera.update();
 		if (!paused && gameState != null) {
 			gameState.update();
 		}
@@ -107,17 +110,17 @@ public class TerrainSandboxContext extends GameContext {
 		fpsCounter.update();
 		re.fbo1.render(() -> {
 			background(0);
-			gameState.render(re);
+			gameState.render(re, is);
 		});
 
 		DefaultFrameBuffer.instance().render(() -> {
 			background(gameState.weather.skyColor(gameState.frameNumber));
 			re.textureRenderer.render(re.fbo1.texture(), new Matrix4f(glContext().screen, glContext()));
-			console.render(re);
-			ui.render(re);
-			ruler.render(re);
-			if (re.showDebugInfo) {
-				fpsText.render(re);
+			console.render(re, is);
+			ui.render(re, is);
+			ruler.render(re, is);
+			if (is.showDebugInfo) {
+				fpsText.render(re, is);
 			}
 		});
 	}
@@ -143,19 +146,19 @@ public class TerrainSandboxContext extends GameContext {
 		}
 		switch (key) {
 			case GLFW_KEY_W:
-				re.camera.up(true);
+				is.camera.up(true);
 				break;
 			case GLFW_KEY_A:
-				re.camera.left(true);
+				is.camera.left(true);
 				break;
 			case GLFW_KEY_S:
-				re.camera.down(true);
+				is.camera.down(true);
 				break;
 			case GLFW_KEY_D:
-				re.camera.right(true);
+				is.camera.right(true);
 				break;
 			case GLFW_KEY_F3:
-				re.showDebugInfo = true;
+				is.showDebugInfo = true;
 				break;
 			default:
 				break;
@@ -177,19 +180,19 @@ public class TerrainSandboxContext extends GameContext {
 		}
 		switch (key) {
 			case GLFW_KEY_W:
-				re.camera.up(false);
+				is.camera.up(false);
 				break;
 			case GLFW_KEY_A:
-				re.camera.left(false);
+				is.camera.left(false);
 				break;
 			case GLFW_KEY_S:
-				re.camera.down(false);
+				is.camera.down(false);
 				break;
 			case GLFW_KEY_D:
-				re.camera.right(false);
+				is.camera.right(false);
 				break;
 			case GLFW_KEY_F3:
-				re.showDebugInfo = false;
+				is.showDebugInfo = false;
 				break;
 			default:
 				break;
@@ -199,7 +202,7 @@ public class TerrainSandboxContext extends GameContext {
 	@Override
 	public void input(MouseScrolledInputEvent event) {
 		float amount = event.yAmount();
-		re.camera.zoom(re.camera.zoom().get() * (float) Math.pow(1.1f, amount), event.mouse());
+		is.camera.zoom(is.camera.zoom().get() * (float) Math.pow(1.1f, amount), event.mouse());
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/GameState.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/GameState.java
@@ -18,6 +18,7 @@ import nomadrealms.context.game.world.map.generation.MapGenerationStrategy;
 import nomadrealms.context.game.world.map.generation.OverworldGenerationStrategy;
 import nomadrealms.context.game.world.weather.Clouds;
 import nomadrealms.context.game.world.weather.Weather;
+import nomadrealms.context.game.interaction.InteractionState;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.particle.NullParticlePool;
 import nomadrealms.render.particle.ParticlePool;
@@ -41,7 +42,6 @@ public class GameState {
 	public World world;
 	public Weather weather = new Weather();
 	public Clouds clouds = new Clouds();
-	public boolean showMap = false;
 	public Queue<InputEvent> uiEventChannel;
 	public transient ParticlePool particlePool = new NullParticlePool();
 	final List<InputEventFrame> inputFrames = new ArrayList<>();
@@ -62,12 +62,12 @@ public class GameState {
 		return world;
 	}
 
-	public void render(RenderingEnvironment re) {
-		re.camera.update();
-		world.renderMap(re);
-		world.renderActors(re);
-		clouds.render(re, this);
-		particlePool.render(re);
+	public void render(RenderingEnvironment re, InteractionState is) {
+		is.camera.update();
+		world.renderMap(re, is);
+		world.renderActors(re, is);
+		clouds.render(re, is, this);
+		particlePool.render(re, is);
 	}
 
 	public void particlePool(ParticlePool particlePool) {
@@ -86,7 +86,8 @@ public class GameState {
 
 	public Tile getMouseHexagon(Mouse mouse, Camera camera) {
 		Vector2f cameraPosition = camera.position().vector();
-		TileCoordinate coord = tileCoordinateOf(cameraPosition.add(mouse.coordinate().vector().scale(1 / camera.zoom().get())));
+		TileCoordinate coord = tileCoordinateOf(
+				cameraPosition.add(mouse.coordinate().vector().scale(1 / camera.zoom().get())));
 		return world.getTile(coord);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/status/Status.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/status/Status.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.actor.status;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_VERTICAL_SPACING;
@@ -30,7 +31,7 @@ public class Status {
 		return stacks[effect.ordinal()];
 	}
 
-	public void render(RenderingEnvironment re, ConstraintPair position) {
+	public void render(RenderingEnvironment re, InteractionState is, ConstraintPair position) {
 		float x = position.x().get();
 		float y = position.y().get();
 		List<StatusEffect> activeEffects = new ArrayList<>();
@@ -41,16 +42,16 @@ public class Status {
 		}
 		for (int i = 0; i < activeEffects.size(); i++) {
 			StatusEffect status = activeEffects.get(i);
-			float iconSize = 10f * re.camera.zoom().get();
+			float iconSize = 10f * is.camera.zoom().get();
 			float iconX = x - (activeEffects.size() * iconSize) / 2 + i * iconSize;
-			float iconY = y - TILE_VERTICAL_SPACING * re.camera.zoom().get() / 2;
+			float iconY = y - TILE_VERTICAL_SPACING * is.camera.zoom().get() / 2;
 			re.textureRenderer.render(re.imageMap.get(status.image()), iconX, iconY, iconSize, iconSize);
 			re.textRenderer.render(
 					iconX + iconSize, iconY + iconSize,
 					textFormat()
 							.text(String.valueOf(count(status)))
 							.font(re.font)
-							.fontSize(10f * re.camera.zoom().get())
+							.fontSize(10f * is.camera.zoom().get())
 							.colour(rgb(255, 255, 255))
 							.hAlign(RIGHT)
 							.vAlign(BOTTOM)

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Bub.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Bub.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.actor.types.cardplayer;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgba;
 import static engine.visuals.rendering.text.HorizontalAlign.CENTER;
@@ -37,9 +38,9 @@ public class Bub extends CardPlayer {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		float scale = 0.6f * TILE_RADIUS;
-		Vector2f screenPosition = tile().getScreenPosition(re).vector();
+		Vector2f screenPosition = tile().getScreenPosition(re, is).vector();
 		re.textureRenderer.render(
 				re.imageMap.get("farmer"),
 				screenPosition.x() - 0.5f * scale,
@@ -53,7 +54,7 @@ public class Bub extends CardPlayer {
 						.text(name + " BUB12")
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER));
 		re.textRenderer.render(
 				screenPosition.x(),
@@ -62,9 +63,9 @@ public class Bub extends CardPlayer {
 						.text(health() + " HP")
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER));
-		super.render(re);
+		super.render(re, is);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/CardPlayer.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/CardPlayer.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.actor.types.cardplayer;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static java.util.Arrays.asList;
 
@@ -149,8 +150,8 @@ public abstract class CardPlayer implements Actor, HasSpeech {
 		this.previousTile = tile;
 	}
 
-	public ConstraintPair getScreenPosition(RenderingEnvironment re) {
-		return tile.getScreenPosition(re).add(actionScheduler.screenOffset(re));
+	public ConstraintPair getScreenPosition(RenderingEnvironment re, InteractionState is) {
+		return tile.getScreenPosition(re, is).add(actionScheduler.screenOffset(re, is));
 	}
 
 	/**
@@ -175,9 +176,9 @@ public abstract class CardPlayer implements Actor, HasSpeech {
 		return 1;
 	}
 
-	public void render(RenderingEnvironment re) {
-		cardStack().render(re, getScreenPosition(re));
-		status().render(re, getScreenPosition(re));
+	public void render(RenderingEnvironment re, InteractionState is) {
+		cardStack().render(re, is, getScreenPosition(re, is));
+		status().render(re, is, getScreenPosition(re, is));
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Farmer.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Farmer.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.actor.types.cardplayer;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgba;
 import static engine.visuals.rendering.text.HorizontalAlign.CENTER;
@@ -45,9 +46,9 @@ public class Farmer extends CardPlayer {
 		this.deckCollection().deck1().addCards(list.toDeck().getCards());
 	}
 
-	public void render(RenderingEnvironment re) {
-		float scale = 0.6f * TILE_RADIUS * re.camera.zoom().get();
-		Vector2f screenPosition = getScreenPosition(re).vector();
+	public void render(RenderingEnvironment re, InteractionState is) {
+		float scale = 0.6f * TILE_RADIUS * is.camera.zoom().get();
+		Vector2f screenPosition = getScreenPosition(re, is).vector();
 		re.textureRenderer.render(
 				re.imageMap.get("farmer"),
 				screenPosition.x() - 0.5f * scale,
@@ -61,7 +62,7 @@ public class Farmer extends CardPlayer {
 						.text(name + " FARMER")
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
 		);
@@ -72,11 +73,11 @@ public class Farmer extends CardPlayer {
 						.text(health() + " HP")
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
 		);
-		super.render(re);
+		super.render(re, is);
 	}
 
 	private int thinkingTime = 10;

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/FeralMonkey.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/FeralMonkey.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.actor.types.cardplayer;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgba;
 import static engine.visuals.rendering.text.HorizontalAlign.CENTER;
@@ -46,9 +47,9 @@ public class FeralMonkey extends CardPlayer {
 		this.deckCollection().deck2().addCards(list2.toDeck().getCards());
 	}
 
-	public void render(RenderingEnvironment re) {
-		float scale = 0.6f * TILE_RADIUS * re.camera.zoom().get();
-		Vector2f screenPosition = getScreenPosition(re).vector();
+	public void render(RenderingEnvironment re, InteractionState is) {
+		float scale = 0.6f * TILE_RADIUS * is.camera.zoom().get();
+		Vector2f screenPosition = getScreenPosition(re, is).vector();
 		re.textureRenderer.render(
 				re.imageMap.get("feral_monkey"),
 				screenPosition.x() - 0.5f * scale,
@@ -61,7 +62,7 @@ public class FeralMonkey extends CardPlayer {
 						.text(name + " FERAL MONKEY")
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP));
 		re.textRenderer.render(
@@ -71,10 +72,10 @@ public class FeralMonkey extends CardPlayer {
 						.text(health() + " HP")
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP));
-		super.render(re);
+		super.render(re, is);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Nomad.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Nomad.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.actor.types.cardplayer;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgba;
 import static java.util.Arrays.asList;
@@ -40,9 +41,9 @@ public class Nomad extends CardPlayer {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
-		float scale = 0.6f * TILE_RADIUS * re.camera.zoom().get();
-		Vector2f screenPosition = getScreenPosition(re).vector();
+	public void render(RenderingEnvironment re, InteractionState is) {
+		float scale = 0.6f * TILE_RADIUS * is.camera.zoom().get();
+		Vector2f screenPosition = getScreenPosition(re, is).vector();
 		re.textureRenderer.render(
 				re.imageMap.get("nomad"),
 				screenPosition.x() - 0.5f * scale,
@@ -55,7 +56,7 @@ public class Nomad extends CardPlayer {
 						.text(name)
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP));
 		re.textRenderer.render(
@@ -65,10 +66,10 @@ public class Nomad extends CardPlayer {
 						.text(health() + " HP")
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP));
-		super.render(re);
+		super.render(re, is);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageChief.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageChief.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.actor.types.cardplayer;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgba;
 import static engine.visuals.rendering.text.HorizontalAlign.CENTER;
@@ -35,9 +36,9 @@ public class VillageChief extends CardPlayer {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
-		float scale = 0.6f * TILE_RADIUS * re.camera.zoom().get();
-		Vector2f screenPosition = getScreenPosition(re).vector();
+	public void render(RenderingEnvironment re, InteractionState is) {
+		float scale = 0.6f * TILE_RADIUS * is.camera.zoom().get();
+		Vector2f screenPosition = getScreenPosition(re, is).vector();
 		re.textureRenderer.render(
 				re.imageMap.get("chief"),
 				screenPosition.x() - 0.5f * scale,
@@ -50,7 +51,7 @@ public class VillageChief extends CardPlayer {
 						.text(name + " VILLAGE CHIEF")
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER));
 		re.textRenderer.render(
 				screenPosition.x(),
@@ -59,9 +60,9 @@ public class VillageChief extends CardPlayer {
 						.text(health() + " HP")
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER));
-		super.render(re);       // Render card stack being played.
+		super.render(re, is);       // Render card stack being played.
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageLumberjack.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageLumberjack.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.actor.types.cardplayer;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgba;
 import static engine.visuals.rendering.text.HorizontalAlign.CENTER;
@@ -48,9 +49,9 @@ public class VillageLumberjack extends CardPlayer {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
-		float scale = 0.6f * TILE_RADIUS * re.camera.zoom().get();
-		Vector2f screenPosition = getScreenPosition(re).vector();
+	public void render(RenderingEnvironment re, InteractionState is) {
+		float scale = 0.6f * TILE_RADIUS * is.camera.zoom().get();
+		Vector2f screenPosition = getScreenPosition(re, is).vector();
 		re.textureRenderer.render(
 				re.imageMap.get(imageName()),
 				screenPosition.x() - 0.5f * scale,
@@ -64,7 +65,7 @@ public class VillageLumberjack extends CardPlayer {
 						.text(name + " LUMBERJACK")
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
 		);
@@ -75,11 +76,11 @@ public class VillageLumberjack extends CardPlayer {
 						.text(health() + " HP")
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
 		);
-		super.render(re);
+		super.render(re, is);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Wolf.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Wolf.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.actor.types.cardplayer;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgba;
 import static engine.visuals.rendering.text.HorizontalAlign.CENTER;
@@ -43,9 +44,9 @@ public class Wolf extends CardPlayer {
 		this.deckCollection().deck2().addCards(new DeckList(MELEE_ATTACK).toDeck().getCards());
 	}
 
-	public void render(RenderingEnvironment re) {
-		float scale = 0.6f * TILE_RADIUS * re.camera.zoom().get();
-		Vector2f screenPosition = getScreenPosition(re).vector();
+	public void render(RenderingEnvironment re, InteractionState is) {
+		float scale = 0.6f * TILE_RADIUS * is.camera.zoom().get();
+		Vector2f screenPosition = getScreenPosition(re, is).vector();
 		re.textureRenderer.render(
 				re.imageMap.get("wolf"),
 				screenPosition.x() - 0.5f * scale,
@@ -58,7 +59,7 @@ public class Wolf extends CardPlayer {
 						.text(name + " WOLF")
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP));
 		re.textRenderer.render(
@@ -68,10 +69,10 @@ public class Wolf extends CardPlayer {
 						.text(health() + " HP")
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP));
-		super.render(re);
+		super.render(re, is);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/creature/Creature.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/creature/Creature.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.actor.types.cardplayer.creature;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import engine.common.math.Vector2f;
 import engine.serialization.Derializable;
@@ -54,9 +55,9 @@ public class Creature extends CardPlayer {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
-		float scale = 0.6f * TILE_RADIUS * re.camera.zoom().get();
-		Vector2f screenPosition = getScreenPosition(re).vector();
+	public void render(RenderingEnvironment re, InteractionState is) {
+		float scale = 0.6f * TILE_RADIUS * is.camera.zoom().get();
+		Vector2f screenPosition = getScreenPosition(re, is).vector();
 		re.textureRenderer.render(
 				re.imageMap.get(image),
 				screenPosition.x() - 0.5f * scale,
@@ -69,7 +70,7 @@ public class Creature extends CardPlayer {
 						.text(name.toUpperCase())
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER));
 		re.textRenderer.render(
 				screenPosition.x(),
@@ -78,9 +79,9 @@ public class Creature extends CardPlayer {
 						.text(health() + " HP")
 						.font(re.font)
 						.fontSize(0.5f * scale)
-						.colour(rgba(255, 255, 255, (int) (re.actorTextOpacity * 255)))
+						.colour(rgba(255, 255, 255, (int) (is.actorTextOpacity * 255)))
 						.hAlign(CENTER));
-		super.render(re);
+		super.render(re, is);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/Structure.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/Structure.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.actor.types.structure;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static nomadrealms.context.game.world.map.area.Tile.TILE_RADIUS;
 
@@ -48,9 +49,9 @@ public abstract class Structure implements Actor {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
-		float scale = 0.6f * TILE_RADIUS * re.camera.zoom().get();
-		Vector2f screenPosition = tile().getScreenPosition(re).vector();
+	public void render(RenderingEnvironment re, InteractionState is) {
+		float scale = 0.6f * TILE_RADIUS * is.camera.zoom().get();
+		Vector2f screenPosition = tile().getScreenPosition(re, is).vector();
 		re.textureRenderer.render(
 				re.imageMap.get(image),
 				screenPosition.x() - 0.5f * scale,

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/UICard.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/UICard.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.card;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
@@ -81,7 +82,7 @@ public class UICard implements Card {
 		return card;
 	}
 
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		if (isUpsideDown()) {
 			re.textureRenderer.render(
 					re.imageMap.get("card_back"),

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/action/Action.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/action/Action.java
@@ -4,6 +4,7 @@ import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 
 import engine.visuals.constraint.box.ConstraintPair;
 import nomadrealms.context.game.actor.types.cardplayer.CardPlayer;
+import nomadrealms.context.game.interaction.InteractionState;
 import nomadrealms.context.game.world.World;
 import nomadrealms.render.RenderingEnvironment;
 
@@ -33,7 +34,7 @@ public abstract class Action {
 
 	public abstract int postDelay();
 
-	public ConstraintPair screenOffset(RenderingEnvironment re) {
+	public ConstraintPair screenOffset(RenderingEnvironment re, InteractionState is) {
 		return new ConstraintPair(absolute(0), absolute(0));
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/action/scheduler/CardPlayerActionScheduler.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/action/scheduler/CardPlayerActionScheduler.java
@@ -8,6 +8,7 @@ import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 import engine.visuals.constraint.box.ConstraintPair;
 import nomadrealms.context.game.actor.Actor;
 import nomadrealms.context.game.card.action.Action;
+import nomadrealms.context.game.interaction.InteractionState;
 import nomadrealms.context.game.world.World;
 import nomadrealms.render.RenderingEnvironment;
 
@@ -73,9 +74,9 @@ public class CardPlayerActionScheduler {
 		queue.add(action);
 	}
 
-	public ConstraintPair screenOffset(RenderingEnvironment re) {
+	public ConstraintPair screenOffset(RenderingEnvironment re, InteractionState is) {
 		if (current != null) {
-			return current.screenOffset(re).scale(re.camera.zoom());
+			return current.screenOffset(re, is).scale(is.camera.zoom());
 		}
 		return new ConstraintPair(absolute(0), absolute(0));
 	}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/effect/SpawnParticlesEffect.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/effect/SpawnParticlesEffect.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.card.effect;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import java.util.List;
 
@@ -47,8 +48,8 @@ public class SpawnParticlesEffect extends Effect {
 	 * @param re the rendering environment.
 	 * @return the list of particles.
 	 */
-	public List<Particle> spawnParticles(RenderingEnvironment re) {
-		return spawner.spawnParticles(re, params);
+	public List<Particle> spawnParticles(RenderingEnvironment re, InteractionState is) {
+		return spawner.spawnParticles(re, is, params);
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/interaction/InteractionState.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/interaction/InteractionState.java
@@ -1,0 +1,45 @@
+package nomadrealms.context.game.interaction;
+
+import engine.context.input.Mouse;
+import nomadrealms.render.ui.Camera;
+import nomadrealms.user.Player;
+
+public class InteractionState {
+
+	public Camera camera = new Camera(0, 0);
+	public Mouse mouse;
+
+	public boolean showDebugInfo = false;
+	public boolean showMap = false;
+
+	public long lastMouseMovedTime = System.currentTimeMillis();
+	public long lastOpacityUpdateTime = System.currentTimeMillis();
+	public float actorTextOpacity = 1;
+
+	public Player localPlayer;
+
+	public InteractionState(Mouse mouse) {
+		this.mouse = mouse;
+	}
+
+	public void update() {
+		long currentTime = System.currentTimeMillis();
+		float dt = (currentTime - lastOpacityUpdateTime) / 1000f;
+		lastOpacityUpdateTime = currentTime;
+		long idleTime = currentTime - lastMouseMovedTime;
+		float targetOpacity;
+		if (idleTime < 3000) {
+			targetOpacity = 1;
+		} else if (idleTime < 4000) {
+			targetOpacity = 1 - (idleTime - 3000) / 1000f;
+		} else {
+			targetOpacity = 0;
+		}
+		if (actorTextOpacity < targetOpacity) {
+			actorTextOpacity = Math.min(targetOpacity, actorTextOpacity + dt / 0.2f);
+		} else {
+			actorTextOpacity = targetOpacity;
+		}
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/item/UIItem.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/item/UIItem.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.item;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.common.colour.Colour.toRangedVector;
@@ -35,7 +36,7 @@ public class UIItem {
 		physics = new CardPhysics(new CardTransform(new UnitQuaternion(), basePosition, UIItem.size(screen, 2)));
 	}
 
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		// Simple rotate
 		re.defaultShaderProgram
 				.set("color", toRangedVector(rgb(100, 0, 0)))

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -41,6 +41,7 @@ import nomadrealms.context.game.world.map.area.coordinate.ZoneCoordinate;
 import nomadrealms.context.game.world.map.generation.MapGenerationStrategy;
 import nomadrealms.context.game.zone.Deck;
 import nomadrealms.event.game.effect.EffectContext;
+import nomadrealms.context.game.interaction.InteractionState;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.particle.ParticlePool;
 import nomadrealms.render.particle.context.game.CardParticle;
@@ -70,15 +71,15 @@ public class World {
 		mapGenerationStrategy.initializeMap(this);
 	}
 
-	public List<Chunk> getVisibleChunks(RenderingEnvironment re) {
-		Vector2f minWorld = re.camera.position().vector();
+	public List<Chunk> getVisibleChunks(RenderingEnvironment re, InteractionState is) {
+		Vector2f minWorld = is.camera.position().vector();
 		ChunkCoordinate minChunk = chunkCoordinateOf(minWorld).left().up();
 
 		float chunkWidth = TILE_HORIZONTAL_SPACING * CHUNK_SIZE;
 		float chunkHeight = TILE_VERTICAL_SPACING * CHUNK_SIZE;
 
-		int numChunksX = (int) Math.ceil(re.config.getWidth() * 0.6f / (chunkWidth * re.camera.zoom().get())) + 2;
-		int numChunksY = (int) Math.ceil(re.config.getHeight() / (chunkHeight * re.camera.zoom().get())) + 2;
+		int numChunksX = (int) Math.ceil(re.config.getWidth() * 0.6f / (chunkWidth * is.camera.zoom().get())) + 2;
+		int numChunksY = (int) Math.ceil(re.config.getHeight() / (chunkHeight * is.camera.zoom().get())) + 2;
 
 		List<Chunk> visibleChunks = new ArrayList<>();
 		ChunkCoordinate rowStart = minChunk;
@@ -93,32 +94,32 @@ public class World {
 		return visibleChunks;
 	}
 
-	public void renderMap(RenderingEnvironment re) {
-		List<Chunk> visibleChunks = getVisibleChunks(re);
+	public void renderMap(RenderingEnvironment re, InteractionState is) {
+		List<Chunk> visibleChunks = getVisibleChunks(re, is);
 		for (Chunk chunk : visibleChunks) {
-			chunk.render(re);
+			chunk.render(re, is);
 		}
-		if (re.showDebugInfo) {
+		if (is.showDebugInfo) {
 			Set<Zone> visibleZones = new HashSet<>();
 			for (Chunk chunk : visibleChunks) {
 				visibleZones.add(chunk.zone());
 			}
 			for (Zone zone : visibleZones) {
-				zone.renderDebug(re);
+				zone.renderDebug(re, is);
 			}
 		}
 	}
 
-	public void renderActors(RenderingEnvironment re) {
-		if (re.camera.zoom().get() < 0.25) {
+	public void renderActors(RenderingEnvironment re, InteractionState is) {
+		if (is.camera.zoom().get() < 0.25) {
 			return;
 		}
-		List<Chunk> chunksToRender = getVisibleChunks(re);
+		List<Chunk> chunksToRender = getVisibleChunks(re, is);
 		for (Chunk chunk : chunksToRender) {
 			for (Tile tile : chunk.tiles()) {
 				// TODO: eventually remove destroyed entities after a delay. not here, but in update()
 				if (tile.actor() != null) {
-					tile.actor().render(re);
+					tile.actor().render(re, is);
 				}
 			}
 		}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Chunk.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Chunk.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.world.map.area;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static nomadrealms.context.game.world.map.area.Tile.TILE_HORIZONTAL_SPACING;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_VERTICAL_SPACING;
@@ -53,10 +54,10 @@ public class Chunk {
 		return tiles[x][y];
 	}
 
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		for (int row = 0; row < CHUNK_SIZE; row++) {
 			for (int col = 0; col < CHUNK_SIZE; col++) {
-				tiles[row][col].render(re);
+				tiles[row][col].render(re, is);
 			}
 		}
 		// TODO: instanced rendering - render all tiles in a chunk together

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.world.map.area;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.common.colour.Colour.toRangedVector;
@@ -84,16 +85,16 @@ public abstract class Tile implements Target, HasTooltip {
 	 *
 	 * @param re rendering environment
 	 */
-	public void render(RenderingEnvironment re) {
-		Vector2f screenPosition = getScreenPosition(re).vector();
-		render(re, screenPosition, re.camera.zoom().get(), 0);
-		if (re.showDebugInfo) {
+	public void render(RenderingEnvironment re, InteractionState is) {
+		Vector2f screenPosition = getScreenPosition(re, is).vector();
+		render(re, is, screenPosition, is.camera.zoom().get(), 0);
+		if (is.showDebugInfo) {
 			re.textRenderer
 					.render(screenPosition.x(), screenPosition.y(),
 							textFormat()
 									.text(coord.x() + ", " + coord.y())
 									.font(re.font)
-									.fontSize(0.35f * TILE_RADIUS * re.camera.zoom().get())
+									.fontSize(0.35f * TILE_RADIUS * is.camera.zoom().get())
 									.colour(rgb(255, 255, 255))
 									.hAlign(CENTER)
 									.vAlign(MIDDLE));
@@ -110,7 +111,7 @@ public abstract class Tile implements Target, HasTooltip {
 	 * @param screenPosition the screen position to render the tile at
 	 * @param scale          the scale of the tile // TODO: not implemented
 	 */
-	public void render(RenderingEnvironment re, Vector2f screenPosition, float scale, float radians) {
+	public void render(RenderingEnvironment re, InteractionState is, Vector2f screenPosition, float scale, float radians) {
 		re.defaultShaderProgram
 				.set("color", toRangedVector(color))
 				.set("transform", new Matrix4f(
@@ -122,7 +123,7 @@ public abstract class Tile implements Target, HasTooltip {
 				.use(
 						new DrawFunction().vao(HexagonVao.instance()).glContext(re.glContext)
 				);
-		if (re.camera.zoom().get() > 0.25) {
+		if (is.camera.zoom().get() > 0.25) {
 			for (WorldItem item : items) {
 				re.textureRenderer.render(re.imageMap.get(item.item().image()), screenPosition.x() - ITEM_SIZE * 0.5f * scale,
 						screenPosition.y() - ITEM_SIZE * 0.5f * scale, ITEM_SIZE * scale, ITEM_SIZE * scale);
@@ -254,8 +255,8 @@ public abstract class Tile implements Target, HasTooltip {
 		}
 	}
 
-	public ConstraintPair getScreenPosition(RenderingEnvironment re) {
-		return chunk.pos().add(indexPosition()).sub(re.camera.position()).scale(re.camera.zoom());
+	public ConstraintPair getScreenPosition(RenderingEnvironment re, InteractionState is) {
+		return chunk.pos().add(indexPosition()).sub(is.camera.position()).scale(is.camera.zoom());
 	}
 
 	public ConstraintPair pos() {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Zone.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Zone.java
@@ -19,6 +19,7 @@ import nomadrealms.context.game.world.map.generation.overworld.points.PointsGene
 import nomadrealms.context.game.world.map.generation.overworld.points.point.PointOfInterest;
 import nomadrealms.context.game.world.map.generation.overworld.structure.StructureGenerationStep;
 import nomadrealms.context.game.world.map.generation.overworld.villager.VillagerGenerationStep;
+import nomadrealms.context.game.interaction.InteractionState;
 import nomadrealms.render.RenderingEnvironment;
 
 /**
@@ -90,9 +91,9 @@ public class Zone {
 	}
 
 
-	public void renderDebug(RenderingEnvironment re) {
+	public void renderDebug(RenderingEnvironment re, InteractionState is) {
 		for (PointOfInterest poi : generationProcess.points().points()) {
-			poi.render(this, re);
+			poi.render(this, re, is);
 		}
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/points/point/PointOfInterest.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/points/point/PointOfInterest.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.world.map.generation.overworld.points.point;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.common.colour.Colour.toRangedVector;
@@ -71,13 +72,13 @@ public class PointOfInterest {
 		return size;
 	}
 
-	public void render(Zone zone, RenderingEnvironment re) {
+	public void render(Zone zone, RenderingEnvironment re, InteractionState is) {
 		float zoneSizeHorizontal = ZONE_SIZE * CHUNK_SIZE * TILE_HORIZONTAL_SPACING;
 		float zoneSizeVertical = ZONE_SIZE * CHUNK_SIZE * TILE_VERTICAL_SPACING;
-		float zoom = re.camera.zoom().get();
+		float zoom = is.camera.zoom().get();
 		float size = 100 * zoom;
 		Vector2f worldPos = position.scale(zoneSizeHorizontal, zoneSizeVertical).add(zone.pos().vector());
-		Vector2f screenPos = worldPos.sub(re.camera.position().vector()).scale(zoom).sub(size / 2, size / 2);
+		Vector2f screenPos = worldPos.sub(is.camera.position().vector()).scale(zoom).sub(size / 2, size / 2);
 		re.circleShaderProgram
 				.set("color", toRangedVector(rgb(100, 0, 0)))
 				.set("transform", new Matrix4f(screenPos.x(), screenPos.y(), size, size, re.glContext))

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/GrassTile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/GrassTile.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.world.map.tile;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.*;
 import static engine.common.java.JavaUtil.map;
@@ -66,20 +67,20 @@ public class GrassTile extends Tile {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
-		super.render(re);
-		ConstraintPair screenPosition = getScreenPosition(re);
-		if (re.camera.zoom().get() > 0.3f && grassType <= 5) {
+	public void render(RenderingEnvironment re, InteractionState is) {
+		super.render(re, is);
+		ConstraintPair screenPosition = getScreenPosition(re, is);
+		if (is.camera.zoom().get() > 0.3f && grassType <= 5) {
 			re.textureRenderer.render(
 					re.imageMap.get("grass_" + grassType),
 					new ConstraintBox(
-							screenPosition.add(GRASS_DECORATION_OFFSETS.get(grassType).scale(re.camera.zoom())),
-							GRASS_DECORATION_DIMENSIONS.get(grassType).scale(re.camera.zoom())));
+							screenPosition.add(GRASS_DECORATION_OFFSETS.get(grassType).scale(is.camera.zoom())),
+							GRASS_DECORATION_DIMENSIONS.get(grassType).scale(is.camera.zoom())));
 		}
 	}
 
 	@Override
-	public void render(RenderingEnvironment re, Vector2f screenPosition, float scale, float radians) {
+	public void render(RenderingEnvironment re, InteractionState is, Vector2f screenPosition, float scale, float radians) {
 		re.texturedShaderProgram
 				.set("color", toRangedVector(color))
 				.set("textureSampler", 0)
@@ -94,7 +95,7 @@ public class GrassTile extends Tile {
 								.textures(re.imageMap.get("grass_texture"))
 								.glContext(re.glContext)
 				);
-		if (re.camera.zoom().get() > 0.25) {
+		if (is.camera.zoom().get() > 0.25) {
 			for (WorldItem item : items()) {
 				float itemSize = TILE_RADIUS * 0.6f;
 				re.textureRenderer.render(re.imageMap.get(item.item().image()),

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/VoidTile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/VoidTile.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.world.map.tile;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgba;
 import static nomadrealms.context.game.world.map.tile.factory.TileType.VOID;
@@ -23,7 +24,7 @@ public class VoidTile extends Tile {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		// Void tiles are not rendered.
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/weather/Clouds.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/weather/Clouds.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.world.weather;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.b;
 import static engine.common.colour.Colour.g;
@@ -16,8 +17,8 @@ public class Clouds {
 
 	private static final float DRIFT_SPEED = 0.5f;
 
-	public void render(RenderingEnvironment re, GameState state) {
-		float zoom = re.camera.zoom().get();
+	public void render(RenderingEnvironment re, InteractionState is, GameState state) {
+		float zoom = is.camera.zoom().get();
 		if (zoom >= 0.9f) {
 			return;
 		}
@@ -36,7 +37,7 @@ public class Clouds {
 		float texWidth = cloudTexture.width() / 3f;
 		float texHeight = cloudTexture.height() / 3f;
 
-		Vector2f cameraPos = re.camera.position().vector();
+		Vector2f cameraPos = is.camera.position().vector();
 		// Parallax factor > 1 means clouds move faster than the world (closer to camera)
 		float parallaxFactor = 1.5f;
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/zone/CardStack.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/zone/CardStack.java
@@ -1,4 +1,5 @@
 package nomadrealms.context.game.zone;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgba;
 import static engine.common.colour.Colour.toRangedVector;
@@ -80,13 +81,13 @@ public class CardStack extends CardZone<CardStackEntry> {
 		}
 	}
 
-	public void render(RenderingEnvironment re, ConstraintPair screenPos) {
-		Constraint padding = absolute(2).multiply(re.camera.zoom());
-		Constraint iconSize = absolute(15).multiply(re.camera.zoom());
+	public void render(RenderingEnvironment re, InteractionState is, ConstraintPair screenPos) {
+		Constraint padding = absolute(2).multiply(is.camera.zoom());
+		Constraint iconSize = absolute(15).multiply(is.camera.zoom());
 		Constraint height = iconSize.add(padding).multiply(5).add(padding);
 		Constraint width = iconSize.add(padding.multiply(2));
 		ConstraintBox box = new ConstraintBox(
-				screenPos.x().add(absolute(TILE_RADIUS / 4).add(PADDING).multiply(re.camera.zoom())),
+				screenPos.x().add(absolute(TILE_RADIUS / 4).add(PADDING).multiply(is.camera.zoom())),
 				screenPos.y().add(height.multiply(0.5f).neg()),
 				width, height);
 		re.defaultShaderProgram
@@ -101,7 +102,7 @@ public class CardStack extends CardZone<CardStackEntry> {
 					box.y().add(box.h()).add(padding.neg()).add(iconSize.neg())
 							.add(iconSize.add(padding).multiply(i).neg()),
 					iconSize, iconSize);
-			entry.icon().constraintBox(iconBox).render(re);
+			entry.icon().constraintBox(iconBox).render(re, is);
 
 			Constraint overlayHeight = iconBox.h().multiply(1 - entry.getProgress());
 			ConstraintBox overlayBox = new ConstraintBox(

--- a/nomad-realms/src/main/java/nomadrealms/render/Renderable.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/Renderable.java
@@ -1,7 +1,9 @@
 package nomadrealms.render;
 
+import nomadrealms.context.game.interaction.InteractionState;
+
 public interface Renderable {
 
-	void render(RenderingEnvironment re);
+	void render(RenderingEnvironment re, InteractionState is);
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
@@ -64,21 +64,9 @@ public class RenderingEnvironment {
 	public GameFont font;
 	public Map<Object, Texture> imageMap = new HashMap<>();
 
-	public Camera camera = new Camera(0, 0);
-	public boolean showDebugInfo = false;
-
-	public Mouse mouse;
-
-	public long lastMouseMovedTime = System.currentTimeMillis();
-	public long lastOpacityUpdateTime = System.currentTimeMillis();
-	public float actorTextOpacity = 1;
-
-	public Player localPlayer;
-
-	public RenderingEnvironment(GLContext glContext, NengenConfiguration config, Mouse mouse) {
+	public RenderingEnvironment(GLContext glContext, NengenConfiguration config) {
 		this.glContext = glContext;
 		this.config = config;
-		this.mouse = mouse;
 
 		loadFonts();
 		loadFBOs();
@@ -224,26 +212,6 @@ public class RenderingEnvironment {
 		imageMap.put(POISON.image(), new Texture().image(loadImage("/images/icons/status/poison.png")).load());
 		imageMap.put(INVINCIBLE.image(),
 				new Texture().image(loadImage("/images/icons/status/invincible.png")).load());
-	}
-
-	public void updateActorTextOpacity() {
-		long currentTime = System.currentTimeMillis();
-		float dt = (currentTime - lastOpacityUpdateTime) / 1000f;
-		lastOpacityUpdateTime = currentTime;
-		long idleTime = currentTime - lastMouseMovedTime;
-		float targetOpacity;
-		if (idleTime < 3000) {
-			targetOpacity = 1;
-		} else if (idleTime < 4000) {
-			targetOpacity = 1 - (idleTime - 3000) / 1000f;
-		} else {
-			targetOpacity = 0;
-		}
-		if (actorTextOpacity < targetOpacity) {
-			actorTextOpacity = Math.min(targetOpacity, actorTextOpacity + dt / 0.2f);
-		} else {
-			actorTextOpacity = targetOpacity;
-		}
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/NullParticlePool.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/NullParticlePool.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.particle;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import nomadrealms.render.RenderingEnvironment;
 
@@ -9,7 +10,7 @@ public class NullParticlePool extends ParticlePool {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		// Do nothing
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/ParticlePool.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/ParticlePool.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.particle;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static java.lang.System.currentTimeMillis;
 
@@ -53,10 +54,10 @@ public class ParticlePool implements Renderable {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		List<SpawnParticlesEffect> newActiveEffects = new ArrayList<>();
 		for (SpawnParticlesEffect effect : new ArrayList<>(activeEffects)) {
-			for (Particle particle : effect.spawnParticles(re)) {
+			for (Particle particle : effect.spawnParticles(re, is)) {
 				addParticle(particle);
 			}
 			if (!effect.spawner().isComplete()) {
@@ -75,7 +76,7 @@ public class ParticlePool implements Renderable {
 			if (bounds != null && !bounds.overlaps(particle.bigBoundingBox())) {
 				continue;
 			}
-			particle.render(re);
+			particle.render(re, is);
 		}
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/TextParticle.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/TextParticle.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.particle;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 
@@ -34,7 +35,7 @@ public class TextParticle extends Particle {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		float x = box().x().get();
 		float y = box().y().get();
 		float fontSize = box().h().get();

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/TextureParticle.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/TextureParticle.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.particle;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import engine.common.math.Matrix4f;
 import engine.common.math.Vector3f;
@@ -26,7 +27,7 @@ public class TextureParticle extends Particle {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		float x = box().x().get();
 		float y = box().y().get();
 		re.textureRenderer

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/context/game/CardParticle.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/context/game/CardParticle.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.particle.context.game;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.common.colour.Colour.toRangedVector;
@@ -18,30 +19,32 @@ import nomadrealms.context.game.event.CardPlayedEvent;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.particle.geometry.RectangleParticle;
 
+import java.util.function.BiFunction;
+
 public class CardParticle extends RectangleParticle {
 
-	public Function<RenderingEnvironment, ConstraintBox> box;
+	public BiFunction<RenderingEnvironment, InteractionState, ConstraintBox> box;
 
 	public CardParticle(CardPlayedEvent event) {
 		super(1000, null, time().multiply(2 * PI / 1000), rgb(155, 130, 95));
-		this.box = (RenderingEnvironment re) ->
+		this.box = (RenderingEnvironment re, InteractionState is) ->
 				new ConstraintBox(
-						event.source().getScreenPosition(re).add(
+						event.source().getScreenPosition(re, is).add(
 								new ConstraintPair(
 										absolute(0),
 										time().multiply(time()).multiply(0.0001f).sub(time().multiply(0.1f))
-								).scale(re.camera.zoom())
+								).scale(is.camera.zoom())
 						),
-						new ConstraintPair(absolute(10), absolute(14)).scale(re.camera.zoom())
+						new ConstraintPair(absolute(10), absolute(14)).scale(is.camera.zoom())
 				);
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		if (box() == null) {
-			box(box.apply(re));
+			box(box.apply(re, is));
 		}
-		float outlineSize = 1 * re.camera.zoom().get();
+		float outlineSize = 1 * is.camera.zoom().get();
 		re.defaultShaderProgram
 				.set("color", toRangedVector(rgb(69, 50, 36)))
 				.set("transform", new Matrix4f()
@@ -55,6 +58,6 @@ public class CardParticle extends RectangleParticle {
 						.scale(box().w().get() + 2 * outlineSize, box().h().get() + 2 * outlineSize)
 						.translate(-0.5f, -0.5f, 0))
 				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
-		super.render(re);
+		super.render(re, is);
 	}
 }

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/geometry/HexagonParticle.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/geometry/HexagonParticle.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.particle.geometry;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.common.colour.Colour.toRangedVector;
@@ -22,7 +23,7 @@ public class HexagonParticle extends Particle {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		re.defaultShaderProgram
 				.set("color", toRangedVector(color))
 				.set("transform", new Matrix4f(box(), re.glContext).rotate(rotation().get(), new Vector3f(0, 0, 1)))

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/geometry/RectangleParticle.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/geometry/RectangleParticle.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.particle.geometry;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.common.colour.Colour.toRangedVector;
@@ -22,7 +23,7 @@ public class RectangleParticle extends Particle {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		re.defaultShaderProgram
 				.set("color", toRangedVector(color))
 				.set("transform", new Matrix4f()

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/spawner/BasicParticleSpawner.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/spawner/BasicParticleSpawner.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.particle.spawner;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 import static nomadrealms.render.particle.spawner.ParticleFactory.createParticle;
@@ -98,7 +99,7 @@ public class BasicParticleSpawner implements ParticleSpawner {
 	}
 
 	@Override
-	public List<Particle> spawnParticles(RenderingEnvironment re, EffectContext p) {
+	public List<Particle> spawnParticles(RenderingEnvironment re, InteractionState is, EffectContext p) {
 		if (isComplete()) {
 			return new ArrayList<>();
 		}
@@ -127,8 +128,8 @@ public class BasicParticleSpawner implements ParticleSpawner {
 				particle.rotation(rotation.apply(i, p.source(), result));
 				particle.box(new ConstraintBox(
 						position.apply(i, p.source(), result)
-								.sub(re.camera.position()).scale(re.camera.zoom()),
-						size.apply(i, p.source(), result).scale(re.camera.zoom())));
+								.sub(is.camera.position()).scale(is.camera.zoom()),
+						size.apply(i, p.source(), result).scale(is.camera.zoom())));
 				particle.lifetime(lifetime.apply(i, p.source(), result));
 				particles.add(particle);
 			}

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/spawner/ParticleSpawner.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/spawner/ParticleSpawner.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.particle.spawner;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import java.util.List;
 
@@ -8,7 +9,7 @@ import nomadrealms.render.particle.Particle;
 
 public interface ParticleSpawner {
 
-	List<Particle> spawnParticles(RenderingEnvironment re, EffectContext params);
+	List<Particle> spawnParticles(RenderingEnvironment re, InteractionState is, EffectContext params);
 
 	boolean isComplete();
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/ButtonUIContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/ButtonUIContent.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.content;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.visuals.rendering.text.HorizontalAlign.CENTER;
@@ -45,7 +46,7 @@ public class ButtonUIContent extends BasicUIContent {
 	}
 
 	@Override
-	public void _render(RenderingEnvironment re) {
+	public void _render(RenderingEnvironment re, InteractionState is) {
 		re.textureRenderer.render(
 				re.imageMap.get("button"),
 				new Matrix4f(constraintBox(), re.glContext)

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/ContainerContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/ContainerContent.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.content;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.toRangedVector;
 
@@ -27,7 +28,7 @@ public class ContainerContent extends BasicUIContent {
 	 * @param re the rendering environment
 	 */
 	@Override
-	public void _render(RenderingEnvironment re) {
+	public void _render(RenderingEnvironment re, InteractionState is) {
 		if (fill) {
 			re.defaultShaderProgram
 					.set("color", toRangedVector(colour))

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/DynamicGridLayoutContainerContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/DynamicGridLayoutContainerContent.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.content;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static java.lang.Math.ceil;
 import static java.lang.Math.max;
@@ -58,8 +59,8 @@ public class DynamicGridLayoutContainerContent extends ContainerContent {
 	}
 
 	//	@Override
-	//	public void render(RenderingEnvironment re) {
-	//		super.render(re);
+	//	public void render(RenderingEnvironment re, InteractionState is) {
+	//		super.render(re, is);
 	//	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/EmptyUIContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/EmptyUIContent.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.content;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.visuals.constraint.posdim.AbsoluteConstraint.zero;
 
@@ -16,7 +17,7 @@ public class EmptyUIContent extends BasicUIContent {
 	}
 
 	@Override
-	public void _render(RenderingEnvironment re) {
+	public void _render(RenderingEnvironment re, InteractionState is) {
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/ImageContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/ImageContent.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.content;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import java.util.function.Supplier;
 
@@ -17,7 +18,7 @@ public class ImageContent extends BasicUIContent {
 	}
 
 	@Override
-	public void _render(RenderingEnvironment re) {
+	public void _render(RenderingEnvironment re, InteractionState is) {
 			re.textureRenderer.render(
 					image.get(),
 					constraintBox().x().get(), constraintBox().y().get(),

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/LabelContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/LabelContent.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.content;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 
@@ -34,7 +35,7 @@ public class LabelContent extends BasicUIContent {
 	}
 
 	@Override
-	public void _render(RenderingEnvironment re) {
+	public void _render(RenderingEnvironment re, InteractionState is) {
 
 		// Render text
 		re.textRenderer

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/TextContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/TextContent.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.content;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 
@@ -52,7 +53,7 @@ public class TextContent extends BasicUIContent {
 	}
 
 	@Override
-	public void _render(RenderingEnvironment re) {
+	public void _render(RenderingEnvironment re, InteractionState is) {
 		re.textRenderer.render(
 				constraintBox().x().get() + padding, constraintBox().y().get() + padding,
 				textFormat()

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/TileSpotlightContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/TileSpotlightContent.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.content;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_RADIUS;
@@ -27,10 +28,11 @@ public class TileSpotlightContent extends BasicUIContent {
 	}
 
 	@Override
-	public void _render(RenderingEnvironment re) {
+	public void _render(RenderingEnvironment re, InteractionState is) {
 		rotation += 0.01f;
 		tile.render(
 				re,
+				is,
 				constraintBox().get().pos()
 						.add(
 								TILE_RADIUS / 2 + PADDING,

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/UIContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/UIContent.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.content;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import java.util.List;
 
@@ -28,10 +29,10 @@ public interface UIContent extends UI {
 	 *
 	 * @param re the rendering environment
 	 */
-	default void render(RenderingEnvironment re) {
-		_render(re);
+	default void render(RenderingEnvironment re, InteractionState is) {
+		_render(re, is);
 		for (UIContent child : children()) {
-			child.render(re);
+			child.render(re, is);
 		}
 	}
 
@@ -43,7 +44,7 @@ public interface UIContent extends UI {
 	 *
 	 * @param re the rendering environment
 	 */
-	void _render(RenderingEnvironment re);
+	void _render(RenderingEnvironment re, InteractionState is);
 
 	/**
 	 * Determines whether the UI element consumes user actions.

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/Ruler.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/Ruler.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.common.colour.Colour.toRangedVector;
@@ -32,7 +33,7 @@ public class Ruler {
 	private static final int FONT_SIZE = 15;
 	private static final int RULER_COLOR = rgb(255, 255, 255);
 
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		if (!show) {
 			return;
 		}

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/Arrow.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/Arrow.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom.card;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.common.colour.Colour.toRangedVector;
@@ -33,14 +34,14 @@ public class Arrow implements UI {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		if (targetCenter != null) {
 			re.defaultShaderProgram
 					.set("color", toRangedVector(rgb(255, 255, 0)))
 					.set("transform", new Matrix4f(
 							targetCenter.x().get(), targetCenter.y().get(),
-							TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get(),
-							TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get(),
+							TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * is.camera.zoom().get(),
+							TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * is.camera.zoom().get(),
 							re.glContext))
 					.use(new DrawFunction()
 							.vao(HexagonVao.instance())

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom.card;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.common.colour.Colour.toRangedVector;
@@ -164,15 +165,15 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		re.defaultShaderProgram
 				.set("color", toRangedVector(rgb(210, 180, 140)))
 				.set("transform", new Matrix4f(constraintBox, re.glContext))
 				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
-		manaIndicator.render(re);
-		targetingArrow.render(re);
-		deckUnrevealedUICards.values().forEach(ui -> ui.render(re));
-		cards().forEach(card -> card.render(re));
+		manaIndicator.render(re, is);
+		targetingArrow.render(re, is);
+		deckUnrevealedUICards.values().forEach(ui -> ui.render(re, is));
+		cards().forEach(card -> card.render(re, is));
 		cards().forEach(UICard::interpolate);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/StackIcon.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/StackIcon.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom.card;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.common.colour.Colour.toRangedVector;
@@ -46,9 +47,9 @@ public class StackIcon implements UI {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
-		Constraint padding = absolute(2).multiply(re.camera.zoom());
-		CardPlayer localPlayer = re.localPlayer.cardPlayer();
+	public void render(RenderingEnvironment re, InteractionState is) {
+		Constraint padding = absolute(2).multiply(is.camera.zoom());
+		CardPlayer localPlayer = is.localPlayer.cardPlayer();
 		boolean isTargeting = isTargeting(localPlayer);
 		if (isTargeting && !wasTargeting) {
 			timer.activate();
@@ -68,7 +69,7 @@ public class StackIcon implements UI {
 				new ImageCropBox(new ConstraintBox(absolute(0.1f), absolute(0.1f), absolute(0.8f), absolute(0.8f)))
 		);
 
-		if (constraintBox.contains(re.mouse.coordinate())) {
+		if (constraintBox.contains(is.mouse.coordinate())) {
 			ConstraintBox cardBox = new ConstraintBox(
 					constraintBox.x().add(constraintBox.w()).add(padding),
 					constraintBox.y().add(constraintBox.h().multiply(0.5f)).add(UICard.cardSize(1.5f).y().multiply(-0.5f)),
@@ -76,10 +77,10 @@ public class StackIcon implements UI {
 			);
 			UICard uiCard = new UICard(entry.event().card(), cardBox);
 			if (entry.event().target() != null) {
-				new Arrow(uiCard.centerPosition(), entry.event().target().tile().getScreenPosition(re))
-						.targetCenter(entry.event().target().tile().getScreenPosition(re)).render(re);
+				new Arrow(uiCard.centerPosition(), entry.event().target().tile().getScreenPosition(re, is))
+						.targetCenter(entry.event().target().tile().getScreenPosition(re, is)).render(re, is);
 			}
-			uiCard.render(re);
+			uiCard.render(re, is);
 		}
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/TargetingArrow.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/TargetingArrow.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom.card;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import engine.context.input.Mouse;
 import engine.visuals.constraint.box.ConstraintPair;
@@ -29,13 +30,13 @@ public class TargetingArrow implements UI {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		target = null;
 		if (origin == null || mouse == null) {
 			return;
 		}
 
-		Tile tile = state.getMouseHexagon(mouse, re.camera);
+		Tile tile = state.getMouseHexagon(is.mouse, is.camera);
 		ConstraintPair screenPosition = null;
 
 		if (info.targetType() == TargetType.HEXAGON) {
@@ -43,18 +44,18 @@ public class TargetingArrow implements UI {
 				return;
 			}
 			target = tile;
-			screenPosition = tile.getScreenPosition(re);
+			screenPosition = tile.getScreenPosition(re, is);
 		} else if (info.targetType() == TargetType.CARD_PLAYER) {
 			if (tile.actor() == null || !checkConditions(info, state.world(), tile.actor(), source)) {
 				return;
 			}
 			target = tile.actor();
-			screenPosition = tile.getScreenPosition(re);
+			screenPosition = tile.getScreenPosition(re, is);
 		}
 
-		new Arrow(origin.centerPosition(), mouse.coordinate())
+		new Arrow(origin.centerPosition(), is.mouse.coordinate())
 				.targetCenter(screenPosition)
-				.render(re);
+				.render(re, is);
 	}
 
 	private boolean checkConditions(TargetingInfo info, World world, Target target, CardPlayer source) {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/UnrevealedCardUI.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/UnrevealedCardUI.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom.card;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import engine.common.math.Matrix4f;
 import engine.visuals.constraint.box.ConstraintBox;
@@ -17,7 +18,7 @@ public class UnrevealedCardUI implements UI {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		for (int i = deck.size() - 2; i >= 0; i--) {
 			re.textureRenderer.render(
 					re.imageMap.get("card_back"),

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/console/Console.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/console/Console.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom.console;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgba;
 import static engine.common.colour.Colour.toRangedVector;
@@ -44,6 +45,7 @@ public class Console implements UI {
 	private final ConstraintBox screen;
 	private final GameState gameState;
 	private final RenderingEnvironment re;
+	private InteractionState is;
 	private CommandProcessor customCommandProcessor;
 
 	public Console(ConstraintBox screen, GameState gameState, RenderingEnvironment re) {
@@ -53,7 +55,8 @@ public class Console implements UI {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
+		this.is = is;
 		if (!active) {
 			return;
 		}
@@ -201,7 +204,7 @@ public class Console implements UI {
 			return "Unknown entity type: " + type;
 		}
 
-		Vector2f center = re.camera.position().vector();
+		Vector2f center = is.camera.position().vector();
 		ChunkCoordinate centerChunkCoord = chunkCoordinateOf(center);
 		Queue<ChunkCoordinate> queue = new LinkedList<>();
 		queue.add(centerChunkCoord);
@@ -226,7 +229,7 @@ public class Console implements UI {
 				Actor nearestInChunk = actorsInChunk.stream()
 						.filter(targetClass::isInstance)
 						.min(Comparator.comparingDouble(actor ->
-								actor.tile().getScreenPosition(re).vector().sub(new Vector2f(re.config.getWidth() / 2f, re.config.getHeight() / 2f)).lengthSquared()
+								actor.tile().getScreenPosition(re, is).vector().sub(new Vector2f(re.config.getWidth() / 2f, re.config.getHeight() / 2f)).lengthSquared()
 						))
 						.orElse(null);
 
@@ -238,19 +241,19 @@ public class Console implements UI {
 					// For "snap to nearest", being "nearest chunk" is usually good enough approximation for "nearest actor"
 					// especially if we are talking about finding *any* actor of that type.
 
-					Vector2f currentCameraPos = re.camera.position().vector();
-					Vector2f actorScreenPos = nearestInChunk.tile().getScreenPosition(re).vector();
+					Vector2f currentCameraPos = is.camera.position().vector();
+					Vector2f actorScreenPos = nearestInChunk.tile().getScreenPosition(re, is).vector();
 					Vector2f screenCenter = new Vector2f(re.config.getWidth() / 2f, re.config.getHeight() / 2f);
-					float zoom = re.camera.zoom().get();
+					float zoom = is.camera.zoom().get();
 
 					// Calculate offset from center of screen to actor
 					// ScreenPos = (WorldPos - CamPos) * Zoom + ScreenCenterOffset?
 					// No, looking at Tile.getScreenPosition:
-					// return chunk.pos().add(indexPosition()).sub(re.camera.position()).scale(re.camera.zoom());
+					// return chunk.pos().add(indexPosition()).sub(is.camera.position()).scale(is.camera.zoom());
 					// So ScreenPos = (TileWorldPos - CamPos) * Zoom.
 					// We want ScreenPos to be (0,0) (relative to camera center? No, usually camera is top-left in 2D or center?)
 					// Actually camera implementation in Tile.render seems to not add half-screen width/height.
-					// "re.camera.position()" usually implies the top-left coordinate of the viewport if 0,0 is top-left.
+					// "is.camera.position()" usually implies the top-left coordinate of the viewport if 0,0 is top-left.
 
 					// If we want to center the camera on the actor:
 					// NewCamPos = ActorWorldPos - (ScreenSize / 2 / Zoom)
@@ -259,7 +262,7 @@ public class Console implements UI {
 					// this.position = this.position.add(mouse.coordinate().scale(1 / this.zoom - 1 / zoom));
 
 					// And Tile.getScreenPosition:
-					// chunk.pos().add(indexPosition()).sub(re.camera.position()).scale(re.camera.zoom())
+					// chunk.pos().add(indexPosition()).sub(is.camera.position()).scale(is.camera.zoom())
 
 					// If we want the actor to be at ScreenCenter (W/2, H/2):
 					// (ActorWorldPos - NewCamPos) * Zoom = ScreenCenter
@@ -275,7 +278,7 @@ public class Console implements UI {
 					Vector2f actorWorldPos = actorScreenPos.scale(1f / zoom).add(currentCameraPos);
 					Vector2f newCameraPos = actorWorldPos.sub(screenCenter.scale(1f / zoom));
 
-					re.camera.position(newCameraPos);
+					is.camera.position(newCameraPos);
 
 					return "Found " + nearestInChunk.name() + "!";
 				}

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/game/GameInterface.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/game/GameInterface.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom.game;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import engine.context.input.Mouse;
 import engine.context.input.event.InputCallbackRegistry;
@@ -41,17 +42,17 @@ public class GameInterface {
 		deckTab = new DeckTab(localPlayer.cardPlayer(), glContext.screen, state, mouse, registry);
 		inventoryTab = new InventoryTab(localPlayer.cardPlayer(), glContext.screen, registry);
 		mapTab = new MapTab(state, glContext.screen, registry);
-		tooltip = new Tooltip(re, screenContainerContent, state, mouse, registry);
+		tooltip = new Tooltip(re, screenContainerContent, state, registry);
 	}
 
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		if (!stateEventChannel.isEmpty()) {
 			stateEventChannel.poll().resolve(this);
 		}
-		deckTab.render(re);
-		inventoryTab.render(re);
-		mapTab.render(re);
-		tooltip.render(re);
+		deckTab.render(re, is);
+		inventoryTab.render(re, is);
+		mapTab.render(re, is);
+		tooltip.render(re, is);
 	}
 
 	public void resolve(InputEvent event) {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/home/HomeInterface.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/home/HomeInterface.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom.home;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 
@@ -84,8 +85,8 @@ public class HomeInterface {
 		terrainSandboxButton.setCallbacks(onClick);
 	}
 
-	public void render(RenderingEnvironment re) {
-		homeScreen.render(re);
+	public void render(RenderingEnvironment re, InteractionState is) {
+		homeScreen.render(re, is);
 	}
 
 	public void resolve(SyncedEvent event) {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/indicator/ManaIndicator.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/indicator/ManaIndicator.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom.indicator;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.visuals.constraint.posdim.CustomSupplierConstraint.custom;
@@ -34,7 +35,7 @@ public class ManaIndicator implements UI {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		long timeSinceError = System.currentTimeMillis() - lastManaErrorTime;
 		int color = (timeSinceError < MANA_ERROR_ANIMATION_DURATION_MS) ? rgb(255, 0, 0) : rgb(0, 0, 0);
 		Constraint xPos = constraintBox.x().add(MANA_TEXT_X_OFFSET).add(custom("shake", () -> {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/indicator/PlayerIndicator.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/indicator/PlayerIndicator.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom.indicator;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.visuals.constraint.misc.TimedConstraint.time;
 import static engine.visuals.constraint.posdim.SineConstraint.sin;
@@ -15,12 +16,12 @@ public class PlayerIndicator {
 
 	private final Constraint bob = sin(time().activate().multiply(2 * PI / 4000)).multiply(0.1f * TILE_RADIUS);
 
-	public void render(RenderingEnvironment re, CardPlayer player) {
+	public void render(RenderingEnvironment re, InteractionState is, CardPlayer player) {
 		if (player == null || player.tile() == null || player.dead()) {
 			return;
 		}
-		Vector2f pos = player.getScreenPosition(re).vector();
-		float zoom = re.camera.zoom().get();
+		Vector2f pos = player.getScreenPosition(re, is).vector();
+		float zoom = is.camera.zoom().get();
 		float scale = 0.4f * TILE_RADIUS * zoom;
 		Texture indicator = re.imageMap.get("triangle_indicator");
 		re.textureRenderer.render(

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/inventory/InventoryTab.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/inventory/InventoryTab.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom.inventory;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.common.colour.Colour.toRangedVector;
@@ -79,7 +80,7 @@ public class InventoryTab implements UI {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		if (!owner.inventory().isOpen()) {
 			cards().forEach(card -> card.physics().snap());
 			return;
@@ -90,7 +91,7 @@ public class InventoryTab implements UI {
 				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
 		itemsUI.values().removeIf(item -> item.item().owner() == null);
 		owner.inventory().items().forEach(this::addUIIfAbsent);
-		cards().sorted(ySort()).forEach(card -> card.render(re));
+		cards().sorted(ySort()).forEach(card -> card.render(re, is));
 		cards().forEach(UIItem::interpolate);
 		cards().filter(card -> card != selectedItem).forEach(UIItem::interpolate);
 	}

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/map/MapTab.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/map/MapTab.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom.map;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.common.colour.Colour.toRangedVector;
@@ -58,8 +59,8 @@ public class MapTab implements UI {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
-		if (!state.showMap) {
+	public void render(RenderingEnvironment re, InteractionState is) {
+		if (!is.showMap) {
 			return;
 		}
 		//        re.fbo1.render(

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/speech/SpeechBubble.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/speech/SpeechBubble.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom.speech;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import nomadrealms.context.game.actor.Actor;
 import nomadrealms.render.RenderingEnvironment;
@@ -17,7 +18,7 @@ public class SpeechBubble implements UI {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
 		if (visible) {
 		}
 	}

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/tooltip/Tooltip.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/tooltip/Tooltip.java
@@ -1,4 +1,5 @@
 package nomadrealms.render.ui.custom.tooltip;
+import nomadrealms.context.game.interaction.InteractionState;
 
 import static engine.common.colour.Colour.rgb;
 import static org.lwjgl.glfw.GLFW.GLFW_MOUSE_BUTTON_RIGHT;
@@ -21,24 +22,23 @@ import nomadrealms.render.ui.content.ScreenContainerContent;
 
 public class Tooltip implements UI {
 
+	private InteractionState is;
 	private final TooltipDeterminer determiner;
 
 	private boolean visible = false;
 
 	private final RenderingEnvironment re;
 	private final GameState state;
-	private final Mouse mouse;
 
 	private HasTooltip target;
 
 	private final ContainerContent containerContent;
 
 	public Tooltip(RenderingEnvironment re, ScreenContainerContent screenContainerContent,
-				   GameState state, Mouse mouse, InputCallbackRegistry registry) {
+				   GameState state, InputCallbackRegistry registry) {
 		determiner = new TooltipDeterminer(this, re);
 		this.re = re;
 		this.state = state;
-		this.mouse = mouse;
 		registry.registerOnPress(this::handleRightClick);
 		registry.registerOnDrag(this::handleMouseOff);
 		containerContent = new DynamicGridLayoutContainerContent(
@@ -51,15 +51,15 @@ public class Tooltip implements UI {
 	}
 
 	private void handleRightClick(MousePressedInputEvent event) {
-		if (event.button() == GLFW_MOUSE_BUTTON_RIGHT) {
-			target = state.getMouseHexagon(mouse, re.camera);
+		if (event.button() == GLFW_MOUSE_BUTTON_RIGHT && is != null) {
+			target = state.getMouseHexagon(is.mouse, is.camera);
 			visible = !visible;
 		}
 	}
 
 	private void handleMouseOff(MouseMovedInputEvent event) {
-		if (visible) {
-			HasTooltip newTarget = state.getMouseHexagon(mouse, re.camera);
+		if (visible && is != null) {
+			HasTooltip newTarget = state.getMouseHexagon(is.mouse, is.camera);
 			if (newTarget != target) {
 				visible = false;
 				target = null;
@@ -68,12 +68,13 @@ public class Tooltip implements UI {
 	}
 
 	@Override
-	public void render(RenderingEnvironment re) {
+	public void render(RenderingEnvironment re, InteractionState is) {
+		this.is = is;
 		if (visible) {
-			containerContent.render(re);
+			containerContent.render(re, is);
 			if (target != null) {
 				containerContent.clearChildren();
-				target.tooltip(determiner).render(re);
+				target.tooltip(determiner).render(re, is);
 			}
 		}
 	}

--- a/nomad-realms/src/test/java/nomadrealms/context/game/GameStateDerializerTest.java
+++ b/nomad-realms/src/test/java/nomadrealms/context/game/GameStateDerializerTest.java
@@ -19,7 +19,6 @@ public class GameStateDerializerTest {
 	public void testSerializeAndDeserialize() {
 		// Given a game state with non-default values
 		gameState.frameNumber = 123L;
-		gameState.showMap = true;
 		gameState.update(); // This increments frameNumber and adds an item to inputFrames list
 
 		// When serializing and deserializing
@@ -29,7 +28,6 @@ public class GameStateDerializerTest {
 		// Then all serializable fields should be equal
 		assertNotNull(loadedGameState);
 		assertEquals(gameState.frameNumber, loadedGameState.frameNumber);
-		assertEquals(gameState.showMap, loadedGameState.showMap);
 
 		// This assertion will fail because collections are not yet supported by the Derializable processor, exposing data loss.
 		// TODO: Enable this assertion once Derializable supports collections

--- a/nomad-realms/src/test/java/nomadrealms/context/game/event/ProcChainTest.java
+++ b/nomad-realms/src/test/java/nomadrealms/context/game/event/ProcChainTest.java
@@ -13,6 +13,7 @@ import nomadrealms.context.game.card.effect.Effect;
 import nomadrealms.context.game.item.Inventory;
 import nomadrealms.context.game.world.World;
 import nomadrealms.context.game.world.map.area.Chunk;
+import nomadrealms.context.game.interaction.InteractionState;
 import nomadrealms.context.game.world.map.area.Tile;
 import nomadrealms.context.game.world.map.tile.factory.TileType;
 import nomadrealms.render.RenderingEnvironment;
@@ -97,7 +98,7 @@ class ProcChainTest {
 		}
 
 		@Override
-		public void render(RenderingEnvironment re) {
+		public void render(RenderingEnvironment re, InteractionState is) {
 		}
 
 		@Override


### PR DESCRIPTION
This change introduces a new `InteractionState` object to hold transient, client-side data that doesn't belong in the persistent `GameState` or the hardware-level `RenderingEnvironment`. 

Key changes:
- New `InteractionState` class in `nomadrealms.context.game.interaction`.
- `RenderingEnvironment` and `GameState` have been refactored to remove fields now held in `InteractionState`.
- The `render` method in `Renderable`, `Actor`, `UI`, `Particle`, and all implementing classes now accepts `InteractionState is` as a second parameter.
- UI components and actors now retrieve camera position, mouse coordinates, and UI visibility toggles from `InteractionState`.
- Encapsulated actor text opacity calculation within `InteractionState.update()`.
- Verified that all references to the moved fields have been updated and that the project compiles and passes all existing tests.

---
*PR created automatically by Jules for task [7467565769458503949](https://jules.google.com/task/7467565769458503949) started by @Lunkle*