### PR TITLE
Move death handling to DeathEffect in ProcChain

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/Actor.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/Actor.java
@@ -45,9 +45,9 @@ public interface Actor extends HasPosition, HasHealth, HasInventory, Target, Ren
 		return new ArrayList<>();
 	}
 
-	default boolean isDestroyed() {
-		return health() <= 0;
-	}
+	boolean dead();
+
+	void dead(boolean dead);
 
 	Status status();
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/FeralMonkeyAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/FeralMonkeyAI.java
@@ -47,7 +47,7 @@ public class FeralMonkeyAI extends CardPlayerAI {
 				.filter(actor -> !(actor instanceof FeralMonkey))
 				.filter(actor -> actor instanceof CardPlayer)
 				.map(actor -> (CardPlayer) actor)
-				.filter(actor -> !actor.isDestroyed())
+				.filter(actor -> !actor.dead())
 				.filter(actor -> actor.tile().coord().distanceTo(self.tile().coord()) < 20)
 				.min(comparingInt(a -> a.tile().coord().distanceTo(self.tile().coord())))
 				.orElse(null);

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/VillageLumberjackAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/VillageLumberjackAI.java
@@ -60,7 +60,7 @@ public class VillageLumberjackAI extends CardPlayerAI {
 		// registered in state.world.structures. Query tiles in radius and inspect tile.actor().
 		Optional<Tile> nearestTreeTile = new TilesInRadiusQuery(10).find(new EffectContext().world(state.world).source(self).target(self)).stream()
 			.filter(tile -> tile.actor() instanceof TreeStructure)
-			.filter(tile -> !tile.actor().isDestroyed())
+			.filter(tile -> !tile.actor().dead())
 			.min(comparingInt(t -> t.coord().distanceTo(self.tile().coord())));
 
 		TreeStructure nearestTree = nearestTreeTile.map(t -> (TreeStructure) t.actor()).orElse(null);

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/WolfAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/WolfAI.java
@@ -46,7 +46,7 @@ public class WolfAI extends CardPlayerAI {
 				.filter(actor -> !(actor instanceof Wolf))
 				.filter(actor -> actor instanceof CardPlayer)
 				.map(actor -> (CardPlayer) actor)
-				.filter(actor -> !actor.isDestroyed())
+				.filter(actor -> !actor.dead())
 				.filter(actor -> actor.tile().coord().distanceTo(self.tile().coord()) < 20)
 				.min(comparingInt(a -> a.tile().coord().distanceTo(self.tile().coord())))
 				.orElse(null);

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/CardPlayer.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/CardPlayer.java
@@ -43,6 +43,7 @@ public abstract class CardPlayer implements Actor, HasSpeech {
 	private transient Tile tile;
 	private Tile previousTile;
 	private int health;
+	private boolean dead;
 	private int mana = 30;
 	private int maxMana = 30;
 
@@ -192,6 +193,16 @@ public abstract class CardPlayer implements Actor, HasSpeech {
 	@Override
 	public void health(int health) {
 		this.health = health;
+	}
+
+	@Override
+	public boolean dead() {
+		return dead;
+	}
+
+	@Override
+	public void dead(boolean dead) {
+		this.dead = dead;
 	}
 
 	public int mana() {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/Structure.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/Structure.java
@@ -37,6 +37,7 @@ public abstract class Structure implements Actor {
 	private final int constructionTime;
 	private final int maxHealth;
 	private int health;
+	private boolean dead;
 
 	public Structure(String name, String image, int constructionTime, int health) {
 		this.name = name;
@@ -66,6 +67,16 @@ public abstract class Structure implements Actor {
 	@Override
 	public void health(int health) {
 		this.health = health;
+	}
+
+	@Override
+	public boolean dead() {
+		return dead;
+	}
+
+	@Override
+	public void dead(boolean dead) {
+		this.dead = dead;
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/action/DestroyStructureAndSpawnItemsAction.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/action/DestroyStructureAndSpawnItemsAction.java
@@ -1,7 +1,11 @@
 package nomadrealms.context.game.card.action;
 
+import static java.util.Collections.singletonList;
+
 import nomadrealms.context.game.actor.Actor;
 import nomadrealms.context.game.actor.types.cardplayer.CardPlayer;
+import nomadrealms.context.game.card.effect.DeathEffect;
+import nomadrealms.context.game.event.ProcChain;
 import nomadrealms.context.game.item.Item;
 import nomadrealms.context.game.item.WorldItem;
 import nomadrealms.context.game.world.World;
@@ -29,8 +33,8 @@ public class DestroyStructureAndSpawnItemsAction extends Action {
 		}
 		if (source.tile().coord().distanceTo(target.tile().coord()) <= 1) {
 			Tile tile = target.tile();
-			tile.clearActor();
-			target.health(0);
+			target.dead(true);
+			world.addProcChain(new ProcChain(singletonList(new DeathEffect(target))));
 			for (int i = 0; i < count; i++) {
 				tile.addItem(new WorldItem(itemToSpawn));
 			}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/effect/DeathEffect.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/effect/DeathEffect.java
@@ -1,0 +1,22 @@
+package nomadrealms.context.game.card.effect;
+
+import nomadrealms.context.game.actor.Actor;
+import nomadrealms.context.game.world.World;
+
+public class DeathEffect extends Effect {
+
+	private final Actor target;
+
+	public DeathEffect(Actor target) {
+		super(target);
+		this.target = target;
+	}
+
+	@Override
+	public void resolve(World world) {
+		world.spawnDeathParticles(target);
+		target.health(0);
+		target.tile().clearActor();
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/effect/DeathEffect.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/effect/DeathEffect.java
@@ -1,7 +1,18 @@
 package nomadrealms.context.game.card.effect;
 
+import static engine.visuals.constraint.misc.TimedConstraint.time;
+import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
+import static java.lang.Math.PI;
+import static java.lang.Math.cos;
+import static java.lang.Math.sin;
+
+import engine.visuals.constraint.box.ConstraintPair;
 import nomadrealms.context.game.actor.Actor;
+import nomadrealms.context.game.card.query.actor.StaticTargetQuery;
 import nomadrealms.context.game.world.World;
+import nomadrealms.context.game.world.map.area.Tile;
+import nomadrealms.event.game.effect.EffectContext;
+import nomadrealms.render.particle.spawner.BasicParticleSpawner;
 
 public class DeathEffect extends Effect {
 
@@ -14,9 +25,42 @@ public class DeathEffect extends Effect {
 
 	@Override
 	public void resolve(World world) {
-		world.spawnDeathParticles(target);
+		spawnDeathParticles(world, target);
 		target.health(0);
 		target.tile().clearActor();
+	}
+
+	private void spawnDeathParticles(World world, Actor actor) {
+		Tile deathTile = actor.tile();
+		world.particlePool().addParticles(new SpawnParticlesEffect(
+				actor,
+				new BasicParticleSpawner(new StaticTargetQuery<>(deathTile), "pill")
+						.particleCount(8)
+						.size((i, s, t) -> new ConstraintPair(absolute(5), absolute(11)))
+						.rotation((i, s, t) -> absolute((float) (i * 2 * PI / 8)))
+						.position((i, s, t) -> {
+							float angle = (float) (i * 2 * PI / 8);
+							return new ConstraintPair(t.tile().pos().vector())
+									.add(time().multiply((float) sin(angle)).multiply(0.1f),
+											time().multiply((float) cos(angle)).multiply(-0.1f));
+						})
+						.lifetime((i, s, t) -> 500L),
+				new EffectContext().source(actor).target(actor)
+		));
+		world.particlePool().addParticles(new SpawnParticlesEffect(
+				actor,
+				new BasicParticleSpawner(new StaticTargetQuery<>(deathTile), "text_pop")
+						.size((i, s, t) -> new ConstraintPair(absolute(10), absolute(10)))
+						.position((i, s, t) -> {
+							float v0x = 0.05f;
+							float v0y = -0.1f;
+							return new ConstraintPair(t.tile().pos().vector())
+									.add(time().multiply(v0x).add(time().multiply(time()).multiply(-v0x / 2000f)),
+											time().multiply(v0y).add(time().multiply(time()).multiply(-v0y / 2000f)));
+						})
+						.lifetime((i, s, t) -> 500L),
+				new EffectContext().source(actor).target(actor)
+		));
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -1,20 +1,13 @@
 package nomadrealms.context.game.world;
 
-import static engine.visuals.constraint.misc.TimedConstraint.time;
-import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_HORIZONTAL_SPACING;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_VERTICAL_SPACING;
 import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.CHUNK_SIZE;
 import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.chunkCoordinateOf;
 
 import static java.util.Collections.singletonList;
-import static java.lang.Math.PI;
-import static java.lang.Math.cos;
-import static java.lang.Math.sin;
-import static java.util.Collections.singletonList;
 
 import engine.common.math.Vector2f;
-import engine.visuals.constraint.box.ConstraintPair;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -27,8 +20,6 @@ import nomadrealms.context.game.card.effect.DeathEffect;
 import nomadrealms.context.game.card.effect.DropItemEffect;
 import nomadrealms.context.game.card.effect.Effect;
 import nomadrealms.context.game.card.effect.RestockEffect;
-import nomadrealms.context.game.card.effect.SpawnParticlesEffect;
-import nomadrealms.context.game.card.query.actor.StaticTargetQuery;
 import nomadrealms.context.game.event.CardPlayedEvent;
 import nomadrealms.context.game.event.DropItemEvent;
 import nomadrealms.context.game.event.InputEvent;
@@ -126,39 +117,6 @@ public class World {
 				zone.renderDebug(re);
 			}
 		}
-	}
-
-	public void spawnDeathParticles(Actor actor) {
-		Tile deathTile = actor.tile();
-		particlePool().addParticles(new SpawnParticlesEffect(
-				actor,
-				new BasicParticleSpawner(new StaticTargetQuery<>(deathTile), "pill")
-						.particleCount(8)
-						.size((i, s, t) -> new ConstraintPair(absolute(5), absolute(11)))
-						.rotation((i, s, t) -> absolute((float) (i * 2 * PI / 8)))
-						.position((i, s, t) -> {
-							float angle = (float) (i * 2 * PI / 8);
-							return new ConstraintPair(t.tile().pos().vector())
-									.add(time().multiply((float) sin(angle)).multiply(0.1f),
-											time().multiply((float) cos(angle)).multiply(-0.1f));
-						})
-						.lifetime((i, s, t) -> 500L),
-				new EffectContext().source(actor).target(actor)
-		));
-		particlePool().addParticles(new SpawnParticlesEffect(
-				actor,
-				new BasicParticleSpawner(new StaticTargetQuery<>(deathTile), "text_pop")
-						.size((i, s, t) -> new ConstraintPair(absolute(10), absolute(10)))
-						.position((i, s, t) -> {
-							float v0x = 0.05f;
-							float v0y = -0.1f;
-							return new ConstraintPair(t.tile().pos().vector())
-									.add(time().multiply(v0x).add(time().multiply(time()).multiply(-v0x / 2000f)),
-											time().multiply(v0y).add(time().multiply(time()).multiply(-v0y / 2000f)));
-						})
-						.lifetime((i, s, t) -> 500L),
-				new EffectContext().source(actor).target(actor)
-		));
 	}
 
 	public void renderActors(RenderingEnvironment re) {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -7,6 +7,7 @@ import static nomadrealms.context.game.world.map.area.Tile.TILE_VERTICAL_SPACING
 import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.CHUNK_SIZE;
 import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.chunkCoordinateOf;
 
+import static java.util.Collections.singletonList;
 import static java.lang.Math.PI;
 import static java.lang.Math.cos;
 import static java.lang.Math.sin;
@@ -22,6 +23,7 @@ import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.actor.Actor;
 import nomadrealms.context.game.actor.types.cardplayer.Nomad;
 import nomadrealms.context.game.actor.types.structure.Structure;
+import nomadrealms.context.game.card.effect.DeathEffect;
 import nomadrealms.context.game.card.effect.DropItemEffect;
 import nomadrealms.context.game.card.effect.Effect;
 import nomadrealms.context.game.card.effect.RestockEffect;
@@ -167,7 +169,7 @@ public class World {
 		for (Chunk chunk : chunksToRender) {
 			for (Tile tile : chunk.tiles()) {
 				// TODO: eventually remove destroyed entities after a delay. not here, but in update()
-				if (tile.actor() != null && !tile.actor().isDestroyed()) {
+				if (tile.actor() != null && !tile.actor().dead()) {
 					tile.actor().render(re);
 				}
 			}
@@ -185,11 +187,7 @@ public class World {
 			}
 		}
 		for (Actor actor : actorsToUpdate) {
-			if (actor.isDestroyed()) {
-				if (actor.tile() != null) {
-					spawnDeathParticles(actor);
-					actor.tile().clearActor();
-				}
+			if (actor.dead()) {
 				continue;
 			}
 			actor.update(this.state);
@@ -200,6 +198,12 @@ public class World {
 		procChains.removeIf(ProcChain::empty);
 		for (ProcChain chain : new ArrayList<>(procChains)) {
 			chain.update(this);
+		}
+		for (Actor actor : actorsToUpdate) {
+			if (actor.health() <= 0 && !actor.dead()) {
+				actor.dead(true);
+				procChains.add(new ProcChain(singletonList(new DeathEffect(actor))));
+			}
 		}
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/indicator/PlayerIndicator.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/indicator/PlayerIndicator.java
@@ -16,7 +16,7 @@ public class PlayerIndicator {
 	private final Constraint bob = sin(time().activate().multiply(2 * PI / 4000)).multiply(0.1f * TILE_RADIUS);
 
 	public void render(RenderingEnvironment re, CardPlayer player) {
-		if (player == null || player.tile() == null || player.isDestroyed()) {
+		if (player == null || player.tile() == null || player.dead()) {
 			return;
 		}
 		Vector2f pos = player.getScreenPosition(re).vector();

--- a/nomad-realms/src/test/java/nomadrealms/context/game/FeralMonkeyTest.java
+++ b/nomad-realms/src/test/java/nomadrealms/context/game/FeralMonkeyTest.java
@@ -33,7 +33,7 @@ public class FeralMonkeyTest {
 		for (int i = 0; i < 400; i++) {
 			world.update(null);
 			ticks++;
-			if (target.isDestroyed()) {
+			if (target.dead()) {
 				break;
 			}
 		}

--- a/nomad-realms/src/test/java/nomadrealms/context/game/card/CutTreeCardTest.java
+++ b/nomad-realms/src/test/java/nomadrealms/context/game/card/CutTreeCardTest.java
@@ -66,7 +66,7 @@ public class CutTreeCardTest {
 		}
 
 		assertTrue(source.tile().coord().distanceTo(treeTile.coord()) <= 1);
-		assertTrue(tree.isDestroyed());
+		assertTrue(tree.dead());
 		assertEquals(0, tree.health());
 		assertEquals(3, treeTile.items().stream().filter(item -> item.item() == Item.OAK_LOG).count());
 	}

--- a/nomad-realms/src/test/java/nomadrealms/context/game/event/ProcChainTest.java
+++ b/nomad-realms/src/test/java/nomadrealms/context/game/event/ProcChainTest.java
@@ -119,6 +119,15 @@ class ProcChainTest {
 		}
 
 		@Override
+		public boolean dead() {
+			return false;
+		}
+
+		@Override
+		public void dead(boolean dead) {
+		}
+
+		@Override
 		public Inventory inventory() {
 			return null;
 		}


### PR DESCRIPTION
This change moves death handling from the immediate update loop in `World` into a deferred `DeathEffect` processed within a `ProcChain`. This allows other game elements to potentially intercept or react to actor deaths. 

Key changes:
- `Actor` interface now has `dead()` and `dead(boolean)` methods.
- `DeathEffect` handles the actual removal of the actor from the world and spawning of particles.
- `World.update` detects actors that should be dead, marks them as such, and creates a `ProcChain` with a `DeathEffect`.
- `DestroyStructureAndSpawnItemsAction` now marks its target as dead and queues a `DeathEffect` rather than performing immediate cleanup.
- All references to `isDestroyed()` have been replaced with `dead()`.

---
*PR created automatically by Jules for task [756379199828772545](https://jules.google.com/task/756379199828772545) started by @Lunkle*