### PR TITLE
Update Deathbloom artwork

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/DeathbloomStructure.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/DeathbloomStructure.java
@@ -28,7 +28,7 @@ import nomadrealms.render.particle.spawner.BasicParticleSpawner;
 public class DeathbloomStructure extends Structure {
 
 	public DeathbloomStructure() {
-		super("Deathbloom", "tree_1", 1, 10);
+		super("Deathbloom", "deathbloom", 1, 10);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/GameCard.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/GameCard.java
@@ -389,7 +389,7 @@ public enum GameCard implements Card {
 			new TargetingInfo(HEXAGON, new RangeCondition(1), new EmptyCondition(new ActorsOnTilesQuery(new TargetQuery<>())))),
 	DEATHBLOOM(
 			"Deathbloom",
-			"regenesis",
+			"deathbloom",
 			"Whenever anyone dies within range 5, restore 1 mana to all other characters within range 5",
 			STRUCTURE,
 			8,

--- a/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
@@ -157,6 +157,7 @@ public class RenderingEnvironment {
 		imageMap.put("oak_tree", new Texture().image(loadImage("/images/oak_tree.png")).load());
 		imageMap.put("pine_tree", new Texture().image(loadImage("/images/pine_tree.png")).load());
 		imageMap.put("chest", new Texture().image(loadImage("/images/chest.png")).load());
+		imageMap.put("deathbloom", new Texture().image(loadImage("/images/deathbloom.png")).load());
 
 		imageMap.put("grass_1", new Texture().image(loadImage("/images/decoration/grass_1.png")).load());
 		imageMap.put("grass_2", new Texture().image(loadImage("/images/decoration/grass_2.png")).load());


### PR DESCRIPTION
This change updates the visual representation of the Deathbloom card and its corresponding structure in the game. It replaces the placeholder "regenesis" and "tree_1" artworks with the dedicated "deathbloom.png" asset.

---
*PR created automatically by Jules for task [12152548830171856923](https://jules.google.com/task/12152548830171856923) started by @Lunkle*