### PR TITLE
Assign UUIDs to all actors

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/Actor.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/Actor.java
@@ -7,6 +7,7 @@ import static nomadrealms.context.game.actor.status.StatusEffect.INVINCIBLE;
 import engine.visuals.constraint.box.ConstraintPair;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.actor.status.Status;
 import nomadrealms.context.game.actor.types.HasHealth;
@@ -31,6 +32,8 @@ import nomadrealms.render.particle.spawner.BasicParticleSpawner;
  * @author Lunkle
  */
 public interface Actor extends HasPosition, HasHealth, HasInventory, Target, Renderable {
+
+	UUID uuid();
 
 	String name();
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/CardPlayer.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/CardPlayer.java
@@ -6,6 +6,7 @@ import engine.serialization.Derializable;
 import engine.visuals.constraint.box.ConstraintPair;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.actor.Actor;
 import nomadrealms.context.game.actor.ai.CardPlayerAI;
@@ -33,6 +34,8 @@ import nomadrealms.render.ui.custom.speech.SpeechBubble;
 
 @Derializable
 public abstract class CardPlayer implements Actor, HasSpeech {
+
+	private transient final UUID uuid = UUID.randomUUID();
 
 	private transient ParticlePool particlePool = new NullParticlePool();
 	private final CardPlayerActionScheduler actionScheduler = new CardPlayerActionScheduler();
@@ -251,6 +254,11 @@ public abstract class CardPlayer implements Actor, HasSpeech {
 
 	public void lastResolvedCard(WorldCard card) {
 		this.lastResolvedCard = card;
+	}
+
+	@Override
+	public UUID uuid() {
+		return uuid;
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/Structure.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/Structure.java
@@ -6,6 +6,7 @@ import static java.util.Collections.emptyList;
 
 import engine.common.math.Vector2f;
 import java.util.List;
+import java.util.UUID;
 import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.actor.Actor;
 import nomadrealms.context.game.actor.status.Status;
@@ -24,6 +25,8 @@ import nomadrealms.render.particle.NullParticlePool;
 import nomadrealms.render.particle.ParticlePool;
 
 public abstract class Structure implements Actor {
+
+	private transient final UUID uuid = UUID.randomUUID();
 
 	private transient ParticlePool particlePool = new NullParticlePool();
 
@@ -142,6 +145,11 @@ public abstract class Structure implements Actor {
 			inventory.reindex(this);
 		}
 		particlePool(world.particlePool());
+	}
+
+	@Override
+	public UUID uuid() {
+		return uuid;
 	}
 
 	@Override

--- a/nomad-realms/src/test/java/nomadrealms/context/game/event/ProcChainTest.java
+++ b/nomad-realms/src/test/java/nomadrealms/context/game/event/ProcChainTest.java
@@ -7,6 +7,7 @@ import static java.util.Collections.singletonList;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import nomadrealms.context.game.actor.Actor;
 import nomadrealms.context.game.actor.status.Status;
 import nomadrealms.context.game.card.effect.Effect;
@@ -71,10 +72,16 @@ class ProcChainTest {
 	}
 
 	private static class TestActor implements Actor {
+		private final UUID uuid = UUID.randomUUID();
 		Tile tile;
 
 		TestActor(Tile tile) {
 			this.tile = tile;
+		}
+
+		@Override
+		public UUID uuid() {
+			return uuid;
 		}
 
 		@Override


### PR DESCRIPTION
This change ensures that every actor in the game is assigned a unique and immutable UUID at the time of creation. The `Actor` interface now requires a `uuid()` method, which is implemented in the primary base classes `CardPlayer` and `Structure`. These implementations use `java.util.UUID.randomUUID()` for initialization. The field is marked `transient` to allow the custom serialization system to handle it as per the user's preference. Unit tests have been updated and verified to pass with these changes.

---
*PR created automatically by Jules for task [795844738868414448](https://jules.google.com/task/795844738868414448) started by @Lunkle*