### PR TITLE
Implement TriangleRenderer with SDF-based anti-aliasing and outlines

### DIFF
--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/TriangleRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/TriangleRenderer.java
@@ -1,0 +1,100 @@
+package engine.visuals.rendering.geometry;
+
+import engine.common.colour.Colour;
+import engine.common.loader.StringLoader;
+import engine.common.math.Matrix4f;
+import engine.common.math.Vector2f;
+import engine.visuals.builtin.RectangleVertexArrayObject;
+import engine.visuals.lwjgl.GLContext;
+import engine.visuals.lwjgl.render.FragmentShader;
+import engine.visuals.lwjgl.render.Shader;
+import engine.visuals.lwjgl.render.ShaderProgram;
+import engine.visuals.lwjgl.render.VertexArrayObject;
+import engine.visuals.lwjgl.render.VertexShader;
+
+/**
+ * A {@link TriangleRenderer} that renders triangles with optional outlines.
+ *
+ * @author Lunkle
+ */
+public class TriangleRenderer {
+
+	/**
+	 * The {@link ShaderProgram} to use when rendering triangles.
+	 */
+	private final ShaderProgram program;
+	private final VertexArrayObject vao;
+
+	private final GLContext glContext;
+
+	public TriangleRenderer(GLContext glContext) {
+		this.glContext = glContext;
+		Shader vertex = new VertexShader()
+				.source(new StringLoader("/shaders/triangleVertex.glsl").load())
+				.load();
+		Shader fragment = new FragmentShader()
+				.source(new StringLoader("/shaders/triangleFragment.glsl").load())
+				.load();
+		this.program = new ShaderProgram().attach(vertex, fragment).load();
+		this.vao = RectangleVertexArrayObject.instance();
+	}
+
+	/**
+	 * Renders a triangle with optional outline in pixel coordinates.
+	 *
+	 * @param x1          the x position of the first corner
+	 * @param y1          the y position of the first corner
+	 * @param x2          the x position of the second corner
+	 * @param y2          the y position of the second corner
+	 * @param x3          the x position of the third corner
+	 * @param y3          the y position of the third corner
+	 * @param fillColor   the fill color (rgba)
+	 * @param borderColor the border color (rgba)
+	 * @param borderWidth the border width in pixels (inside)
+	 */
+	public void render(float x1, float y1, float x2, float y2, float x3, float y3, int fillColor, int borderColor, float borderWidth) {
+		float minX = Math.min(x1, Math.min(x2, x3));
+		float maxX = Math.max(x1, Math.max(x2, x3));
+		float minY = Math.min(y1, Math.min(y2, y3));
+		float maxY = Math.max(y1, Math.max(y2, y3));
+
+		float w = maxX - minX;
+		float h = maxY - minY;
+
+		Matrix4f matrix4f = new Matrix4f()
+				.translate(-1, 1)
+				.scale(2, -2)
+				.scale(1 / glContext.width(), 1 / glContext.height())
+				.translate(minX, minY)
+				.scale(w, h);
+
+		program.use(glContext);
+		program.uniforms()
+				.set("transform", matrix4f)
+				.set("size", new Vector2f(w, h))
+				.set("v1", new Vector2f(x1 - minX, y1 - minY))
+				.set("v2", new Vector2f(x2 - minX, y2 - minY))
+				.set("v3", new Vector2f(x3 - minX, y3 - minY))
+				.set("borderWidth", borderWidth)
+				.set("fillColor", Colour.toRangedVector(fillColor))
+				.set("borderColor", Colour.toRangedVector(borderColor))
+				.complete();
+		vao.draw(glContext);
+	}
+
+	/**
+	 * Renders a triangle with no outline in pixel coordinates.
+	 *
+	 * @param x1        the x position of the first corner
+	 * @param y1        the y position of the first corner
+	 * @param x2        the x position of the second corner
+	 * @param y2        the y position of the second corner
+	 * @param x3        the x position of the third corner
+	 * @param y3        the y position of the third corner
+	 * @param fillColor the fill color (rgba)
+	 */
+	public void render(float x1, float y1, float x2, float y2, float x3, float y3, int fillColor) {
+		render(x1, y1, x2, y2, x3, y3, fillColor, 0, 0);
+	}
+
+}

--- a/nomad-realms/src/main/java/experimental/geometry/GeometryContext.java
+++ b/nomad-realms/src/main/java/experimental/geometry/GeometryContext.java
@@ -46,6 +46,18 @@ public class GeometryContext extends GameContext {
 
 		// Transparent fill with outline
 		re.rectangleRenderer.render(300, 350, 200, 100, 10, rgba(0, 0, 0, 0), rgba(255, 165, 0, 255), 4);
+
+		// Basic filled triangle
+		re.triangleRenderer.render(600, 50, 750, 50, 675, 150, rgba(255, 0, 0, 255));
+
+		// Triangle with outline
+		re.triangleRenderer.render(600, 200, 800, 200, 700, 350, rgba(0, 255, 0, 255), rgba(0, 0, 0, 255), 5);
+
+		// Acute triangle with thick outline
+		re.triangleRenderer.render(850, 50, 950, 150, 850, 250, rgba(0, 0, 255, 255), rgba(255, 255, 255, 255), 10);
+
+		// Obtuse triangle
+		re.triangleRenderer.render(600, 400, 900, 450, 700, 550, rgba(255, 255, 0, 255), rgba(255, 0, 255, 255), 3);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
@@ -21,6 +21,7 @@ import engine.visuals.lwjgl.render.VertexShader;
 import engine.visuals.lwjgl.render.framebuffer.DefaultFrameBuffer;
 import engine.visuals.rendering.text.GameFont;
 import engine.visuals.rendering.geometry.RectangleRenderer;
+import engine.visuals.rendering.geometry.TriangleRenderer;
 import engine.visuals.rendering.text.TextRenderer;
 import engine.visuals.rendering.texture.TextureRenderer;
 import java.util.HashMap;
@@ -44,6 +45,7 @@ public class RenderingEnvironment {
 	public TextRenderer textRenderer;
 	public TextureRenderer textureRenderer;
 	public RectangleRenderer rectangleRenderer;
+	public TriangleRenderer triangleRenderer;
 
 	public VertexShader defaultVertexShader;
 	public FragmentShader defaultFragmentShader;
@@ -103,6 +105,7 @@ public class RenderingEnvironment {
 		textRenderer = new TextRenderer(glContext);
 		textureRenderer = new TextureRenderer(glContext);
 		rectangleRenderer = new RectangleRenderer(glContext);
+		triangleRenderer = new TriangleRenderer(glContext);
 	}
 
 	private void loadShaders() {

--- a/nomad-realms/src/main/resources/shaders/triangleFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/triangleFragment.glsl
@@ -1,0 +1,53 @@
+#version 330 core
+
+in vec2 texCoord;
+out vec4 fragColor;
+
+uniform vec2 size;          // bounding box dimensions (w, h) in pixels
+uniform vec2 v1;            // vertex 1 in pixels (relative to BB top-left)
+uniform vec2 v2;            // vertex 2 in pixels (relative to BB top-left)
+uniform vec2 v3;            // vertex 3 in pixels (relative to BB top-left)
+uniform float borderWidth;  // border width in pixels (inside)
+uniform vec4 fillColor;     // fill color (rgba)
+uniform vec4 borderColor;   // border color (rgba)
+
+float sdTriangle( in vec2 p, in vec2 p0, in vec2 p1, in vec2 p2 )
+{
+    vec2 e0 = p1-p0, e1 = p2-p1, e2 = p0-p2;
+    vec2 v0 = p -p0, v1 = p -p1, v2 = p -p2;
+    vec2 pq0 = v0 - e0*clamp( dot(v0,e0)/dot(e0,e0), 0.0, 1.0 );
+    vec2 pq1 = v1 - e1*clamp( dot(v1,e1)/dot(e1,e1), 0.0, 1.0 );
+    vec2 pq2 = v2 - e2*clamp( dot(v2,e2)/dot(e2,e2), 0.0, 1.0 );
+    float s = sign( e0.x*e2.y - e0.y*e2.x );
+    vec2 d = min(min(vec2(dot(pq0,pq0), s*(v0.x*e0.y-v0.y*e0.x)),
+                     vec2(dot(pq1,pq1), s*(v1.x*e1.y-v1.y*e1.x))),
+                     vec2(dot(pq2,pq2), s*(v2.x*e2.y-v2.y*e2.x)));
+    return -sqrt(d.x)*sign(d.y);
+}
+
+void main() {
+    vec2 p = texCoord * size;
+
+    float d = sdTriangle(p, v1, v2, v3);
+
+    float smoothing = 1.0;
+
+    // Outside mask: 0 inside, 1 outside (smoothed)
+    float outerMask = smoothstep(0.0, smoothing, d);
+
+    // Border mask: 0 deep inside, 1 at the border edge
+    float borderEdge = -borderWidth;
+    float borderMask = smoothstep(borderEdge, borderEdge + smoothing, d);
+
+    // Combine fill and border
+    vec4 color = mix(fillColor, borderColor, borderMask);
+
+    // Apply outer alpha
+    color.a *= (1.0 - outerMask);
+
+    if (color.a <= 0.0) {
+        discard;
+    }
+
+    fragColor = color;
+}

--- a/nomad-realms/src/main/resources/shaders/triangleFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/triangleFragment.glsl
@@ -26,7 +26,7 @@ float sdTriangle( in vec2 p, in vec2 p0, in vec2 p1, in vec2 p2 )
 }
 
 void main() {
-    vec2 p = texCoord * size;
+    vec2 p = vec2(texCoord.x, 1.0 - texCoord.y) * size;
 
     float d = sdTriangle(p, v1, v2, v3);
 

--- a/nomad-realms/src/main/resources/shaders/triangleVertex.glsl
+++ b/nomad-realms/src/main/resources/shaders/triangleVertex.glsl
@@ -1,0 +1,13 @@
+#version 330 core
+
+layout(location = 0) in vec3 position;
+layout(location = 1) in vec2 uv;
+
+out vec2 texCoord;
+
+uniform mat4 transform;
+
+void main() {
+    gl_Position = transform * vec4(position, 1.0);
+    texCoord = uv;
+}


### PR DESCRIPTION
This change introduces a new TriangleRenderer capable of drawing triangles with specified corner coordinates. It uses a Signed Distance Field (SDF) approach in the fragment shader to provide high-quality anti-aliasing and precise internal borders, matching the style and functionality of the existing RectangleRenderer. The API allows passing three pairs of (x, y) coordinates as floats, along with fill color, border color, and border width.

---
*PR created automatically by Jules for task [17130311074332830991](https://jules.google.com/task/17130311074332830991) started by @Lunkle*