### PR TITLE
Refactor Actor to Abstract Class

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/Actor.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/Actor.java
@@ -169,9 +169,7 @@ public abstract class Actor implements HasPosition, HasHealth, HasInventory, Tar
 	@Override
 	public void tile(Tile tile) {
 		this.tile = tile;
-		if (tile != null) {
-			this.tileCoord = tile.coord();
-		}
+		this.tileCoord = (tile == null) ? null : tile.coord();
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/Actor.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/Actor.java
@@ -18,10 +18,13 @@ import nomadrealms.context.game.card.effect.SpawnParticlesEffect;
 import nomadrealms.context.game.card.query.actor.SelfQuery;
 import nomadrealms.context.game.event.InputEvent;
 import nomadrealms.context.game.event.Target;
+import nomadrealms.context.game.item.Inventory;
 import nomadrealms.context.game.world.World;
 import nomadrealms.context.game.world.map.area.Tile;
+import nomadrealms.context.game.world.map.area.coordinate.TileCoordinate;
 import nomadrealms.event.game.effect.EffectContext;
 import nomadrealms.render.Renderable;
+import nomadrealms.render.particle.NullParticlePool;
 import nomadrealms.render.particle.ParticlePool;
 import nomadrealms.render.particle.spawner.BasicParticleSpawner;
 
@@ -31,31 +34,62 @@ import nomadrealms.render.particle.spawner.BasicParticleSpawner;
  *
  * @author Lunkle
  */
-public interface Actor extends HasPosition, HasHealth, HasInventory, Target, Renderable {
+public abstract class Actor implements HasPosition, HasHealth, HasInventory, Target, Renderable {
 
-	UUID uuid();
+	private transient final UUID uuid = UUID.randomUUID();
+	private transient ParticlePool particlePool = new NullParticlePool();
 
-	String name();
+	protected String name;
+	protected int health;
+	protected boolean dead;
 
-	default List<Action> actions() {
+	protected TileCoordinate tileCoord;
+	protected transient Tile tile;
+
+	protected final Status status = new Status();
+	protected Inventory inventory = new Inventory(this);
+
+	public Actor() {
+	}
+
+	public Actor(String name, int health) {
+		this.name = name;
+		this.health = health;
+	}
+
+	public UUID uuid() {
+		return uuid;
+	}
+
+	public String name() {
+		return name;
+	}
+
+	public List<Action> actions() {
 		return new ArrayList<>();
 	}
 
-	default void update(GameState state) {
+	public void update(GameState state) {
 	}
 
-	default List<InputEvent> retrieveNextPlays() {
+	public List<InputEvent> retrieveNextPlays() {
 		return new ArrayList<>();
 	}
 
-	boolean dead();
+	public boolean dead() {
+		return dead;
+	}
 
-	void dead(boolean dead);
+	public void dead(boolean dead) {
+		this.dead = dead;
+	}
 
-	Status status();
+	public Status status() {
+		return status;
+	}
 
 	@Override
-	default void damage(int damage) {
+	public void damage(int damage) {
 		if (damage > 0 && status().count(INVINCIBLE) > 0) {
 			status().remove(INVINCIBLE, 1);
 			particlePool().addParticles(new SpawnParticlesEffect(
@@ -71,26 +105,34 @@ public interface Actor extends HasPosition, HasHealth, HasInventory, Target, Ren
 		HasHealth.super.damage(damage);
 	}
 
-	void particlePool(ParticlePool particlePool);
+	public void particlePool(ParticlePool particlePool) {
+		this.particlePool = particlePool;
+	}
 
-	ParticlePool particlePool();
+	public ParticlePool particlePool() {
+		return particlePool;
+	}
 
 	/**
 	 * @return Whether this actor has the capability of restocking cards when they run out, or if they will simply die once
 	 * they are out of cards.
 	 */
-	default boolean shouldRestock() {
+	public boolean shouldRestock() {
 		return true;
 	}
 
 	/**
 	 * purely done for the sake of adding references to optimize other algorithms
 	 */
-	default void reindex(World world) {
+	public void reindex(World world) {
+		tile = world.getTile(tileCoord);
+		if (inventory != null) {
+			inventory.reindex(this);
+		}
 	}
 
 	@Override
-	default boolean move(Tile target) {
+	public boolean move(Tile target) {
 		if (target.actor() != null) {
 			return false;
 		}
@@ -102,6 +144,34 @@ public interface Actor extends HasPosition, HasHealth, HasInventory, Target, Ren
 		}
 		target.actor(this);
 		return true;
+	}
+
+	@Override
+	public int health() {
+		return health;
+	}
+
+	@Override
+	public void health(int health) {
+		this.health = health;
+	}
+
+	@Override
+	public Inventory inventory() {
+		return inventory;
+	}
+
+	@Override
+	public Tile tile() {
+		return tile;
+	}
+
+	@Override
+	public void tile(Tile tile) {
+		this.tile = tile;
+		if (tile != null) {
+			this.tileCoord = tile.coord();
+		}
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Bub.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Bub.java
@@ -24,8 +24,6 @@ import nomadrealms.render.RenderingEnvironment;
 
 public class Bub extends CardPlayer {
 
-	private final String name;
-
 	public Bub(String name, Tile tile) {
 		this.name = name;
 		this.tile(tile);

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/CardPlayer.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/CardPlayer.java
@@ -6,11 +6,9 @@ import engine.serialization.Derializable;
 import engine.visuals.constraint.box.ConstraintPair;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.actor.Actor;
 import nomadrealms.context.game.actor.ai.CardPlayerAI;
-import nomadrealms.context.game.actor.status.Status;
 import nomadrealms.context.game.actor.status.StatusEffect;
 import nomadrealms.context.game.actor.types.HasSpeech;
 import nomadrealms.context.game.actor.types.cardplayer.appendage.Appendage;
@@ -21,32 +19,21 @@ import nomadrealms.context.game.card.effect.ApplyStatusEffect;
 import nomadrealms.context.game.card.effect.DamageEffect;
 import nomadrealms.context.game.event.InputEvent;
 import nomadrealms.context.game.event.ProcChain;
-import nomadrealms.context.game.item.Inventory;
 import nomadrealms.context.game.world.World;
 import nomadrealms.context.game.world.map.area.Tile;
-import nomadrealms.context.game.world.map.area.coordinate.TileCoordinate;
 import nomadrealms.context.game.zone.CardStack;
 import nomadrealms.context.game.zone.DeckCollection;
 import nomadrealms.render.RenderingEnvironment;
-import nomadrealms.render.particle.NullParticlePool;
-import nomadrealms.render.particle.ParticlePool;
 import nomadrealms.render.ui.custom.speech.SpeechBubble;
 
 @Derializable
-public abstract class CardPlayer implements Actor, HasSpeech {
+public abstract class CardPlayer extends Actor implements HasSpeech {
 
-	private transient final UUID uuid = UUID.randomUUID();
-
-	private transient ParticlePool particlePool = new NullParticlePool();
 	private final CardPlayerActionScheduler actionScheduler = new CardPlayerActionScheduler();
 
 	private CardPlayerAI ai;
 	private int burnTick = 10;
-	private TileCoordinate tileCoord;
-	private transient Tile tile;
 	private Tile previousTile;
-	private int health;
-	private boolean dead;
 	private int mana = 30;
 	private int maxMana = 30;
 
@@ -60,10 +47,7 @@ public abstract class CardPlayer implements Actor, HasSpeech {
 	private final CardStack cardStack = new CardStack();
 	private final List<InputEvent> lastPlays = new ArrayList<>();
 
-	private final Status status = new Status();
-
 	protected final DeckCollection deckCollection = new DeckCollection();
-	private final Inventory inventory = new Inventory(this);
 
 	private WorldCard lastResolvedCard = null;
 
@@ -122,27 +106,6 @@ public abstract class CardPlayer implements Actor, HasSpeech {
 	}
 
 	@Override
-	public Inventory inventory() {
-		return inventory;
-	}
-
-	@Override
-	public Status status() {
-		return status;
-	}
-
-	@Override
-	public Tile tile() {
-		return tile;
-	}
-
-	@Override
-	public void tile(Tile tile) {
-		this.tile = tile;
-		this.tileCoord = tile.coord();
-	}
-
-	@Override
 	public Tile previousTile() {
 		return previousTile;
 	}
@@ -188,26 +151,6 @@ public abstract class CardPlayer implements Actor, HasSpeech {
 		return speech;
 	}
 
-	@Override
-	public int health() {
-		return health;
-	}
-
-	@Override
-	public void health(int health) {
-		this.health = health;
-	}
-
-	@Override
-	public boolean dead() {
-		return dead;
-	}
-
-	@Override
-	public void dead(boolean dead) {
-		this.dead = dead;
-	}
-
 	public int mana() {
 		return mana;
 	}
@@ -236,8 +179,7 @@ public abstract class CardPlayer implements Actor, HasSpeech {
 
 	@Override
 	public void reindex(World world) {
-		tile = world.getTile(tileCoord);
-		inventory.reindex(this);
+		super.reindex(world);
 		if (ai != null) {
 			ai.setSelf(this);
 		}
@@ -254,26 +196,6 @@ public abstract class CardPlayer implements Actor, HasSpeech {
 
 	public void lastResolvedCard(WorldCard card) {
 		this.lastResolvedCard = card;
-	}
-
-	@Override
-	public UUID uuid() {
-		return uuid;
-	}
-
-	@Override
-	public String name() {
-		return "Card Player";
-	}
-
-	@Override
-	public void particlePool(ParticlePool particlePool) {
-		this.particlePool = particlePool;
-	}
-
-	@Override
-	public ParticlePool particlePool() {
-		return particlePool;
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Farmer.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Farmer.java
@@ -28,8 +28,6 @@ import nomadrealms.render.RenderingEnvironment;
 
 public class Farmer extends CardPlayer {
 
-	private final String name;
-
 	/**
 	 * No-arg constructor for serialization.
 	 */
@@ -108,11 +106,6 @@ public class Farmer extends CardPlayer {
 	@Override
 	public List<Appendage> appendages() {
 		return asList(HEAD, EYE, EYE, TORSO, ARM, ARM, LEG, LEG);
-	}
-
-	@Override
-	public String name() {
-		return name;
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/FeralMonkey.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/FeralMonkey.java
@@ -26,8 +26,6 @@ import nomadrealms.render.RenderingEnvironment;
 
 public class FeralMonkey extends CardPlayer {
 
-	private final String name;
-
 	/**
 	 * No-arg constructor for serialization.
 	 */
@@ -80,11 +78,6 @@ public class FeralMonkey extends CardPlayer {
 	@Override
 	public List<Appendage> appendages() {
 		return asList(HEAD, EYE, EYE, TORSO, ARM, ARM, LEG, LEG, TAIL);
-	}
-
-	@Override
-	public String name() {
-		return name;
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Nomad.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Nomad.java
@@ -24,8 +24,6 @@ import nomadrealms.render.RenderingEnvironment;
 @Derializable
 public class Nomad extends CardPlayer {
 
-	private String name;
-
 	/**
 	 * No-arg constructor for serialization.
 	 */
@@ -83,11 +81,6 @@ public class Nomad extends CardPlayer {
 	@Override
 	public List<Appendage> appendages() {
 		return asList(HEAD, EYE, EYE, TORSO, ARM, ARM, LEG, LEG);
-	}
-
-	@Override
-	public String name() {
-		return name;
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageChief.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageChief.java
@@ -23,8 +23,6 @@ import nomadrealms.render.RenderingEnvironment;
 
 public class VillageChief extends CardPlayer {
 
-	private final String name;
-
 	public VillageChief(String name) {
 		this.setAi(new VillageChiefAI(this));
 		this.name = name;

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageLumberjack.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageLumberjack.java
@@ -27,8 +27,6 @@ import nomadrealms.render.RenderingEnvironment;
 
 public class VillageLumberjack extends CardPlayer {
 
-	private final String name;
-
 	/**
 	 * No-arg constructor for serialization.
 	 */
@@ -90,11 +88,6 @@ public class VillageLumberjack extends CardPlayer {
 	@Override
 	public List<Appendage> appendages() {
 		return asList(HEAD, EYE, EYE, TORSO, ARM, ARM, LEG, LEG);
-	}
-
-	@Override
-	public String name() {
-		return name;
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Wolf.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Wolf.java
@@ -25,8 +25,6 @@ import nomadrealms.render.RenderingEnvironment;
 
 public class Wolf extends CardPlayer {
 
-	private final String name;
-
 	/**
 	 * No-arg constructor for serialization.
 	 */
@@ -77,11 +75,6 @@ public class Wolf extends CardPlayer {
 	@Override
 	public List<Appendage> appendages() {
 		return asList(HEAD, EYE, EYE, TORSO, LEG, LEG, LEG, LEG, TAIL);
-	}
-
-	@Override
-	public String name() {
-		return name;
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/creature/Creature.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/creature/Creature.java
@@ -20,7 +20,6 @@ import static nomadrealms.context.game.world.map.area.Tile.TILE_RADIUS;
 @Derializable
 public class Creature extends CardPlayer {
 
-	private String name;
 	private String image;
 
 	/**
@@ -86,11 +85,6 @@ public class Creature extends CardPlayer {
 	@Override
 	public boolean shouldRestock() {
 		return false;
-	}
-
-	@Override
-	public String name() {
-		return name;
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/Structure.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/Structure.java
@@ -6,48 +6,29 @@ import static java.util.Collections.emptyList;
 
 import engine.common.math.Vector2f;
 import java.util.List;
-import java.util.UUID;
 import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.actor.Actor;
-import nomadrealms.context.game.actor.status.Status;
 import nomadrealms.context.game.actor.types.cardplayer.CardPlayer;
 import nomadrealms.context.game.actor.types.structure.factory.StructureType;
 import nomadrealms.context.game.card.action.Action;
 import nomadrealms.context.game.card.effect.Effect;
 import nomadrealms.context.game.event.InteractEvent;
 import nomadrealms.context.game.event.ProcChain;
-import nomadrealms.context.game.item.Inventory;
 import nomadrealms.context.game.world.World;
 import nomadrealms.context.game.world.map.area.Tile;
-import nomadrealms.context.game.world.map.area.coordinate.TileCoordinate;
 import nomadrealms.render.RenderingEnvironment;
-import nomadrealms.render.particle.NullParticlePool;
-import nomadrealms.render.particle.ParticlePool;
 
-public abstract class Structure implements Actor {
+public abstract class Structure extends Actor {
 
-	private transient final UUID uuid = UUID.randomUUID();
-
-	private transient ParticlePool particlePool = new NullParticlePool();
-
-	private TileCoordinate tileCoord;
-	private transient Tile tile;
-	private Inventory inventory;
-	private final Status status = new Status();
-
-	private final String name;
 	protected final String image;
 	private final int constructionTime;
 	private final int maxHealth;
-	private int health;
-	private boolean dead;
 
 	public Structure(String name, String image, int constructionTime, int health) {
-		this.name = name;
+		super(name, health);
 		this.image = image;
 		this.constructionTime = constructionTime;
 		this.maxHealth = health;
-		this.health = health;
 	}
 
 	@Override
@@ -60,42 +41,6 @@ public abstract class Structure implements Actor {
 				screenPosition.y() - 0.7f * scale,
 				scale, scale
 		);
-	}
-
-	@Override
-	public int health() {
-		return health;
-	}
-
-	@Override
-	public void health(int health) {
-		this.health = health;
-	}
-
-	@Override
-	public boolean dead() {
-		return dead;
-	}
-
-	@Override
-	public void dead(boolean dead) {
-		this.dead = dead;
-	}
-
-	@Override
-	public Inventory inventory() {
-		return inventory;
-	}
-
-	@Override
-	public Tile tile() {
-		return tile;
-	}
-
-	@Override
-	public void tile(Tile tile) {
-		this.tile = tile;
-		this.tileCoord = tile.coord();
 	}
 
 	// TODO perhaps reconsider having previousTile for structures
@@ -140,36 +85,8 @@ public abstract class Structure implements Actor {
 
 	@Override
 	public void reindex(World world) {
-		tile = world.getTile(tileCoord);
-		if (inventory != null) {
-			inventory.reindex(this);
-		}
+		super.reindex(world);
 		particlePool(world.particlePool());
-	}
-
-	@Override
-	public UUID uuid() {
-		return uuid;
-	}
-
-	@Override
-	public String name() {
-		return name;
-	}
-
-	@Override
-	public Status status() {
-		return status;
-	}
-
-	@Override
-	public void particlePool(ParticlePool particlePool) {
-		this.particlePool = particlePool;
-	}
-
-	@Override
-	public ParticlePool particlePool() {
-		return particlePool;
 	}
 
 	public abstract StructureType structureType();


### PR DESCRIPTION
This PR refactors the `Actor` interface into an abstract class to reduce code duplication across different actor implementations. Common fields such as `uuid`, `name`, `health`, `dead`, `tile`, `status`, `inventory`, and `particlePool` have been moved into the `Actor` base class along with their getter and setter methods. `CardPlayer`, `Structure`, and their respective subclasses have been updated to utilize these inherited fields, leading to a cleaner and more maintainable architecture.

---
*PR created automatically by Jules for task [18047076385998013156](https://jules.google.com/task/18047076385998013156) started by @Lunkle*