### PR TITLE
Console History Navigation

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/console/Console.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/console/Console.java
@@ -136,6 +136,9 @@ public class Console implements UI {
 	}
 
 	public void handleKey(int key) {
+		if (!active) {
+			return;
+		}
 		if (key == GLFW_KEY_ENTER || key == GLFW_KEY_KP_ENTER) {
 			if (!currentInput.isEmpty()) {
 				commandHistory.add(currentInput);
@@ -177,6 +180,9 @@ public class Console implements UI {
 	}
 
 	public void handleChar(int codepoint) {
+		if (!active) {
+			return;
+		}
 		currentInput += (char) codepoint;
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/console/Console.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/console/Console.java
@@ -5,9 +5,11 @@ import static engine.common.colour.Colour.toRangedVector;
 import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.chunkCoordinateOf;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_BACKSPACE;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_DOWN;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_ENTER;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_ESCAPE;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_KP_ENTER;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_UP;
 
 import engine.common.math.Matrix4f;
 import engine.common.math.Vector2f;
@@ -39,6 +41,9 @@ import nomadrealms.render.ui.UI;
 public class Console implements UI {
 
 	private final List<String> history = new ArrayList<>();
+	private final List<String> commandHistory = new ArrayList<>();
+	private int historyIndex = 0;
+	private String inputBeforeHistoryNavigation = "";
 	private String currentInput = "";
 	private boolean active = false;
 	private final ConstraintBox screen;
@@ -124,11 +129,18 @@ public class Console implements UI {
 
 	public void active(boolean active) {
 		this.active = active;
+		if (active) {
+			this.historyIndex = commandHistory.size();
+			this.inputBeforeHistoryNavigation = "";
+		}
 	}
 
 	public void handleKey(int key) {
 		if (key == GLFW_KEY_ENTER || key == GLFW_KEY_KP_ENTER) {
 			if (!currentInput.isEmpty()) {
+				commandHistory.add(currentInput);
+				historyIndex = commandHistory.size();
+				inputBeforeHistoryNavigation = "";
 				history.add("> " + currentInput);
 				String output = processCommand(currentInput);
 				if (output != null) {
@@ -137,6 +149,23 @@ public class Console implements UI {
 				currentInput = "";
 			} else {
 				active = false;
+			}
+		} else if (key == GLFW_KEY_UP) {
+			if (historyIndex > 0) {
+				if (historyIndex == commandHistory.size()) {
+					inputBeforeHistoryNavigation = currentInput;
+				}
+				historyIndex--;
+				currentInput = commandHistory.get(historyIndex);
+			}
+		} else if (key == GLFW_KEY_DOWN) {
+			if (historyIndex < commandHistory.size()) {
+				historyIndex++;
+				if (historyIndex == commandHistory.size()) {
+					currentInput = inputBeforeHistoryNavigation;
+				} else {
+					currentInput = commandHistory.get(historyIndex);
+				}
 			}
 		} else if (key == GLFW_KEY_ESCAPE) {
 			active = false;

--- a/nomad-realms/src/test/java/nomadrealms/render/ui/custom/console/ConsoleTest.java
+++ b/nomad-realms/src/test/java/nomadrealms/render/ui/custom/console/ConsoleTest.java
@@ -14,6 +14,7 @@ public class ConsoleTest {
     @Test
     public void testCommandHistory() throws Exception {
         Console console = new Console(null, null, null);
+        console.active(true);
 
         // Type first command "HELLO"
         console.handleChar('H');
@@ -75,6 +76,7 @@ public class ConsoleTest {
     @Test
     public void testHistoryIndexResetOnOpen() throws Exception {
         Console console = new Console(null, null, null);
+        console.active(true);
         console.handleChar('H');
         console.handleKey(GLFW_KEY_ENTER); // history: ["H"]
 

--- a/nomad-realms/src/test/java/nomadrealms/render/ui/custom/console/ConsoleTest.java
+++ b/nomad-realms/src/test/java/nomadrealms/render/ui/custom/console/ConsoleTest.java
@@ -1,0 +1,104 @@
+package nomadrealms.render.ui.custom.console;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_DOWN;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_ENTER;
+import static org.lwjgl.glfw.GLFW.GLFW_KEY_UP;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+public class ConsoleTest {
+
+    @Test
+    public void testCommandHistory() throws Exception {
+        Console console = new Console(null, null, null);
+
+        // Type first command "HELLO"
+        console.handleChar('H');
+        console.handleChar('E');
+        console.handleChar('L');
+        console.handleChar('L');
+        console.handleChar('O');
+        assertEquals("HELLO", getCurrentInput(console));
+
+        // Submit first command
+        console.handleKey(GLFW_KEY_ENTER);
+        assertEquals("", getCurrentInput(console));
+
+        // Type second command "PING"
+        console.handleChar('P');
+        console.handleChar('I');
+        console.handleChar('N');
+        console.handleChar('G');
+        assertEquals("PING", getCurrentInput(console));
+
+        // Submit second command
+        console.handleKey(GLFW_KEY_ENTER);
+        assertEquals("", getCurrentInput(console));
+
+        // Press UP - should get "PING"
+        console.handleKey(GLFW_KEY_UP);
+        assertEquals("PING", getCurrentInput(console));
+
+        // Press UP - should get "HELLO"
+        console.handleKey(GLFW_KEY_UP);
+        assertEquals("HELLO", getCurrentInput(console));
+
+        // Press UP - should still be "HELLO" (start of history)
+        console.handleKey(GLFW_KEY_UP);
+        assertEquals("HELLO", getCurrentInput(console));
+
+        // Press DOWN - should get "PING"
+        console.handleKey(GLFW_KEY_DOWN);
+        assertEquals("PING", getCurrentInput(console));
+
+        // Press DOWN - should get empty (original input)
+        console.handleKey(GLFW_KEY_DOWN);
+        assertEquals("", getCurrentInput(console));
+
+        // Type something but don't submit: "TE"
+        console.handleChar('T');
+        console.handleChar('E');
+        assertEquals("TE", getCurrentInput(console));
+
+        // Press UP - should get "PING"
+        console.handleKey(GLFW_KEY_UP);
+        assertEquals("PING", getCurrentInput(console));
+
+        // Press DOWN - should get back "TE"
+        console.handleKey(GLFW_KEY_DOWN);
+        assertEquals("TE", getCurrentInput(console));
+    }
+
+    @Test
+    public void testHistoryIndexResetOnOpen() throws Exception {
+        Console console = new Console(null, null, null);
+        console.handleChar('H');
+        console.handleKey(GLFW_KEY_ENTER); // history: ["H"]
+
+        console.handleKey(GLFW_KEY_UP);
+        assertEquals("H", getCurrentInput(console));
+        assertEquals(0, getHistoryIndex(console));
+
+        // Close console
+        console.active(false);
+
+        // Open console
+        console.active(true);
+        assertEquals(1, getHistoryIndex(console));
+    }
+
+    private int getHistoryIndex(Console console) throws Exception {
+        Field field = Console.class.getDeclaredField("historyIndex");
+        field.setAccessible(true);
+        return (int) field.get(console);
+    }
+
+    private String getCurrentInput(Console console) throws Exception {
+        Field field = Console.class.getDeclaredField("currentInput");
+        field.setAccessible(true);
+        return (String) field.get(console);
+    }
+}


### PR DESCRIPTION
This change adds the ability to navigate through previous console commands using the up and down arrow keys. It maintains a separate history for user inputs, allows cycling through them, and preserves any unsaved input when the user begins navigating the history. The navigation state is reset when a new command is entered or when the console is reactivated.

---
*PR created automatically by Jules for task [4911709534990454822](https://jules.google.com/task/4911709534990454822) started by @Lunkle*