### PR TITLE
Add GameStateHistory and tracking to MainContext

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
@@ -97,13 +97,13 @@ public class MainContext extends GameContext {
 		gameState = new GameState("New World", stateToUiEventChannel, new OverworldGenerationStrategy(123456789)
 				.mapInitialization(new DefaultMapInitialization()));
 		gameState.world.nomad.deckCollection().importDecks(deck1, deck2, deck3, deck4);
-		gameStateHistory.addGameState(gameState);
+		gameStateHistory.push(gameState);
 	}
 
 	public MainContext(GameState gameState) {
 		this.gameState = gameState;
 		gameState.reindex(stateToUiEventChannel);
-		gameStateHistory.addGameState(gameState);
+		gameStateHistory.push(gameState);
 	}
 
 	@Override
@@ -125,7 +125,7 @@ public class MainContext extends GameContext {
 	public void update() {
 		if (gameState != null) {
 			gameState.update();
-			gameStateHistory.addGameState(gameState);
+			gameStateHistory.push(gameState);
 		}
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
@@ -82,7 +82,7 @@ public class MainContext extends GameContext {
 	private final NetworkingSender networkingSender = new NetworkingSender();
 
 	private final GameState gameState;
-	private final GameStateHistory gameStateHistory = new GameStateHistory(20);
+	private final GameStateHistory gameStateHistory = new GameStateHistory();
 
 	private final InputCallbackRegistry inputCallbackRegistry = new InputCallbackRegistry();
 

--- a/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
@@ -38,6 +38,7 @@ import nomadrealms.context.game.actor.types.structure.Structure;
 import nomadrealms.context.game.event.InputEvent;
 import nomadrealms.context.game.world.map.area.Tile;
 import nomadrealms.context.game.world.map.generation.DefaultMapInitialization;
+import nomadrealms.context.game.GameStateHistory;
 import nomadrealms.context.game.world.map.generation.OverworldGenerationStrategy;
 import nomadrealms.context.game.zone.Deck;
 import nomadrealms.render.RenderingEnvironment;
@@ -81,6 +82,7 @@ public class MainContext extends GameContext {
 	private final NetworkingSender networkingSender = new NetworkingSender();
 
 	private final GameState gameState;
+	private final GameStateHistory gameStateHistory = new GameStateHistory(20);
 
 	private final InputCallbackRegistry inputCallbackRegistry = new InputCallbackRegistry();
 
@@ -95,11 +97,13 @@ public class MainContext extends GameContext {
 		gameState = new GameState("New World", stateToUiEventChannel, new OverworldGenerationStrategy(123456789)
 				.mapInitialization(new DefaultMapInitialization()));
 		gameState.world.nomad.deckCollection().importDecks(deck1, deck2, deck3, deck4);
+		gameStateHistory.addGameState(gameState);
 	}
 
 	public MainContext(GameState gameState) {
 		this.gameState = gameState;
 		gameState.reindex(stateToUiEventChannel);
+		gameStateHistory.addGameState(gameState);
 	}
 
 	@Override
@@ -121,6 +125,7 @@ public class MainContext extends GameContext {
 	public void update() {
 		if (gameState != null) {
 			gameState.update();
+			gameStateHistory.addGameState(gameState);
 		}
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
@@ -97,13 +97,11 @@ public class MainContext extends GameContext {
 		gameState = new GameState("New World", stateToUiEventChannel, new OverworldGenerationStrategy(123456789)
 				.mapInitialization(new DefaultMapInitialization()));
 		gameState.world.nomad.deckCollection().importDecks(deck1, deck2, deck3, deck4);
-		gameStateHistory.push(gameState);
 	}
 
 	public MainContext(GameState gameState) {
 		this.gameState = gameState;
 		gameState.reindex(stateToUiEventChannel);
-		gameStateHistory.push(gameState);
 	}
 
 	@Override
@@ -124,8 +122,8 @@ public class MainContext extends GameContext {
 	@Override
 	public void update() {
 		if (gameState != null) {
-			gameState.update();
 			gameStateHistory.push(gameState);
+			gameState.update();
 		}
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/GameStateHistory.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/GameStateHistory.java
@@ -1,0 +1,37 @@
+package nomadrealms.context.game;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class GameStateHistory {
+
+    private final int maxHistorySize;
+    private final Map<Long, byte[]> history;
+
+    public GameStateHistory(int maxHistorySize) {
+        this.maxHistorySize = maxHistorySize;
+        this.history = new LinkedHashMap<Long, byte[]>() {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<Long, byte[]> eldest) {
+                return size() > maxHistorySize;
+            }
+        };
+    }
+
+    public void addGameState(GameState gameState) {
+        byte[] serialized = GameStateDerializer.serialize(gameState);
+        history.put(gameState.frameNumber, serialized);
+    }
+
+    public boolean hasGameState(long tick) {
+        return history.containsKey(tick);
+    }
+
+    public GameState getGameState(long tick) {
+        byte[] serialized = history.get(tick);
+        if (serialized == null) {
+            throw new IllegalArgumentException("GameState for tick " + tick + " not found in history.");
+        }
+        return GameStateDerializer.deserialize(serialized);
+    }
+}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/GameStateHistory.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/GameStateHistory.java
@@ -3,6 +3,10 @@ package nomadrealms.context.game;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+/**
+ * Stores the last N game states in serialized form.
+ * The states are stored BEFORE they are updated, so this history EXCLUDES the current game state.
+ */
 public class GameStateHistory {
 
     public static final int DEFAULT_MAX_HISTORY_SIZE = 20;

--- a/nomad-realms/src/main/java/nomadrealms/context/game/GameStateHistory.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/GameStateHistory.java
@@ -24,7 +24,7 @@ public class GameStateHistory {
         };
     }
 
-    public void addGameState(GameState gameState) {
+    public void push(GameState gameState) {
         byte[] serialized = GameStateDerializer.serialize(gameState);
         history.put(gameState.frameNumber, serialized);
     }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/GameStateHistory.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/GameStateHistory.java
@@ -5,8 +5,14 @@ import java.util.Map;
 
 public class GameStateHistory {
 
+    public static final int DEFAULT_MAX_HISTORY_SIZE = 20;
+
     private final int maxHistorySize;
     private final Map<Long, byte[]> history;
+
+    public GameStateHistory() {
+        this(DEFAULT_MAX_HISTORY_SIZE);
+    }
 
     public GameStateHistory(int maxHistorySize) {
         this.maxHistorySize = maxHistorySize;
@@ -23,14 +29,14 @@ public class GameStateHistory {
         history.put(gameState.frameNumber, serialized);
     }
 
-    public boolean hasGameState(long tick) {
-        return history.containsKey(tick);
+    public boolean hasGameState(long frameNumber) {
+        return history.containsKey(frameNumber);
     }
 
-    public GameState getGameState(long tick) {
-        byte[] serialized = history.get(tick);
+    public GameState getGameState(long frameNumber) {
+        byte[] serialized = history.get(frameNumber);
         if (serialized == null) {
-            throw new IllegalArgumentException("GameState for tick " + tick + " not found in history.");
+            throw new IllegalArgumentException("GameState for frameNumber " + frameNumber + " not found in history.");
         }
         return GameStateDerializer.deserialize(serialized);
     }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/GameStateHistory.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/GameStateHistory.java
@@ -9,39 +9,38 @@ import java.util.Map;
  */
 public class GameStateHistory {
 
-    public static final int DEFAULT_MAX_HISTORY_SIZE = 20;
+	public static final int DEFAULT_MAX_HISTORY_SIZE = 20;
 
-    private final int maxHistorySize;
-    private final Map<Long, byte[]> history;
+	private final Map<Long, byte[]> history;
 
-    public GameStateHistory() {
-        this(DEFAULT_MAX_HISTORY_SIZE);
-    }
+	public GameStateHistory() {
+		this(DEFAULT_MAX_HISTORY_SIZE);
+	}
 
-    public GameStateHistory(int maxHistorySize) {
-        this.maxHistorySize = maxHistorySize;
-        this.history = new LinkedHashMap<Long, byte[]>() {
-            @Override
-            protected boolean removeEldestEntry(Map.Entry<Long, byte[]> eldest) {
-                return size() > maxHistorySize;
-            }
-        };
-    }
+	public GameStateHistory(int maxHistorySize) {
+		this.history = new LinkedHashMap<Long, byte[]>() {
+			@Override
+			protected boolean removeEldestEntry(Map.Entry<Long, byte[]> eldest) {
+				return size() > maxHistorySize;
+			}
+		};
+	}
 
-    public void push(GameState gameState) {
-        byte[] serialized = GameStateDerializer.serialize(gameState);
-        history.put(gameState.frameNumber, serialized);
-    }
+	public void push(GameState gameState) {
+		byte[] serialized = GameStateDerializer.serialize(gameState);
+		history.put(gameState.frameNumber, serialized);
+	}
 
-    public boolean hasGameState(long frameNumber) {
-        return history.containsKey(frameNumber);
-    }
+	public boolean hasGameState(long frameNumber) {
+		return history.containsKey(frameNumber);
+	}
 
-    public GameState getGameState(long frameNumber) {
-        byte[] serialized = history.get(frameNumber);
-        if (serialized == null) {
-            throw new IllegalArgumentException("GameState for frameNumber " + frameNumber + " not found in history.");
-        }
-        return GameStateDerializer.deserialize(serialized);
-    }
+	public GameState getGameState(long frameNumber) {
+		byte[] serialized = history.get(frameNumber);
+		if (serialized == null) {
+			throw new IllegalArgumentException("GameState for frameNumber " + frameNumber + " not found in history.");
+		}
+		return GameStateDerializer.deserialize(serialized);
+	}
+
 }


### PR DESCRIPTION
Adds a `GameStateHistory` class that stores the last N (default 20) `GameState` objects in their serialized byte format. It includes functions to retrieve the game state at a specific tick number (frameNumber) and check if a specific state is present in the history. It's integrated directly into `MainContext` so every new/updated game state is appended.

---
*PR created automatically by Jules for task [2108883831746433400](https://jules.google.com/task/2108883831746433400) started by @JaryJay*