### PR TITLE
Refactor: Move InputEventFrames out of GameState

### DIFF
--- a/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
+++ b/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
@@ -10,6 +10,7 @@ import engine.context.input.event.PacketReceivedInputEvent;
 import engine.networking.NetworkingReceiver;
 import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.event.InputEvent;
+import nomadrealms.context.game.event.InputEventFrame;
 import nomadrealms.context.game.world.map.generation.OverworldGenerationStrategy;
 import nomadrealms.event.networking.SyncedEvent;
 import nomadrealms.render.RenderingEnvironment;
@@ -19,6 +20,7 @@ public class ServerContext extends GameContext {
 	private RenderingEnvironment re;
 	private GameState gameState;
 	private final Queue<InputEvent> uiEventChannel = new ArrayDeque<>();
+	private final java.util.List<InputEventFrame> inputFrames = new java.util.ArrayList<>();
 
 	private final NetworkingReceiver networkingReceiver = new NetworkingReceiver();
 
@@ -34,7 +36,11 @@ public class ServerContext extends GameContext {
 		if (gameState == null) {
 			return;
 		}
-		gameState.update();
+		inputFrames.add(new InputEventFrame(gameState.frameNumber + 1));
+		if (inputFrames.size() > 30) {
+			inputFrames.remove(0);
+		}
+		gameState.update(inputFrames.get(inputFrames.size() - 1));
 		while (!uiEventChannel.isEmpty()) {
 			uiEventChannel.poll();
 		}

--- a/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
@@ -36,6 +36,7 @@ import java.util.Queue;
 import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.actor.types.structure.Structure;
 import nomadrealms.context.game.event.InputEvent;
+import nomadrealms.context.game.event.InputEventFrame;
 import nomadrealms.context.game.world.map.area.Tile;
 import nomadrealms.context.game.world.map.generation.DefaultMapInitialization;
 import nomadrealms.context.game.world.map.generation.OverworldGenerationStrategy;
@@ -87,6 +88,8 @@ public class MainContext extends GameContext {
 	private Player localPlayer;
 	private final List<Player> onlinePlayers = new ArrayList<>();
 
+	private final List<InputEventFrame> inputFrames = new ArrayList<>();
+
 	public MainContext() {
 		this(new Deck(), new Deck(), new Deck(), new Deck());
 	}
@@ -120,8 +123,21 @@ public class MainContext extends GameContext {
 	@Override
 	public void update() {
 		if (gameState != null) {
-			gameState.update();
+			inputFrames.add(new InputEventFrame(gameState.frameNumber + 1));
+			if (inputFrames.size() > 30) {
+				inputFrames.remove(0);
+			}
+			gameState.update(lastInputFrame());
 		}
+	}
+
+	public InputEventFrame lastInputFrame() {
+		return inputFrames.get(inputFrames.size() - 1);
+	}
+
+	public void addEvent(InputEvent event) {
+		lastInputFrame().addEvent(event);
+		event.resolve(gameState.world());
 	}
 
 	@Override
@@ -276,7 +292,7 @@ public class MainContext extends GameContext {
 				Tile tile = gameState.getMouseHexagon(mouse(), re.camera);
 				if (tile != null && tile.actor() instanceof Structure) {
 					Structure structure = (Structure) tile.actor();
-					structure.maybeInteract(gameState, localPlayer.cardPlayer());
+					structure.maybeInteract(this::addEvent, localPlayer.cardPlayer());
 				}
 				break;
 			case GLFW_MOUSE_BUTTON_RIGHT:

--- a/nomad-realms/src/main/java/nomadrealms/app/context/TerrainSandboxContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/TerrainSandboxContext.java
@@ -26,6 +26,7 @@ import engine.visuals.constraint.box.ConstraintPair;
 import engine.visuals.lwjgl.render.framebuffer.DefaultFrameBuffer;
 import java.util.LinkedList;
 import nomadrealms.context.game.GameState;
+import nomadrealms.context.game.event.InputEventFrame;
 import nomadrealms.context.game.world.map.generation.OverworldGenerationStrategy;
 import nomadrealms.context.game.world.map.generation.TerrainSandboxMapInitialization;
 import nomadrealms.render.RenderingEnvironment;
@@ -50,6 +51,8 @@ public class TerrainSandboxContext extends GameContext {
 	private ScreenContainerContent ui;
 	private ButtonUIContent pausePlayButton;
 	private boolean paused = false;
+
+	private final java.util.List<InputEventFrame> inputFrames = new java.util.ArrayList<>();
 
 	@Override
 	public void init() {
@@ -98,8 +101,17 @@ public class TerrainSandboxContext extends GameContext {
 	public void update() {
 		re.camera.update();
 		if (!paused && gameState != null) {
-			gameState.update();
+			inputFrames.add(new InputEventFrame(gameState.frameNumber + 1));
+			if (inputFrames.size() > 30) {
+				inputFrames.remove(0);
+			}
+			gameState.update(lastInputFrame());
 		}
+	}
+
+	public InputEventFrame lastInputFrame() {
+		if (inputFrames.isEmpty()) return new InputEventFrame(gameState.frameNumber);
+		return inputFrames.get(inputFrames.size() - 1);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/GameState.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/GameState.java
@@ -44,7 +44,6 @@ public class GameState {
 	public boolean showMap = false;
 	public Queue<InputEvent> uiEventChannel;
 	public transient ParticlePool particlePool = new NullParticlePool();
-	final List<InputEventFrame> inputFrames = new ArrayList<>();
 
 	/**
 	 * No-arg constructor for serialization.
@@ -75,13 +74,9 @@ public class GameState {
 		world.particlePool(particlePool);
 	}
 
-	public void update() {
+	public void update(InputEventFrame inputEventFrame) {
 		frameNumber++;
-		inputFrames.add(new InputEventFrame(frameNumber));
-		if (inputFrames.size() > 30) {
-			inputFrames.remove(0);
-		}
-		world.update(lastInputFrame());
+		world.update(inputEventFrame);
 	}
 
 	public Tile getMouseHexagon(Mouse mouse, Camera camera) {
@@ -92,15 +87,6 @@ public class GameState {
 
 	public String name() {
 		return name;
-	}
-
-	public InputEventFrame lastInputFrame() {
-		return inputFrames.get(inputFrames.size() - 1);
-	}
-
-	public void addEvent(InputEvent event) {
-		lastInputFrame().addEvent(event);
-		event.resolve(world);
 	}
 
 	/**

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/Structure.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/Structure.java
@@ -7,7 +7,8 @@ import static java.util.Collections.emptyList;
 import engine.common.math.Vector2f;
 import java.util.List;
 import java.util.UUID;
-import nomadrealms.context.game.GameState;
+import java.util.function.Consumer;
+import nomadrealms.context.game.event.InputEvent;
 import nomadrealms.context.game.actor.Actor;
 import nomadrealms.context.game.actor.status.Status;
 import nomadrealms.context.game.actor.types.HasSpeech;
@@ -94,11 +95,11 @@ public abstract class Structure extends Actor implements HasSpeech {
 		return 1;
 	}
 
-	public void maybeInteract(GameState state, CardPlayer cardPlayer) {
+	public void maybeInteract(Consumer<InputEvent> eventConsumer, CardPlayer cardPlayer) {
 		Tile playerTile = cardPlayer.tile();
 		if ((tile.chunk() == playerTile.chunk() || tile.chunk().getSurroundingChunks().contains(playerTile.chunk()))
 				&& tile.coord().distanceTo(playerTile.coord()) <= interactRange()) {
-			state.addEvent(new InteractEvent(cardPlayer, this));
+			eventConsumer.accept(new InteractEvent(cardPlayer, this));
 		}
 	}
 

--- a/nomad-realms/src/test/java/nomadrealms/context/game/GameStateDerializerTest.java
+++ b/nomad-realms/src/test/java/nomadrealms/context/game/GameStateDerializerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.BeforeEach;
+import nomadrealms.context.game.event.InputEventFrame;
 import org.junit.jupiter.api.Test;
 
 public class GameStateDerializerTest {
@@ -20,7 +21,7 @@ public class GameStateDerializerTest {
 		// Given a game state with non-default values
 		gameState.frameNumber = 123L;
 		gameState.showMap = true;
-		gameState.update(); // This increments frameNumber and adds an item to inputFrames list
+		gameState.update(new InputEventFrame(gameState.frameNumber + 1)); // This increments frameNumber
 
 		// When serializing and deserializing
 		byte[] bytes = GameStateDerializer.serialize(gameState);

--- a/nomad-realms/src/test/java/nomadrealms/context/game/GameStateTest.java
+++ b/nomad-realms/src/test/java/nomadrealms/context/game/GameStateTest.java
@@ -13,6 +13,7 @@ import nomadrealms.context.game.world.map.area.Tile;
 import nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate;
 import nomadrealms.context.game.world.map.area.coordinate.RegionCoordinate;
 import nomadrealms.context.game.world.map.area.coordinate.TileCoordinate;
+import nomadrealms.context.game.event.InputEventFrame;
 import nomadrealms.context.game.world.map.area.coordinate.ZoneCoordinate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,7 +51,7 @@ public class GameStateTest {
 
 		boolean cardPlayed = false;
 		for (int i = 0; i < 24; i++) {
-			gameState.update();
+			gameState.update(new InputEventFrame(gameState.frameNumber + 1));
 			if (!farmer.lastPlays().isEmpty()) {
 				cardPlayed = true;
 				break;

--- a/nomad-realms/src/test/java/nomadrealms/context/game/TerrainSandboxTest.java
+++ b/nomad-realms/src/test/java/nomadrealms/context/game/TerrainSandboxTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.LinkedList;
 import nomadrealms.context.game.world.map.generation.OverworldGenerationStrategy;
+import nomadrealms.context.game.event.InputEventFrame;
 import nomadrealms.context.game.world.map.generation.TerrainSandboxMapInitialization;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +18,7 @@ public class TerrainSandboxTest {
 
 		assertNull(gameState.world.nomad);
 		assertDoesNotThrow(() -> gameState.reindex(new LinkedList<>()));
-		assertDoesNotThrow(gameState::update);
+		assertDoesNotThrow(() -> gameState.update(new InputEventFrame(gameState.frameNumber + 1)));
 	}
 
 }

--- a/nomad-realms/src/test/java/nomadrealms/context/game/card/CutTreeCardTest.java
+++ b/nomad-realms/src/test/java/nomadrealms/context/game/card/CutTreeCardTest.java
@@ -16,6 +16,7 @@ import nomadrealms.context.game.world.map.area.Tile;
 import nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate;
 import nomadrealms.context.game.world.map.area.coordinate.RegionCoordinate;
 import nomadrealms.context.game.world.map.area.coordinate.TileCoordinate;
+import nomadrealms.context.game.event.InputEventFrame;
 import nomadrealms.context.game.world.map.area.coordinate.ZoneCoordinate;
 import nomadrealms.context.game.world.map.generation.TemplateGenerationStrategy;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +63,7 @@ public class CutTreeCardTest {
 		// Manually update world to run actions
 		// WalkToAdjacentAction + DestroyStructureAndSpawnItemsAction
 		for (int i = 0; i < 200; i++) {
-			gameState.update();
+			gameState.update(new InputEventFrame(gameState.frameNumber + 1));
 		}
 
 		assertTrue(source.tile().coord().distanceTo(treeTile.coord()) <= 1);


### PR DESCRIPTION
Moves `InputEventFrames` list and logic from `GameState` to `MainContext` (and other game contexts like `ServerContext` and `TerrainSandboxContext`). Updates `Structure.maybeInteract()` to take an event consumer rather than `GameState`, and updates tests accordingly.

---
*PR created automatically by Jules for task [15383930078874657205](https://jules.google.com/task/15383930078874657205) started by @JaryJay*