### PR TITLE
Create Server Ping App

### DIFF
--- a/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
+++ b/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
@@ -7,10 +7,14 @@ import java.util.Queue;
 
 import engine.context.GameContext;
 import engine.context.input.event.PacketReceivedInputEvent;
+import engine.context.input.networking.packet.address.PacketAddress;
 import engine.networking.NetworkingReceiver;
+import engine.networking.NetworkingSender;
 import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.event.InputEvent;
 import nomadrealms.context.game.world.map.generation.OverworldGenerationStrategy;
+import nomadrealms.event.networking.PingSyncedEvent;
+import nomadrealms.event.networking.PongSyncedEvent;
 import nomadrealms.event.networking.SyncedEvent;
 import nomadrealms.render.RenderingEnvironment;
 
@@ -21,12 +25,14 @@ public class ServerContext extends GameContext {
 	private final Queue<InputEvent> uiEventChannel = new ArrayDeque<>();
 
 	private final NetworkingReceiver networkingReceiver = new NetworkingReceiver();
+	private final NetworkingSender networkingSender = new NetworkingSender();
 
 	@Override
 	public void init() {
 		re = new RenderingEnvironment(glContext(), config(), mouse());
 		gameState = new GameState("Server World", uiEventChannel, new OverworldGenerationStrategy(123456789));
 		networkingReceiver.init(44999);
+		networkingSender.init();
 	}
 
 	@Override
@@ -38,16 +44,23 @@ public class ServerContext extends GameContext {
 		while (!uiEventChannel.isEmpty()) {
 			uiEventChannel.poll();
 		}
-		networkingReceiver.update(this::input);
+		networkingReceiver.update((event, address) -> input(event, address));
 	}
 
-	public void input(SyncedEvent event) {
-		System.out.println("Received UDP message: " + event);
+	public void input(SyncedEvent event, PacketAddress address) {
+		System.out.println("Received UDP message from " + address + ": " + event);
+		if (event instanceof PingSyncedEvent) {
+			PingSyncedEvent ping = (PingSyncedEvent) event;
+			System.out.println("Ping message: " + ping.message());
+			System.out.println("Ping timestamp: " + ping.timestamp());
+			networkingSender.send(new PongSyncedEvent("Pong from server", System.currentTimeMillis()), address);
+		}
 	}
 
 	@Override
 	public void cleanUp() {
 		networkingReceiver.cleanUp();
+		networkingSender.cleanUp();
 	}
 
 	@Override

--- a/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
+++ b/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
@@ -2,11 +2,14 @@ package nomadrealms.app.context;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.io.IOException;
+import java.net.DatagramSocket;
 import java.util.ArrayDeque;
 import java.util.Queue;
 
 import engine.context.GameContext;
 import engine.context.input.event.PacketReceivedInputEvent;
+import engine.context.input.networking.SocketFinder;
 import engine.context.input.networking.packet.address.PacketAddress;
 import engine.networking.NetworkingReceiver;
 import engine.networking.NetworkingSender;
@@ -31,8 +34,13 @@ public class ServerContext extends GameContext {
 	public void init() {
 		re = new RenderingEnvironment(glContext(), config(), mouse());
 		gameState = new GameState("Server World", uiEventChannel, new OverworldGenerationStrategy(123456789));
-		networkingReceiver.init(44999);
-		networkingSender.init();
+		try {
+			DatagramSocket socket = SocketFinder.findSocket(44999);
+			networkingReceiver.init(socket);
+			networkingSender.init(socket);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/engine/networking/NetworkingReceiver.java
+++ b/nomad-realms/src/main/java/engine/networking/NetworkingReceiver.java
@@ -7,7 +7,10 @@ import engine.context.input.networking.UDPReceiver;
 import java.io.IOException;
 import java.net.DatagramSocket;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+
+import engine.context.input.networking.packet.address.PacketAddress;
 import nomadrealms.event.networking.SyncedEvent;
 import nomadrealms.event.networking.SyncedEventDerializer;
 
@@ -20,20 +23,28 @@ public class NetworkingReceiver {
 
 	public void init(int port) {
 		try {
-			socket = findSocket(port);
-			receiver = new UDPReceiver(socket, networkReceiveBuffer);
-			receiverThread = new Thread(receiver);
-			receiverThread.setName("UDP Receiver Thread");
-			receiverThread.start();
+			init(findSocket(port));
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
 	}
 
+	public void init(DatagramSocket socket) {
+		this.socket = socket;
+		receiver = new UDPReceiver(socket, networkReceiveBuffer);
+		receiverThread = new Thread(receiver);
+		receiverThread.setName("UDP Receiver Thread");
+		receiverThread.start();
+	}
+
 	public void update(Consumer<SyncedEvent> consumer) {
+		update((event, address) -> consumer.accept(event));
+	}
+
+	public void update(BiConsumer<SyncedEvent, PacketAddress> consumer) {
 		PacketReceivedInputEvent event;
 		while ((event = networkReceiveBuffer.poll()) != null) {
-			consumer.accept(SyncedEventDerializer.deserialize(event.model().bytes()));
+			consumer.accept(SyncedEventDerializer.deserialize(event.model().bytes()), event.source().address());
 		}
 	}
 

--- a/nomad-realms/src/main/java/engine/networking/NetworkingSender.java
+++ b/nomad-realms/src/main/java/engine/networking/NetworkingSender.java
@@ -17,9 +17,13 @@ public class NetworkingSender {
 	private Thread senderThread;
 
 	public void init() {
+		init(null);
+	}
+
+	public void init(DatagramSocket socket) {
 		try {
-			socket = new DatagramSocket();
-			sender = new UDPSender(socket, networkSendBuffer);
+			this.socket = (socket == null) ? new DatagramSocket() : socket;
+			sender = new UDPSender(this.socket, networkSendBuffer);
 			senderThread = new Thread(sender);
 			senderThread.setName("UDP Sender Thread");
 			senderThread.start();

--- a/nomad-realms/src/main/java/nomadrealms/app/PingApp.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/PingApp.java
@@ -1,0 +1,60 @@
+package nomadrealms.app;
+
+import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import engine.context.input.networking.SocketFinder;
+import engine.context.input.networking.packet.address.PacketAddress;
+import engine.networking.NetworkingReceiver;
+import engine.networking.NetworkingSender;
+import nomadrealms.event.networking.PingSyncedEvent;
+import nomadrealms.event.networking.PongSyncedEvent;
+
+public class PingApp {
+
+	public static void main(String[] args) throws IOException, InterruptedException {
+		System.out.println("Starting PingApp...");
+		NetworkingSender sender = new NetworkingSender();
+		NetworkingReceiver receiver = new NetworkingReceiver();
+
+		DatagramSocket socket = SocketFinder.findSocket(0);
+		sender.init(socket);
+		receiver.init(socket);
+
+		PacketAddress serverAddress = new PacketAddress(InetAddress.getByName("localhost"), 44999);
+		long startTime = System.currentTimeMillis();
+		System.out.println("Sending PingSyncedEvent to " + serverAddress);
+		sender.send(new PingSyncedEvent("Ping from PingApp", startTime), serverAddress);
+
+		boolean receivedPong = false;
+		long deadline = System.currentTimeMillis() + 5000;
+
+		while (System.currentTimeMillis() < deadline) {
+			final boolean[] pongReceived = {false};
+			receiver.update((event) -> {
+				if (event instanceof PongSyncedEvent) {
+					PongSyncedEvent pong = (PongSyncedEvent) event;
+					System.out.println("Received PongSyncedEvent: " + pong);
+					System.out.println("Round trip time: " + (System.currentTimeMillis() - startTime) + "ms");
+					pongReceived[0] = true;
+				}
+			});
+			if (pongReceived[0]) {
+				receivedPong = true;
+				break;
+			}
+			Thread.sleep(100);
+		}
+
+		if (!receivedPong) {
+			System.out.println("deadline exceeded");
+		}
+
+		sender.cleanUp();
+		receiver.cleanUp();
+		System.out.println("PingApp finished.");
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/PingSyncedEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/PingSyncedEvent.java
@@ -1,0 +1,35 @@
+package nomadrealms.event.networking;
+
+import engine.serialization.Derializable;
+
+@Derializable
+public class PingSyncedEvent implements SyncedEvent {
+
+	private String message;
+	private long timestamp;
+
+	public PingSyncedEvent() {
+	}
+
+	public PingSyncedEvent(String message, long timestamp) {
+		this.message = message;
+		this.timestamp = timestamp;
+	}
+
+	public String message() {
+		return message;
+	}
+
+	public long timestamp() {
+		return timestamp;
+	}
+
+	@Override
+	public String toString() {
+		return "PingSyncedEvent{" +
+				"message='" + message + '\'' +
+				", timestamp=" + timestamp +
+				'}';
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/PongSyncedEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/PongSyncedEvent.java
@@ -1,0 +1,35 @@
+package nomadrealms.event.networking;
+
+import engine.serialization.Derializable;
+
+@Derializable
+public class PongSyncedEvent implements SyncedEvent {
+
+	private String message;
+	private long timestamp;
+
+	public PongSyncedEvent() {
+	}
+
+	public PongSyncedEvent(String message, long timestamp) {
+		this.message = message;
+		this.timestamp = timestamp;
+	}
+
+	public String message() {
+		return message;
+	}
+
+	public long timestamp() {
+		return timestamp;
+	}
+
+	@Override
+	public String toString() {
+		return "PongSyncedEvent{" +
+				"message='" + message + '\'' +
+				", timestamp=" + timestamp +
+				'}';
+	}
+
+}


### PR DESCRIPTION
I have implemented a server ping application as requested.

Key changes:
1.  **Events**: Added `PingSyncedEvent` and `PongSyncedEvent` in `nomadrealms.event.networking`.
2.  **Networking Core**: 
    - Modified `NetworkingReceiver` to include an `update` method that provides the sender's `PacketAddress`.
    - Added `init(DatagramSocket)` to both `NetworkingSender` and `NetworkingReceiver` to allow them to share the same socket, which is essential for receiving UDP responses on the same port used for sending.
3.  **Server**: Updated `ServerContext` to listen for `PingSyncedEvent`, log the client's details, and send a `PongSyncedEvent` back.
4.  **Standalone App**: Created `PingApp` which sends a ping, waits up to 5 seconds for a pong, and logs the round-trip time or a "deadline exceeded" message.

I have verified the changes by ensuring the code compiles and running existing networking tests.

---
*PR created automatically by Jules for task [9764786667055942897](https://jules.google.com/task/9764786667055942897) started by @Lunkle*