### PR TITLE
Add JUnit Jupiter Engine dependency and update Surefire plugin version

### DIFF
--- a/nomad-realms/pom.xml
+++ b/nomad-realms/pom.xml
@@ -83,7 +83,12 @@
             <artifactId>jlayer</artifactId>
             <version>1.0.1</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.0</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -106,6 +111,11 @@
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
This pull request updates the project's build and test configuration in `pom.xml` to improve support for running unit tests with JUnit Jupiter. The main changes include adding the JUnit Jupiter Engine dependency and configuring the Maven Surefire Plugin to enable proper execution of JUnit 5 tests.

**Testing improvements:**

* Added `org.junit.jupiter:junit-jupiter-engine` as a test dependency to enable running JUnit 5 tests.
* Added and configured the `maven-surefire-plugin` (version 3.2.5) to ensure tests are correctly discovered and executed during the build process.

> [!IMPORTANT]
> If @BeforeEach is not being called when running mvn test, the issue usually stems from a version mismatch or incorrect configuration in the pom.xml. 
> The most common cause is an outdated Maven Surefire Plugin. Versions older than 2.22.0 do not natively support the JUnit 5 Jupiter engine