### PR TITLE
build: specify maven-surefire-plugin version in parent pom

### DIFF
--- a/nomad-realms-server/pom.xml
+++ b/nomad-realms-server/pom.xml
@@ -25,7 +25,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.3.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/nomad-realms/pom.xml
+++ b/nomad-realms/pom.xml
@@ -118,7 +118,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.3.0</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/nomad-realms/pom.xml
+++ b/nomad-realms/pom.xml
@@ -115,7 +115,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.5</version>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,15 @@
     </dependencyManagement>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.2.5</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,13 +86,22 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.2.5</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.13.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This pull request centralizes the version management of the `maven-surefire-plugin`. 

The version `3.2.5` has been moved to the `<pluginManagement>` section of the root `pom.xml`, allowing all modules to inherit the same version. The explicit version declaration in `nomad-realms/pom.xml` has been removed accordingly.

---
*PR created automatically by Jules for task [6444030546913804670](https://jules.google.com/task/6444030546913804670) started by @JaryJay*