### PR TITLE
Graceful shutdown for UDPReceiver

### DIFF
--- a/nomad-realms/src/main/java/engine/context/input/networking/UDPReceiver.java
+++ b/nomad-realms/src/main/java/engine/context/input/networking/UDPReceiver.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
+import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.concurrent.ArrayBlockingQueue;
 
@@ -33,6 +34,10 @@ public class UDPReceiver extends TerminateableRunnable {
 			PacketReceivedInputEvent event = new PacketReceivedInputEvent(source, toModel(packet));
 			networkReceiveBuffer.put(event);
 		} catch (SocketTimeoutException e) {
+		} catch (SocketException e) {
+			if (!socket.isClosed()) {
+				e.printStackTrace();
+			}
 		} catch (IOException | InterruptedException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Fixes an issue where a `SocketException: Socket closed` stack trace was printed during the cleanup phase of `UDPReceiver`. This was happening because `NetworkingReceiver.cleanUp()` closes the socket, interrupting the blocking `socket.receive()` call. The exception is now caught and ignored if the socket is confirmed to be closed, allowing for a cleaner shutdown.

---
*PR created automatically by Jules for task [12608161641480792428](https://jules.google.com/task/12608161641480792428) started by @JaryJay*