### PR TITLE
Encapsulate network sender and receiver into NetworkNode

### DIFF
--- a/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
+++ b/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
@@ -9,10 +9,8 @@ import java.util.Queue;
 
 import engine.context.GameContext;
 import engine.context.input.event.PacketReceivedInputEvent;
-import engine.context.input.networking.SocketFinder;
 import engine.context.input.networking.packet.address.PacketAddress;
-import engine.networking.NetworkingReceiver;
-import engine.networking.NetworkingSender;
+import engine.networking.NetworkNode;
 import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.event.InputEvent;
 import nomadrealms.context.game.world.map.generation.OverworldGenerationStrategy;
@@ -27,20 +25,13 @@ public class ServerContext extends GameContext {
 	private GameState gameState;
 	private final Queue<InputEvent> uiEventChannel = new ArrayDeque<>();
 
-	private final NetworkingReceiver networkingReceiver = new NetworkingReceiver();
-	private final NetworkingSender networkingSender = new NetworkingSender();
+	private final NetworkNode networkNode = new NetworkNode();
 
 	@Override
 	public void init() {
 		re = new RenderingEnvironment(glContext(), config(), mouse());
 		gameState = new GameState("Server World", uiEventChannel, new OverworldGenerationStrategy(123456789));
-		try {
-			DatagramSocket socket = SocketFinder.findSocket(44999);
-			networkingReceiver.init(socket);
-			networkingSender.init(socket);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+		networkNode.init(44999);
 	}
 
 	@Override
@@ -52,7 +43,7 @@ public class ServerContext extends GameContext {
 		while (!uiEventChannel.isEmpty()) {
 			uiEventChannel.poll();
 		}
-		networkingReceiver.update((event, address) -> input(event, address));
+		networkNode.update((event, address) -> input(event, address));
 	}
 
 	public void input(SyncedEvent event, PacketAddress address) {
@@ -61,14 +52,13 @@ public class ServerContext extends GameContext {
 			PingSyncedEvent ping = (PingSyncedEvent) event;
 			System.out.println("Ping message: " + ping.message());
 			System.out.println("Ping timestamp: " + ping.timestamp());
-			networkingSender.send(new PongSyncedEvent("Pong from server", System.currentTimeMillis()), address);
+			networkNode.send(new PongSyncedEvent("Pong from server", System.currentTimeMillis()), address);
 		}
 	}
 
 	@Override
 	public void cleanUp() {
-		networkingReceiver.cleanUp();
-		networkingSender.cleanUp();
+		networkNode.cleanUp();
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/engine/networking/NetworkNode.java
+++ b/nomad-realms/src/main/java/engine/networking/NetworkNode.java
@@ -1,0 +1,53 @@
+package engine.networking;
+
+import engine.context.input.networking.SocketFinder;
+import engine.context.input.networking.packet.address.PacketAddress;
+import nomadrealms.event.networking.SyncedEvent;
+
+import java.io.IOException;
+import java.net.DatagramSocket;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+public class NetworkNode {
+
+	private final NetworkingSender sender = new NetworkingSender();
+	private final NetworkingReceiver receiver = new NetworkingReceiver();
+
+	public void init() {
+		try {
+			DatagramSocket socket = SocketFinder.findSocket(0);
+			sender.init(socket);
+			receiver.init(socket);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public void init(int port) {
+		try {
+			DatagramSocket socket = SocketFinder.findSocket(port);
+			sender.init(socket);
+			receiver.init(socket);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public void send(SyncedEvent event, PacketAddress dest) {
+		sender.send(event, dest);
+	}
+
+	public void update(Consumer<SyncedEvent> consumer) {
+		receiver.update(consumer);
+	}
+
+	public void update(BiConsumer<SyncedEvent, PacketAddress> consumer) {
+		receiver.update(consumer);
+	}
+
+	public void cleanUp() {
+		sender.cleanUp();
+		receiver.cleanUp();
+	}
+}

--- a/nomad-realms/src/main/java/engine/networking/NetworkNode.java
+++ b/nomad-realms/src/main/java/engine/networking/NetworkNode.java
@@ -15,13 +15,7 @@ public class NetworkNode {
 	private final NetworkingReceiver receiver = new NetworkingReceiver();
 
 	public void init() {
-		try {
-			DatagramSocket socket = SocketFinder.findSocket(0);
-			sender.init(socket);
-			receiver.init(socket);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+		init(0);
 	}
 
 	public void init(int port) {

--- a/nomad-realms/src/main/java/nomadrealms/app/PingApp.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/PingApp.java
@@ -1,14 +1,11 @@
 package nomadrealms.app;
 
 import java.io.IOException;
-import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
-import engine.context.input.networking.SocketFinder;
 import engine.context.input.networking.packet.address.PacketAddress;
-import engine.networking.NetworkingReceiver;
-import engine.networking.NetworkingSender;
+import engine.networking.NetworkNode;
 import nomadrealms.event.networking.PingSyncedEvent;
 import nomadrealms.event.networking.PongSyncedEvent;
 
@@ -16,24 +13,21 @@ public class PingApp {
 
 	public static void main(String[] args) throws IOException, InterruptedException {
 		System.out.println("Starting PingApp...");
-		NetworkingSender sender = new NetworkingSender();
-		NetworkingReceiver receiver = new NetworkingReceiver();
+		NetworkNode networkNode = new NetworkNode();
 
-		DatagramSocket socket = SocketFinder.findSocket(0);
-		sender.init(socket);
-		receiver.init(socket);
+		networkNode.init(0);
 
 		PacketAddress serverAddress = new PacketAddress(InetAddress.getByName("localhost"), 44999);
 		long startTime = System.currentTimeMillis();
 		System.out.println("Sending PingSyncedEvent to " + serverAddress);
-		sender.send(new PingSyncedEvent("Ping from PingApp", startTime), serverAddress);
+		networkNode.send(new PingSyncedEvent("Ping from PingApp", startTime), serverAddress);
 
 		boolean receivedPong = false;
 		long deadline = System.currentTimeMillis() + 5000;
 
 		while (System.currentTimeMillis() < deadline) {
 			final boolean[] pongReceived = {false};
-			receiver.update((event) -> {
+			networkNode.update((event) -> {
 				if (event instanceof PongSyncedEvent) {
 					PongSyncedEvent pong = (PongSyncedEvent) event;
 					System.out.println("Received PongSyncedEvent: " + pong);
@@ -52,8 +46,7 @@ public class PingApp {
 			System.out.println("deadline exceeded");
 		}
 
-		sender.cleanUp();
-		receiver.cleanUp();
+		networkNode.cleanUp();
 		System.out.println("PingApp finished.");
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
@@ -26,7 +26,7 @@ import engine.context.input.event.MousePressedInputEvent;
 import engine.context.input.event.MouseReleasedInputEvent;
 import engine.context.input.event.MouseScrolledInputEvent;
 import engine.context.input.networking.packet.address.PacketAddress;
-import engine.networking.NetworkingSender;
+import engine.networking.NetworkNode;
 import engine.visuals.constraint.box.ConstraintPair;
 import engine.visuals.lwjgl.render.framebuffer.DefaultFrameBuffer;
 import java.util.ArrayDeque;
@@ -78,7 +78,7 @@ public class MainContext extends GameContext {
 	private TextContent fpsText;
 	private final Queue<InputEvent> stateToUiEventChannel = new ArrayDeque<>();
 
-	private final NetworkingSender networkingSender = new NetworkingSender();
+	private final NetworkNode networkNode = new NetworkNode();
 
 	private final GameState gameState;
 
@@ -111,7 +111,7 @@ public class MainContext extends GameContext {
 		ui = new GameInterface(re, localPlayer, stateToUiEventChannel, gameState, glContext(), mouse(), inputCallbackRegistry);
 		console = new Console(glContext().screen, gameState, re);
 		gameState.particlePool(new ParticlePool(glContext()));
-		networkingSender.init();
+		networkNode.init();
 		audioPlayer().playBackgroundMusic("/audio/toughened-nomad.mp3");
 		fpsText = new TextContent(() -> String.format("FPS: %.1f", fpsCounter.getFPS()), 1000, 20, re.font,
 				new ConstraintPair(absolute(20), absolute(20)), 0);
@@ -179,7 +179,7 @@ public class MainContext extends GameContext {
 	public void cleanUp() {
 		System.out.println("Saving game");
 //		data.saves().writeGameState(gameState);
-		networkingSender.cleanUp();
+		networkNode.cleanUp();
 	}
 
 	@Override


### PR DESCRIPTION
Encapsulate network sender and receiver into NetworkNode

Created a `NetworkNode` class in `engine.networking` that encapsulates
both `NetworkingSender` and `NetworkingReceiver`. This new class ensures
that both the sender and receiver share the exact same `DatagramSocket`
allocated via `SocketFinder`.

Updated the following classes to use `NetworkNode` instead of standalone
senders and receivers:
- `nomadrealms.app.context.MainContext`
- `nomadrealms.app.context.ServerContext`
- `nomadrealms.app.PingApp`

---
*PR created automatically by Jules for task [17539302695093274505](https://jules.google.com/task/17539302695093274505) started by @Lunkle*