### PR TITLE
Implement double visitor pattern for SyncedEvents

### DIFF
--- a/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
+++ b/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
@@ -17,6 +17,7 @@ import nomadrealms.context.game.world.map.generation.OverworldGenerationStrategy
 import nomadrealms.event.networking.PingSyncedEvent;
 import nomadrealms.event.networking.PongSyncedEvent;
 import nomadrealms.event.networking.SyncedEvent;
+import nomadrealms.event.networking.handler.ServerSyncedEventHandler;
 import nomadrealms.render.RenderingEnvironment;
 
 public class ServerContext extends GameContext {
@@ -26,12 +27,14 @@ public class ServerContext extends GameContext {
 	private final Queue<InputEvent> uiEventChannel = new ArrayDeque<>();
 
 	private final NetworkNode networkNode = new NetworkNode();
+	private ServerSyncedEventHandler eventHandler;
 
 	@Override
 	public void init() {
 		re = new RenderingEnvironment(glContext(), config(), mouse());
 		gameState = new GameState("Server World", uiEventChannel, new OverworldGenerationStrategy(123456789));
 		networkNode.init(44999);
+		eventHandler = new ServerSyncedEventHandler(networkNode);
 	}
 
 	@Override
@@ -47,13 +50,7 @@ public class ServerContext extends GameContext {
 	}
 
 	public void input(SyncedEvent event, PacketAddress address) {
-		System.out.println("Received UDP message from " + address + ": " + event);
-		if (event instanceof PingSyncedEvent) {
-			PingSyncedEvent ping = (PingSyncedEvent) event;
-			System.out.println("Ping message: " + ping.message());
-			System.out.println("Ping timestamp: " + ping.timestamp());
-			networkNode.send(new PongSyncedEvent("Pong from server", System.currentTimeMillis()), address);
-		}
+		event.accept(eventHandler, address);
 	}
 
 	@Override

--- a/nomad-realms-server/src/main/java/nomadrealms/event/networking/handler/ServerSyncedEventHandler.java
+++ b/nomad-realms-server/src/main/java/nomadrealms/event/networking/handler/ServerSyncedEventHandler.java
@@ -1,0 +1,59 @@
+package nomadrealms.event.networking.handler;
+
+import engine.context.input.networking.packet.address.PacketAddress;
+import engine.networking.NetworkNode;
+import nomadrealms.context.game.event.CardPlayedEvent;
+import nomadrealms.context.game.event.DropItemEvent;
+import nomadrealms.context.game.event.InputEvent;
+import nomadrealms.context.game.event.InteractEvent;
+import nomadrealms.event.networking.PingSyncedEvent;
+import nomadrealms.event.networking.PongSyncedEvent;
+import nomadrealms.event.networking.SyncedEvent;
+import nomadrealms.event.networking.SyncedEventHandler;
+import nomadrealms.event.networking.bootstrap.BootstrapEvent;
+
+public class ServerSyncedEventHandler implements SyncedEventHandler {
+
+	private final NetworkNode networkNode;
+
+	public ServerSyncedEventHandler(NetworkNode networkNode) {
+		this.networkNode = networkNode;
+	}
+
+	@Override
+	public void resolve(SyncedEvent event, PacketAddress address) {
+		System.out.println("Received unknown SyncedEvent from " + address + ": " + event);
+	}
+
+	@Override
+	public void resolve(PingSyncedEvent event, PacketAddress address) {
+		System.out.println("Received Ping message from " + address + ": " + event.message());
+		System.out.println("Ping timestamp: " + event.timestamp());
+		networkNode.send(new PongSyncedEvent("Pong from server", System.currentTimeMillis()), address);
+	}
+
+	@Override
+	public void resolve(PongSyncedEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(BootstrapEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(InputEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(DropItemEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(CardPlayedEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(InteractEvent event, PacketAddress address) {
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/app/context/HomeScreenContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/HomeScreenContext.java
@@ -42,6 +42,9 @@ public class HomeScreenContext extends GameContext {
 		homeInterface.initStartGameButton(() -> {
 			transition(new DeckEditingContext());
 		});
+		homeInterface.initJoinGameButton(() -> {
+			transition(new JoinWorldContext());
+		});
 		homeInterface.initLoadGameButton(() -> {
 			// TODO - Show a list of save files to choose from
 			List<Supplier<GameState>> gameStates = data.saves().fetch();

--- a/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
@@ -1,0 +1,38 @@
+package nomadrealms.app.context;
+
+import static engine.common.colour.Colour.rgb;
+
+import engine.context.GameContext;
+import engine.networking.NetworkNode;
+import nomadrealms.event.networking.handler.ClientSyncedEventHandler;
+import nomadrealms.render.RenderingEnvironment;
+
+public class JoinWorldContext extends GameContext {
+
+	private RenderingEnvironment re;
+	private final NetworkNode networkNode = new NetworkNode();
+	private ClientSyncedEventHandler eventHandler;
+
+	@Override
+	public void init() {
+		re = new RenderingEnvironment(glContext(), config(), mouse());
+		networkNode.init();
+		eventHandler = new ClientSyncedEventHandler();
+	}
+
+	@Override
+	public void update() {
+		networkNode.update((event, address) -> event.accept(eventHandler, address));
+	}
+
+	@Override
+	public void render(float alpha) {
+		background(rgb(50, 50, 50));
+	}
+
+	@Override
+	public void cleanUp() {
+		networkNode.cleanUp();
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/event/CardPlayedEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/event/CardPlayedEvent.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import engine.serialization.Derializable;
+import engine.context.input.networking.packet.address.PacketAddress;
+import nomadrealms.event.networking.SyncedEventHandler;
 import nomadrealms.context.game.actor.types.cardplayer.CardPlayer;
 import nomadrealms.context.game.card.Card;
 import nomadrealms.context.game.card.CardType;
@@ -70,6 +72,11 @@ public class CardPlayedEvent implements InputEvent, Card {
 	@Override
 	public void resolve(GameInterface ui) {
 		ui.resolve(this);
+	}
+
+	@Override
+	public void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/event/DropItemEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/event/DropItemEvent.java
@@ -1,6 +1,8 @@
 package nomadrealms.context.game.event;
 
 import engine.serialization.Derializable;
+import engine.context.input.networking.packet.address.PacketAddress;
+import nomadrealms.event.networking.SyncedEventHandler;
 import nomadrealms.context.game.actor.types.HasInventory;
 import nomadrealms.context.game.item.WorldItem;
 import nomadrealms.context.game.world.World;
@@ -43,6 +45,11 @@ public class DropItemEvent implements InputEvent {
 	@Override
 	public void resolve(GameInterface ui) {
 		ui.resolve(this);
+	}
+
+	@Override
+	public void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/event/InputEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/event/InputEvent.java
@@ -1,8 +1,10 @@
 package nomadrealms.context.game.event;
 
+import engine.context.input.networking.packet.address.PacketAddress;
 import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.world.World;
 import nomadrealms.event.networking.SyncedEvent;
+import nomadrealms.event.networking.SyncedEventHandler;
 import nomadrealms.render.ui.custom.game.GameInterface;
 
 /**
@@ -10,6 +12,11 @@ import nomadrealms.render.ui.custom.game.GameInterface;
  * 30 frames of {@link InputEventFrame InputEventFrames} are stored inside {@link GameState}.
  */
 public interface InputEvent extends SyncedEvent {
+
+	@Override
+	default void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
+	}
 
 	/**
 	 * Double visitor pattern

--- a/nomad-realms/src/main/java/nomadrealms/context/game/event/InteractEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/event/InteractEvent.java
@@ -1,6 +1,8 @@
 package nomadrealms.context.game.event;
 
 import engine.serialization.Derializable;
+import engine.context.input.networking.packet.address.PacketAddress;
+import nomadrealms.event.networking.SyncedEventHandler;
 import nomadrealms.context.game.actor.types.cardplayer.CardPlayer;
 import nomadrealms.context.game.actor.types.structure.Structure;
 import nomadrealms.context.game.world.World;
@@ -39,6 +41,11 @@ public class InteractEvent implements InputEvent {
 	@Override
 	public void resolve(GameInterface ui) {
 		ui.resolve(this);
+	}
+
+	@Override
+	public void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/PingSyncedEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/PingSyncedEvent.java
@@ -1,5 +1,6 @@
 package nomadrealms.event.networking;
 
+import engine.context.input.networking.packet.address.PacketAddress;
 import engine.serialization.Derializable;
 
 @Derializable
@@ -22,6 +23,11 @@ public class PingSyncedEvent implements SyncedEvent {
 
 	public long timestamp() {
 		return timestamp;
+	}
+
+	@Override
+	public void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/PongSyncedEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/PongSyncedEvent.java
@@ -1,5 +1,6 @@
 package nomadrealms.event.networking;
 
+import engine.context.input.networking.packet.address.PacketAddress;
 import engine.serialization.Derializable;
 
 @Derializable
@@ -22,6 +23,11 @@ public class PongSyncedEvent implements SyncedEvent {
 
 	public long timestamp() {
 		return timestamp;
+	}
+
+	@Override
+	public void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/SyncedEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/SyncedEvent.java
@@ -15,4 +15,8 @@ public interface SyncedEvent extends Event {
 	default PacketModel toPacket(PacketAddress address) {
 		return new PacketModel(SyncedEventDerializer.serialize(this), address);
 	}
+
+	default void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
+	}
 }

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/SyncedEventHandler.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/SyncedEventHandler.java
@@ -1,0 +1,21 @@
+package nomadrealms.event.networking;
+
+import engine.context.input.networking.packet.address.PacketAddress;
+import nomadrealms.context.game.event.CardPlayedEvent;
+import nomadrealms.context.game.event.DropItemEvent;
+import nomadrealms.context.game.event.InputEvent;
+import nomadrealms.context.game.event.InteractEvent;
+import nomadrealms.event.networking.bootstrap.BootstrapEvent;
+
+public interface SyncedEventHandler {
+
+	void resolve(SyncedEvent event, PacketAddress address);
+	void resolve(PingSyncedEvent event, PacketAddress address);
+	void resolve(PongSyncedEvent event, PacketAddress address);
+	void resolve(BootstrapEvent event, PacketAddress address);
+	void resolve(InputEvent event, PacketAddress address);
+	void resolve(DropItemEvent event, PacketAddress address);
+	void resolve(CardPlayedEvent event, PacketAddress address);
+	void resolve(InteractEvent event, PacketAddress address);
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/bootstrap/BootstrapEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/bootstrap/BootstrapEvent.java
@@ -1,6 +1,12 @@
 package nomadrealms.event.networking.bootstrap;
 
+import engine.context.input.networking.packet.address.PacketAddress;
 import nomadrealms.event.networking.SyncedEvent;
+import nomadrealms.event.networking.SyncedEventHandler;
 
 public abstract class BootstrapEvent implements SyncedEvent {
+	@Override
+	public void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
+	}
 }

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
@@ -1,0 +1,51 @@
+package nomadrealms.event.networking.handler;
+
+import engine.context.input.networking.packet.address.PacketAddress;
+import nomadrealms.context.game.event.CardPlayedEvent;
+import nomadrealms.context.game.event.DropItemEvent;
+import nomadrealms.context.game.event.InputEvent;
+import nomadrealms.context.game.event.InteractEvent;
+import nomadrealms.event.networking.PingSyncedEvent;
+import nomadrealms.event.networking.PongSyncedEvent;
+import nomadrealms.event.networking.SyncedEvent;
+import nomadrealms.event.networking.SyncedEventHandler;
+import nomadrealms.event.networking.bootstrap.BootstrapEvent;
+
+public class ClientSyncedEventHandler implements SyncedEventHandler {
+
+	@Override
+	public void resolve(SyncedEvent event, PacketAddress address) {
+		System.out.println("Received unknown SyncedEvent from server " + address + ": " + event);
+	}
+
+	@Override
+	public void resolve(PingSyncedEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(PongSyncedEvent event, PacketAddress address) {
+		System.out.println("Received Pong from server " + address + ": " + event.message());
+		System.out.println("Pong timestamp: " + event.timestamp());
+	}
+
+	@Override
+	public void resolve(BootstrapEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(InputEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(DropItemEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(CardPlayedEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(InteractEvent event, PacketAddress address) {
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/home/HomeInterface.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/home/HomeInterface.java
@@ -18,6 +18,7 @@ public class HomeInterface {
 	private final ScreenContainerContent homeScreen;
 
 	private final ButtonUIContent startGameButton;
+	private final ButtonUIContent joinGameButton;
 	private final ButtonUIContent loadGameButton;
 	private final ButtonUIContent collectionButton;
 	private final ButtonUIContent sandboxButton;
@@ -30,18 +31,28 @@ public class HomeInterface {
 
 		ConstraintBox screen = glContext.screen;
 		ConstraintPair dimensions = new ConstraintPair(absolute(200), absolute(100));
+
 		startGameButton = new ButtonUIContent(homeScreen, "Start Game",
+				new ConstraintBox(
+						screen.center().add(dimensions.scale(-0.5f)).add(absolute(0), dimensions.y().multiply(-2.4f)),
+						dimensions
+				), null);
+		startGameButton.registerCallbacks(registry);
+
+		joinGameButton = new ButtonUIContent(homeScreen, "Join Game",
 				new ConstraintBox(
 						screen.center().add(dimensions.scale(-0.5f)).add(absolute(0), dimensions.y().multiply(-1.2f)),
 						dimensions
 				), null);
-		startGameButton.registerCallbacks(registry);
+		joinGameButton.registerCallbacks(registry);
+
 		loadGameButton = new ButtonUIContent(homeScreen, "Load Game",
 				new ConstraintBox(
 						screen.center().add(dimensions.scale(-0.5f)),
 						dimensions
 				), null);
 		loadGameButton.registerCallbacks(registry);
+
 		collectionButton = new ButtonUIContent(homeScreen, "Collection",
 				new ConstraintBox(
 						screen.center().add(dimensions.scale(-0.5f)).add(absolute(0), dimensions.y().multiply(1.2f)),
@@ -50,6 +61,7 @@ public class HomeInterface {
 				() -> {
 				});
 		collectionButton.registerCallbacks(registry);
+
 		sandboxButton = new ButtonUIContent(homeScreen, "Card Sandbox",
 				new ConstraintBox(
 						screen.center().add(dimensions.scale(-0.5f)).add(absolute(0), dimensions.y().multiply(2.4f)),
@@ -58,6 +70,7 @@ public class HomeInterface {
 				() -> {
 				});
 		sandboxButton.registerCallbacks(registry);
+
 		terrainSandboxButton = new ButtonUIContent(homeScreen, "Terrain Sandbox",
 				new ConstraintBox(
 						screen.center().add(dimensions.scale(-0.5f)).add(absolute(0), dimensions.y().multiply(3.6f)),
@@ -70,6 +83,10 @@ public class HomeInterface {
 
 	public void initStartGameButton(Runnable onClick) {
 		startGameButton.setCallbacks(onClick);
+	}
+
+	public void initJoinGameButton(Runnable onClick) {
+		joinGameButton.setCallbacks(onClick);
 	}
 
 	public void initLoadGameButton(Runnable onClick) {


### PR DESCRIPTION
Implemented double visitor pattern for `SyncedEvent`s. Added `SyncedEventHandler` interface, `ClientSyncedEventHandler`, and `ServerSyncedEventHandler`. Also updated `ServerContext` and added a skeleton `JoinWorldContext` to demonstrate usage. Updates both regular synced events and input events.

---
*PR created automatically by Jules for task [15135146764160717727](https://jules.google.com/task/15135146764160717727) started by @Lunkle*