### PR TITLE
Refactor VertexBufferObject to separate OpenGL buffer data from vertex attributes

### DIFF
--- a/nomad-realms/src/main/java/engine/nengen/DrawBatch.java
+++ b/nomad-realms/src/main/java/engine/nengen/DrawBatch.java
@@ -13,6 +13,7 @@ import engine.common.math.Matrix4f;
 import engine.visuals.lwjgl.GLContext;
 import engine.visuals.lwjgl.render.ShaderProgram;
 import engine.visuals.lwjgl.render.VertexArrayObject;
+import engine.visuals.lwjgl.render.VertexBufferData;
 import engine.visuals.lwjgl.render.VertexBufferObject;
 
 /**
@@ -84,46 +85,52 @@ public class DrawBatch {
 		}
 
 		if (instancedVao == null) {
-			tVbo = new VertexBufferObject()
-					.index(2)
-					.dimensions(4)
+			VertexBufferData tVboData = new VertexBufferData()
 					.data(transformData)
-					.stride(16 * Float.BYTES)
-					.offset(0)
 					.usage(GL_STREAM_DRAW)
 					.load();
+
+			tVbo = new VertexBufferObject()
+					.buffer(tVboData)
+					.index(2)
+					.dimensions(4)
+					.stride(16 * Float.BYTES)
+					.offset(0);
 			tVbo.divisor(1);
 
 			VertexBufferObject tVbo2 = new VertexBufferObject()
+					.buffer(tVboData)
 					.index(3)
 					.dimensions(4)
 					.stride(16 * Float.BYTES)
-					.offset(4 * Float.BYTES)
-					.loadConfig(tVbo.id());
+					.offset(4 * Float.BYTES);
 			tVbo2.divisor(1);
 
 			VertexBufferObject tVbo3 = new VertexBufferObject()
+					.buffer(tVboData)
 					.index(4)
 					.dimensions(4)
 					.stride(16 * Float.BYTES)
-					.offset(8 * Float.BYTES)
-					.loadConfig(tVbo.id());
+					.offset(8 * Float.BYTES);
 			tVbo3.divisor(1);
 
 			VertexBufferObject tVbo4 = new VertexBufferObject()
+					.buffer(tVboData)
 					.index(5)
 					.dimensions(4)
 					.stride(16 * Float.BYTES)
-					.offset(12 * Float.BYTES)
-					.loadConfig(tVbo.id());
+					.offset(12 * Float.BYTES);
 			tVbo4.divisor(1);
 
-			cVbo = new VertexBufferObject()
-					.index(6)
-					.dimensions(4)
+			VertexBufferData cVboData = new VertexBufferData()
 					.data(colorData)
 					.usage(GL_STREAM_DRAW)
 					.load();
+
+			cVbo = new VertexBufferObject()
+					.buffer(cVboData)
+					.index(6)
+					.dimensions(4);
 			cVbo.divisor(1);
 
 			instancedVao = new VertexArrayObject()

--- a/nomad-realms/src/main/java/engine/visuals/lwjgl/render/InstancedVertexBufferObject.java
+++ b/nomad-realms/src/main/java/engine/visuals/lwjgl/render/InstancedVertexBufferObject.java
@@ -1,8 +1,6 @@
 package engine.visuals.lwjgl.render;
 
 import static org.lwjgl.opengl.GL11.GL_FLOAT;
-import static org.lwjgl.opengl.GL15.GL_ARRAY_BUFFER;
-import static org.lwjgl.opengl.GL15.glBindBuffer;
 import static org.lwjgl.opengl.GL20.glEnableVertexAttribArray;
 import static org.lwjgl.opengl.GL20.glVertexAttribPointer;
 import static org.lwjgl.opengl.GL33.glVertexAttribDivisor;
@@ -11,7 +9,7 @@ public class InstancedVertexBufferObject extends VertexBufferObject {
 
 	@Override
 	protected void enableVertexAttribArray() {
-		glBindBuffer(GL_ARRAY_BUFFER, id);
+		vboData.bind();
 		glVertexAttribPointer(index, dimensions, GL_FLOAT, false, dimensions * Float.BYTES, 0);
 		glEnableVertexAttribArray(index);
 		glVertexAttribDivisor(index, 1);

--- a/nomad-realms/src/main/java/engine/visuals/lwjgl/render/VertexBufferData.java
+++ b/nomad-realms/src/main/java/engine/visuals/lwjgl/render/VertexBufferData.java
@@ -1,0 +1,68 @@
+package engine.visuals.lwjgl.render;
+
+import static org.lwjgl.opengl.GL15.GL_ARRAY_BUFFER;
+import static org.lwjgl.opengl.GL15.GL_STATIC_DRAW;
+import static org.lwjgl.opengl.GL15.glBindBuffer;
+import static org.lwjgl.opengl.GL15.glBufferData;
+import static org.lwjgl.opengl.GL15.glBufferSubData;
+import static org.lwjgl.opengl.GL15.glDeleteBuffers;
+import static org.lwjgl.opengl.GL15.glGenBuffers;
+
+public class VertexBufferData extends GLRegularObject {
+
+	private float[] data;
+	private int usage = GL_STATIC_DRAW;
+
+	public int id() {
+		return id;
+	}
+
+	@Override
+	public void genID() {
+		// TODO: Delete
+	}
+
+	public void bind() {
+		glBindBuffer(GL_ARRAY_BUFFER, id);
+	}
+
+	public VertexBufferData data(float[] data) {
+		this.data = data;
+		return this;
+	}
+
+	public VertexBufferData usage(int usage) {
+		this.usage = usage;
+		return this;
+	}
+
+	public VertexBufferData load() {
+		return load(glGenBuffers());
+	}
+
+	public VertexBufferData load(int id) {
+		this.id = id;
+		bind();
+		glBufferData(GL_ARRAY_BUFFER, data, usage);
+		initialize();
+		return this;
+	}
+
+	public void reallocate() {
+		bind();
+		glBufferData(GL_ARRAY_BUFFER, data, usage);
+	}
+
+	public void updateData() {
+		bind();
+		glBufferSubData(GL_ARRAY_BUFFER, 0, data);
+	}
+
+	public void delete() {
+		glDeleteBuffers(id);
+	}
+
+	public float[] data() {
+		return data;
+	}
+}

--- a/nomad-realms/src/main/java/engine/visuals/lwjgl/render/VertexBufferObject.java
+++ b/nomad-realms/src/main/java/engine/visuals/lwjgl/render/VertexBufferObject.java
@@ -2,14 +2,8 @@ package engine.visuals.lwjgl.render;
 
 import static org.lwjgl.opengl.GL11.GL_FLOAT;
 import static org.lwjgl.opengl.GL15.GL_ARRAY_BUFFER;
-import static org.lwjgl.opengl.GL15.GL_DYNAMIC_DRAW;
 import static org.lwjgl.opengl.GL15.GL_STATIC_DRAW;
-import static org.lwjgl.opengl.GL15.GL_STREAM_DRAW;
 import static org.lwjgl.opengl.GL15.glBindBuffer;
-import static org.lwjgl.opengl.GL15.glBufferData;
-import static org.lwjgl.opengl.GL15.glBufferSubData;
-import static org.lwjgl.opengl.GL15.glDeleteBuffers;
-import static org.lwjgl.opengl.GL15.glGenBuffers;
 import static org.lwjgl.opengl.GL20.glEnableVertexAttribArray;
 import static org.lwjgl.opengl.GL20.glVertexAttribPointer;
 import static org.lwjgl.opengl.GL33.glVertexAttribDivisor;
@@ -22,31 +16,30 @@ import engine.visuals.lwjgl.render.vbo.VertexBufferObjectDivisorBuilder;
  *
  * @author Jay
  */
-public class VertexBufferObject extends GLRegularObject {
+public class VertexBufferObject {
 
-	protected float[] data;
+	protected VertexBufferData vboData;
 	protected int dimensions;
 	protected int index;
 	private int divisor;
 	private int stride;
 	private int offset;
-	private int usage = GL_STATIC_DRAW;
 
-	public int id() {
-		return id;
+	public VertexBufferObject() {
+		this.vboData = new VertexBufferData();
 	}
 
-	@Override
-	public void genID() {
-		// TODO: Delete
+	public VertexBufferObject buffer(VertexBufferData vboData) {
+		this.vboData = vboData;
+		return this;
 	}
 
-	private void bind() {
-		glBindBuffer(GL_ARRAY_BUFFER, id);
+	public VertexBufferData buffer() {
+		return vboData;
 	}
 
 	public VertexBufferObject data(float[] data) {
-		this.data = data;
+		this.vboData.data(data);
 		return this;
 	}
 
@@ -71,7 +64,7 @@ public class VertexBufferObject extends GLRegularObject {
 	}
 
 	public VertexBufferObject usage(int usage) {
-		this.usage = usage;
+		this.vboData.usage(usage);
 		return this;
 	}
 
@@ -84,43 +77,28 @@ public class VertexBufferObject extends GLRegularObject {
 	}
 
 	public VertexBufferObject load() {
-		return load(glGenBuffers());
-	}
-
-	public VertexBufferObject load(int id) {
-		this.id = id;
-		bind();
-		glBufferData(GL_ARRAY_BUFFER, data, usage);
-		initialize();
-		return this;
-	}
-
-	public VertexBufferObject loadConfig(int id) {
-		this.id = id;
-		initialize();
+		vboData.load();
 		return this;
 	}
 
 	public void reallocate() {
-		bind();
-		glBufferData(GL_ARRAY_BUFFER, data, usage);
+		vboData.reallocate();
+	}
+
+	public void updateData() {
+		vboData.updateData();
 	}
 
 	protected void enableVertexAttribArray() {
-		bind();
+		vboData.bind();
 		int s = stride == 0 ? dimensions * Float.BYTES : stride;
 		glVertexAttribPointer(index, dimensions, GL_FLOAT, false, s, offset);
 		glEnableVertexAttribArray(index);
 		glVertexAttribDivisor(index, divisor);
 	}
 
-	public void updateData() {
-		bind();
-		glBufferSubData(GL_ARRAY_BUFFER, 0, data);
-	}
-
 	public void delete() {
-		glDeleteBuffers(id);
+		vboData.delete();
 	}
 
 }


### PR DESCRIPTION
Refactor VertexBufferObject to separate OpenGL buffer data from vertex attributes. Created `VertexBufferData` to hold OpenGL buffer state and `VertexBufferObject` now focuses on vertex attribute configurations. Removed the problematic `loadConfig()` method.

---
*PR created automatically by Jules for task [17979952718294423084](https://jules.google.com/task/17979952718294423084) started by @Lunkle*