### PR TITLE
Delete genID method from VertexBufferData

### DIFF
--- a/nomad-realms/src/main/java/engine/visuals/lwjgl/render/VertexBufferData.java
+++ b/nomad-realms/src/main/java/engine/visuals/lwjgl/render/VertexBufferData.java
@@ -17,11 +17,6 @@ public class VertexBufferData extends GLRegularObject {
 		return id;
 	}
 
-	@Override
-	public void genID() {
-		// TODO: Delete
-	}
-
 	public void bind() {
 		glBindBuffer(GL_ARRAY_BUFFER, id);
 	}


### PR DESCRIPTION
Removed the `genID` method from `VertexBufferData.java` which was marked with a `TODO: Delete` comment. This aligns with the issue request to clean up the unused or obsolete `genID` methods.

---
*PR created automatically by Jules for task [1764327626864152174](https://jules.google.com/task/1764327626864152174) started by @Lunkle*