### PR TITLE
Add Return to Home button and DisconnectFromServerEvent

### DIFF
--- a/nomad-realms-server/src/main/java/nomadrealms/event/networking/handler/ServerSyncedEventHandler.java
+++ b/nomad-realms-server/src/main/java/nomadrealms/event/networking/handler/ServerSyncedEventHandler.java
@@ -14,6 +14,7 @@ import nomadrealms.event.networking.SyncedEvent;
 import nomadrealms.event.networking.SyncedEventHandler;
 import nomadrealms.event.networking.bootstrap.BootstrapEvent;
 import nomadrealms.event.networking.bootstrap.ConnectToServerEvent;
+import nomadrealms.event.networking.bootstrap.DisconnectFromServerEvent;
 import nomadrealms.event.networking.bootstrap.GetOnlinePlayersEvent;
 import nomadrealms.event.networking.bootstrap.OnlinePlayersListEvent;
 import nomadrealms.user.Player;
@@ -54,6 +55,12 @@ public class ServerSyncedEventHandler implements SyncedEventHandler {
 		Player newPlayer = new Player(event.name(), address);
 		System.out.println("Player connected: " + event.name() + " from " + address);
 		onlinePlayers.add(newPlayer);
+	}
+
+	@Override
+	public void resolve(DisconnectFromServerEvent event, PacketAddress address) {
+		System.out.println("Player disconnected: " + event.name() + " from " + address);
+		onlinePlayers.removeIf(player -> player.address().equals(address));
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
@@ -4,6 +4,10 @@ import static engine.common.colour.Colour.rgb;
 
 import engine.common.colour.Colour;
 import engine.context.GameContext;
+import engine.context.input.event.InputCallbackRegistry;
+import engine.context.input.event.MouseMovedInputEvent;
+import engine.context.input.event.MousePressedInputEvent;
+import engine.context.input.event.MouseReleasedInputEvent;
 import engine.context.input.networking.packet.address.PacketAddress;
 import engine.networking.NetworkNode;
 import engine.visuals.rendering.text.TextFormat;
@@ -14,9 +18,11 @@ import java.util.List;
 import java.util.UUID;
 import nomadrealms.event.networking.PingSyncedEvent;
 import nomadrealms.event.networking.bootstrap.ConnectToServerEvent;
+import nomadrealms.event.networking.bootstrap.DisconnectFromServerEvent;
 import nomadrealms.event.networking.bootstrap.GetOnlinePlayersEvent;
 import nomadrealms.event.networking.handler.ClientSyncedEventHandler;
 import nomadrealms.render.RenderingEnvironment;
+import nomadrealms.render.ui.custom.join.JoinWorldInterface;
 import nomadrealms.user.Player;
 
 public class JoinWorldContext extends GameContext {
@@ -27,11 +33,23 @@ public class JoinWorldContext extends GameContext {
 	private List<Player> onlinePlayers = new ArrayList<>();
 
 	private PacketAddress serverAddress;
+	private String playerName;
+
+	private JoinWorldInterface joinWorldInterface;
+	private final InputCallbackRegistry inputCallbackRegistry = new InputCallbackRegistry();
 
 	@Override
 	public void init() {
 		re = new RenderingEnvironment(glContext(), config(), mouse());
 		networkNode.init();
+
+		joinWorldInterface = new JoinWorldInterface(re, glContext(), inputCallbackRegistry);
+		joinWorldInterface.initHomeButton(() -> {
+			if (serverAddress != null && playerName != null) {
+				networkNode.send(new DisconnectFromServerEvent(playerName), serverAddress);
+			}
+			transition(new HomeScreenContext());
+		});
 
 		eventHandler = new ClientSyncedEventHandler(players -> {
 			this.onlinePlayers = players;
@@ -39,7 +57,7 @@ public class JoinWorldContext extends GameContext {
 
 		try {
 			serverAddress = new PacketAddress(InetAddress.getByName("localhost"), 44999);
-			String playerName = "Player-" + UUID.randomUUID().toString().substring(0, 4);
+			playerName = "Player-" + UUID.randomUUID().toString().substring(0, 4);
 
 			System.out.println("Sending PingSyncedEvent to " + serverAddress);
 			networkNode.send(new PingSyncedEvent("Ping from PingApp", System.currentTimeMillis()), serverAddress);
@@ -62,40 +80,27 @@ public class JoinWorldContext extends GameContext {
 	@Override
 	public void render(float alpha) {
 		background(rgb(50, 50, 50));
-
-		// Render UI to show online players
-		float startX = 20;
-		float startY = 20;
-		float width = 300;
-		float height = 50 + (onlinePlayers.size() * 30);
-
-		// Draw background box
-		re.rectangleRenderer.render(startX, startY, width, height, 10, Colour.rgba(0, 0, 0, 180));
-
-		// Draw Title
-		re.textRenderer.render(startX + 10, startY + 10,
-				TextFormat.textFormat()
-						.text("Online Players: " + onlinePlayers.size())
-						.font(re.font)
-						.fontSize(20)
-						.colour(Colour.rgb(255, 255, 255)));
-
-		// Draw Player List
-		float yOffset = startY + 40;
-		for (Player p : onlinePlayers) {
-			re.textRenderer.render(startX + 10, yOffset,
-					TextFormat.textFormat()
-							.text(p.name() + " (" + p.address() + ")")
-							.font(re.font)
-							.fontSize(16)
-							.colour(Colour.rgb(200, 200, 200)));
-			yOffset += 30;
-		}
+		joinWorldInterface.render(re, onlinePlayers);
 	}
 
 	@Override
 	public void cleanUp() {
 		networkNode.cleanUp();
+	}
+
+	@Override
+	public void input(MouseMovedInputEvent event) {
+		inputCallbackRegistry.triggerOnDrag(event);
+	}
+
+	@Override
+	public void input(MousePressedInputEvent event) {
+		inputCallbackRegistry.triggerOnPress(event);
+	}
+
+	@Override
+	public void input(MouseReleasedInputEvent event) {
+		inputCallbackRegistry.triggerOnDrop(event);
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/SyncedEventHandler.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/SyncedEventHandler.java
@@ -7,6 +7,7 @@ import nomadrealms.context.game.event.InputEvent;
 import nomadrealms.context.game.event.InteractEvent;
 import nomadrealms.event.networking.bootstrap.BootstrapEvent;
 import nomadrealms.event.networking.bootstrap.ConnectToServerEvent;
+import nomadrealms.event.networking.bootstrap.DisconnectFromServerEvent;
 import nomadrealms.event.networking.bootstrap.GetOnlinePlayersEvent;
 import nomadrealms.event.networking.bootstrap.OnlinePlayersListEvent;
 
@@ -25,6 +26,8 @@ public interface SyncedEventHandler {
 	void resolve(BootstrapEvent event, PacketAddress address);
 
 	void resolve(ConnectToServerEvent event, PacketAddress address);
+
+	void resolve(DisconnectFromServerEvent event, PacketAddress address);
 
 	void resolve(GetOnlinePlayersEvent event, PacketAddress address);
 

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/bootstrap/DisconnectFromServerEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/bootstrap/DisconnectFromServerEvent.java
@@ -1,0 +1,28 @@
+package nomadrealms.event.networking.bootstrap;
+
+import engine.context.input.networking.packet.address.PacketAddress;
+import engine.serialization.Derializable;
+import nomadrealms.event.networking.SyncedEventHandler;
+
+@Derializable
+public class DisconnectFromServerEvent extends BootstrapEvent {
+
+	private String name;
+
+	protected DisconnectFromServerEvent() {
+	}
+
+	public DisconnectFromServerEvent(String name) {
+		this.name = name;
+	}
+
+	public String name() {
+		return name;
+	}
+
+	@Override
+	public void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
@@ -13,6 +13,7 @@ import nomadrealms.event.networking.SyncedEvent;
 import nomadrealms.event.networking.SyncedEventHandler;
 import nomadrealms.event.networking.bootstrap.BootstrapEvent;
 import nomadrealms.event.networking.bootstrap.ConnectToServerEvent;
+import nomadrealms.event.networking.bootstrap.DisconnectFromServerEvent;
 import nomadrealms.event.networking.bootstrap.GetOnlinePlayersEvent;
 import nomadrealms.event.networking.bootstrap.OnlinePlayersListEvent;
 import nomadrealms.user.Player;
@@ -49,6 +50,10 @@ public class ClientSyncedEventHandler implements SyncedEventHandler {
 
 	@Override
 	public void resolve(ConnectToServerEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(DisconnectFromServerEvent event, PacketAddress address) {
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/join/JoinWorldInterface.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/join/JoinWorldInterface.java
@@ -1,0 +1,74 @@
+package nomadrealms.render.ui.custom.join;
+
+import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
+
+import engine.common.colour.Colour;
+import engine.context.input.event.InputCallbackRegistry;
+import engine.visuals.constraint.box.ConstraintBox;
+import engine.visuals.constraint.box.ConstraintPair;
+import engine.visuals.lwjgl.GLContext;
+import engine.visuals.rendering.text.TextFormat;
+import java.util.List;
+import nomadrealms.render.RenderingEnvironment;
+import nomadrealms.render.ui.content.ButtonUIContent;
+import nomadrealms.render.ui.content.ScreenContainerContent;
+import nomadrealms.user.Player;
+
+public class JoinWorldInterface {
+
+	private final GLContext glContext;
+	private final ScreenContainerContent joinWorldScreen;
+	private final ButtonUIContent returnHomeButton;
+
+	public JoinWorldInterface(RenderingEnvironment re, GLContext glContext, InputCallbackRegistry registry) {
+		this.glContext = glContext;
+
+		joinWorldScreen = new ScreenContainerContent(re);
+
+		ConstraintBox screen = glContext.screen;
+		ConstraintPair dimensions = new ConstraintPair(absolute(200), absolute(50));
+
+		returnHomeButton = new ButtonUIContent(joinWorldScreen, "Return to Home",
+				new ConstraintBox(
+						new ConstraintPair(screen.left().add(absolute(20)), screen.bottom().add(absolute(-70))),
+						dimensions
+				), null);
+		returnHomeButton.registerCallbacks(registry);
+	}
+
+	public void initHomeButton(Runnable onClick) {
+		returnHomeButton.setCallbacks(onClick);
+	}
+
+	public void render(RenderingEnvironment re, List<Player> onlinePlayers) {
+		joinWorldScreen.render(re);
+
+		float startX = 20;
+		float startY = 20;
+		float width = 300;
+		float height = 50 + (onlinePlayers.size() * 30);
+
+		// Draw background box
+		re.rectangleRenderer.render(startX, startY, width, height, 10, Colour.rgba(0, 0, 0, 180));
+
+		// Draw Title
+		re.textRenderer.render(startX + 10, startY + 10,
+				TextFormat.textFormat()
+						.text("Online Players: " + onlinePlayers.size())
+						.font(re.font)
+						.fontSize(20)
+						.colour(Colour.rgb(255, 255, 255)));
+
+		// Draw Player List
+		float yOffset = startY + 40;
+		for (Player p : onlinePlayers) {
+			re.textRenderer.render(startX + 10, yOffset,
+					TextFormat.textFormat()
+							.text(p.name() + " (" + p.address() + ")")
+							.font(re.font)
+							.fontSize(16)
+							.colour(Colour.rgb(200, 200, 200)));
+			yOffset += 30;
+		}
+	}
+}

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/join/JoinWorldInterface.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/join/JoinWorldInterface.java
@@ -16,12 +16,10 @@ import nomadrealms.user.Player;
 
 public class JoinWorldInterface {
 
-	private final GLContext glContext;
 	private final ScreenContainerContent joinWorldScreen;
 	private final ButtonUIContent returnHomeButton;
 
 	public JoinWorldInterface(RenderingEnvironment re, GLContext glContext, InputCallbackRegistry registry) {
-		this.glContext = glContext;
 
 		joinWorldScreen = new ScreenContainerContent(re);
 


### PR DESCRIPTION
Adds a "Return to Home Screen" button inside the `JoinWorldContext` view. This button sends a new `DisconnectFromServerEvent` to the server and navigates the user back to the `HomeScreenContext`. The server handles this event by correctly removing the player from the active player list based on their packet address. Additionally, the UI code for `JoinWorldContext` has been refactored into a `JoinWorldInterface` class for better separation of concerns, similar to `HomeInterface`.

---
*PR created automatically by Jules for task [13088833893999835126](https://jules.google.com/task/13088833893999835126) started by @Lunkle*