### PR TITLE
Fix right-click cancellation to return card to deck

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
@@ -144,12 +144,22 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 	private void addCallbacks(InputCallbackRegistry registry) {
 		registry.registerOnPress(
 				(event) -> {
-					selectedCard = cards()
-							.filter(card -> card.physics().cardBox().contains(event.mouse().coordinate()))
-							.findFirst()
-							.orElse(null);
-					if (selectedCard != null) {
-						selectedCardOriginalTransform = selectedCard.physics().targetTransform().copy();
+					if (event.button() == org.lwjgl.glfw.GLFW.GLFW_MOUSE_BUTTON_LEFT) {
+						selectedCard = cards()
+								.filter(card -> card.physics().cardBox().contains(event.mouse().coordinate()))
+								.findFirst()
+								.orElse(null);
+						if (selectedCard != null) {
+							selectedCardOriginalTransform = selectedCard.physics().targetTransform().copy();
+						}
+					} else if (event.button() == org.lwjgl.glfw.GLFW.GLFW_MOUSE_BUTTON_RIGHT) {
+						if (selectedCard != null) {
+							selectedCard.physics().targetTransform(selectedCardOriginalTransform);
+							selectedCard.physics().pauseRestoration = false;
+							selectedCard = null;
+							targetingArrow.origin(null);
+							targetingArrow.target(null);
+						}
 					}
 				});
 		registry.registerOnDrag(
@@ -178,25 +188,27 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 				});
 		registry.registerOnDrop(
 				(event) -> {
-					if (selectedCard != null) {
-						if (selectedCard.position().x().get() < constraintBox.x().get()
-								&& (targetingArrow.target() == null ^ selectedCard.needsTarget())) {
-							if (owner.mana() >= ((GameCard) selectedCard.card().card()).manaCost()) {
-								owner.addNextPlay(new CardPlayedEvent(selectedCard.card(), owner, targetingArrow.target()));
-								selectedCard.physics().pauseRestoration = true;
+					if (event.button() == org.lwjgl.glfw.GLFW.GLFW_MOUSE_BUTTON_LEFT) {
+						if (selectedCard != null) {
+							if (selectedCard.position().x().get() < constraintBox.x().get()
+									&& (targetingArrow.target() == null ^ selectedCard.needsTarget())) {
+								if (owner.mana() >= ((GameCard) selectedCard.card().card()).manaCost()) {
+									owner.addNextPlay(new CardPlayedEvent(selectedCard.card(), owner, targetingArrow.target()));
+									selectedCard.physics().pauseRestoration = true;
+								} else {
+									manaIndicator.triggerError();
+									selectedCard.physics().targetTransform(selectedCardOriginalTransform);
+									selectedCard.physics().pauseRestoration = false;
+								}
 							} else {
-								manaIndicator.triggerError();
 								selectedCard.physics().targetTransform(selectedCardOriginalTransform);
 								selectedCard.physics().pauseRestoration = false;
 							}
-						} else {
-							selectedCard.physics().targetTransform(selectedCardOriginalTransform);
-							selectedCard.physics().pauseRestoration = false;
 						}
+						selectedCard = null;
+						targetingArrow.origin(null);
+						targetingArrow.target(null);
 					}
-					selectedCard = null;
-					targetingArrow.origin(null);
-					targetingArrow.target(null);
 				});
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
@@ -190,17 +190,19 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 				(event) -> {
 					if (event.button() == org.lwjgl.glfw.GLFW.GLFW_MOUSE_BUTTON_LEFT) {
 						if (selectedCard != null) {
+							boolean played = false;
 							if (selectedCard.position().x().get() < constraintBox.x().get()
 									&& (targetingArrow.target() == null ^ selectedCard.needsTarget())) {
 								if (owner.mana() >= ((GameCard) selectedCard.card().card()).manaCost()) {
 									owner.addNextPlay(new CardPlayedEvent(selectedCard.card(), owner, targetingArrow.target()));
 									selectedCard.physics().pauseRestoration = true;
+									played = true;
 								} else {
 									manaIndicator.triggerError();
-									selectedCard.physics().targetTransform(selectedCardOriginalTransform);
-									selectedCard.physics().pauseRestoration = false;
 								}
-							} else {
+							}
+
+							if (!played) {
 								selectedCard.physics().targetTransform(selectedCardOriginalTransform);
 								selectedCard.physics().pauseRestoration = false;
 							}


### PR DESCRIPTION
This pull request correctly implements a right-click cancel interaction while dragging a card in `DeckTab`. It restricts card picking and dropping strictly to the left mouse button. Pressing the right mouse button while holding a card now gracefully resets its transform to the original deck location and clears the targeting arrow.

---
*PR created automatically by Jules for task [7358390023125450782](https://jules.google.com/task/7358390023125450782) started by @Lunkle*