### PR TITLE
Refactor DeckTab and DiscardUI restock logic

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DeckTab.java
@@ -48,22 +48,6 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 	Map<WorldCardZone, Map<WorldCard, UICard>> deckUICards = new HashMap<>();
 	Map<WorldCardZone, UnrevealedCardUI> deckUnrevealedUICards = new HashMap<>();
 
-	private static class RestockTask {
-		WorldCard card;
-		UICard ui;
-		Deck deck;
-		long executeTime;
-
-		public RestockTask(WorldCard card, UICard ui, Deck deck, long executeTime) {
-			this.card = card;
-			this.ui = ui;
-			this.deck = deck;
-			this.executeTime = executeTime;
-		}
-	}
-
-	private final List<RestockTask> restockTasks = new ArrayList<>();
-
 	transient CardPlayer owner;
 
 	private ManaIndicator manaIndicator;
@@ -216,15 +200,7 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 
 	@Override
 	public void render(RenderingEnvironment re) {
-		long currentTime = System.currentTimeMillis();
-		Iterator<RestockTask> taskIterator = restockTasks.iterator();
-		while (taskIterator.hasNext()) {
-			RestockTask task = taskIterator.next();
-			if (currentTime >= task.executeTime) {
-				deckUICards.get(task.deck).put(task.card, task.ui);
-				taskIterator.remove();
-			}
-		}
+		discardUI.processRestockTasks(task -> deckUICards.get(task.deck).put(task.card, task.ui));
 
 		re.defaultShaderProgram
 				.set("color", toRangedVector(rgb(210, 180, 140)))
@@ -298,19 +274,7 @@ public class DeckTab implements UI, CardZoneListener<WorldCard> {
 	public void handle(RestockCardZoneEvent<WorldCard> event) {
 		if (event.zone() instanceof Deck && owner.deckCollection().contains((Deck) event.zone())) {
 			Deck deck = (Deck) event.zone();
-			List<UICard> toRestock = discardUI.discardUICards().stream()
-					.filter(ui -> ui.card().deck() == deck)
-					.collect(Collectors.toList());
-			discardUI.discardUICards().removeAll(toRestock);
-			long startTime = System.currentTimeMillis();
-			for (int i = 0; i < toRestock.size(); i++) {
-				UICard ui = toRestock.get(i);
-				ui.physics().targetTransform(new CardTransform(
-						new engine.common.math.UnitQuaternion(),
-						deckConstraints.get(deck)
-				));
-				restockTasks.add(new RestockTask(ui.card(), ui, deck, startTime + i * 100));
-			}
+			discardUI.restockDeck(deck, deckConstraints.get(deck));
 		}
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DiscardUI.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/DiscardUI.java
@@ -14,6 +14,10 @@ import java.util.ArrayList;
 import java.util.List;
 import nomadrealms.context.game.card.UICard;
 import nomadrealms.context.game.card.WorldCard;
+import java.util.Iterator;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import nomadrealms.context.game.zone.Deck;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.ui.UI;
 
@@ -21,6 +25,7 @@ public class DiscardUI implements UI {
 
 	private final ConstraintBox discardArea;
 	private final List<UICard> discardUICards = new ArrayList<>();
+	private final List<RestockTask> restockTasks = new ArrayList<>();
 
 	public DiscardUI(ConstraintBox discardArea) {
 		this.discardArea = discardArea;
@@ -64,6 +69,34 @@ public class DiscardUI implements UI {
 				targetBox
 		));
 		discardUICards.add(ui);
+	}
+
+	public void restockDeck(Deck deck, ConstraintBox deckConstraint) {
+		List<UICard> toRestock = discardUICards.stream()
+				.filter(ui -> ui.card().deck() == deck)
+				.collect(Collectors.toList());
+		discardUICards.removeAll(toRestock);
+		long startTime = System.currentTimeMillis();
+		for (int i = 0; i < toRestock.size(); i++) {
+			UICard ui = toRestock.get(i);
+			ui.physics().targetTransform(new CardTransform(
+					new engine.common.math.UnitQuaternion(),
+					deckConstraint
+			));
+			restockTasks.add(new RestockTask(ui.card(), ui, deck, startTime + i * 100));
+		}
+	}
+
+	public void processRestockTasks(Consumer<RestockTask> onRestockReady) {
+		long currentTime = System.currentTimeMillis();
+		Iterator<RestockTask> taskIterator = restockTasks.iterator();
+		while (taskIterator.hasNext()) {
+			RestockTask task = taskIterator.next();
+			if (currentTime >= task.executeTime) {
+				onRestockReady.accept(task);
+				taskIterator.remove();
+			}
+		}
 	}
 
 	public List<UICard> discardUICards() {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/RestockTask.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/RestockTask.java
@@ -1,0 +1,19 @@
+package nomadrealms.render.ui.custom.card;
+
+import nomadrealms.context.game.card.UICard;
+import nomadrealms.context.game.card.WorldCard;
+import nomadrealms.context.game.zone.Deck;
+
+public class RestockTask {
+	public WorldCard card;
+	public UICard ui;
+	public Deck deck;
+	public long executeTime;
+
+	public RestockTask(WorldCard card, UICard ui, Deck deck, long executeTime) {
+		this.card = card;
+		this.ui = ui;
+		this.deck = deck;
+		this.executeTime = executeTime;
+	}
+}


### PR DESCRIPTION
The decktab card ui logic is getting really complex with the discard logic. see what you can do to simplify the logic, remove nested classes, and encapsulate code.

- Extract `RestockTask` out of `DeckTab` and into a public file.
- Encapsulate task processing within `DiscardUI`.
- Move the `RestockCardZoneEvent` listener processing step logic from `DeckTab` to `DiscardUI.restockDeck`.

---
*PR created automatically by Jules for task [17382485382073763063](https://jules.google.com/task/17382485382073763063) started by @Lunkle*