### PR TITLE
Centralize FPS counter in generic DebugUI

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
@@ -46,6 +46,7 @@ import nomadrealms.render.particle.ParticlePool;
 import nomadrealms.render.ui.Camera;
 import nomadrealms.render.ui.custom.Ruler;
 import nomadrealms.render.ui.custom.console.Console;
+import nomadrealms.render.ui.custom.debug.DebugUI;
 import nomadrealms.render.ui.custom.game.GameInterface;
 import nomadrealms.render.ui.custom.indicator.PlayerIndicator;
 import nomadrealms.user.Player;
@@ -74,6 +75,7 @@ public class MainContext extends GameContext {
 	private PlayerIndicator playerIndicator = new PlayerIndicator();
 	private Console console;
 	private final Ruler ruler = new Ruler();
+	private DebugUI debugUI;
 	private final Queue<InputEvent> stateToUiEventChannel = new ArrayDeque<>();
 
 	private final NetworkNode networkNode = new NetworkNode();
@@ -114,6 +116,7 @@ public class MainContext extends GameContext {
 		re.camera = new Camera(localPlayer.cardPlayer(gameState.world).tile().pos().sub(glContext().screen.dimensions().scale(0.5f * 0.6f, 0.5f)));
 		ui = new GameInterface(re, localPlayer, stateToUiEventChannel, gameState, glContext(), mouse(), inputCallbackRegistry);
 		console = new Console(glContext().screen, gameState, re);
+		debugUI = new DebugUI(gameState.world);
 		gameState.particlePool(new ParticlePool(glContext()));
 		networkNode.init();
 		audioPlayer().playBackgroundMusic("/audio/toughened-nomad.mp3");
@@ -135,7 +138,7 @@ public class MainContext extends GameContext {
 
 	@Override
 	public void render(float alpha) {
-		gameState.world.debugUI().update();
+		debugUI.update();
 		re.updateActorTextOpacity();
 		// Render the scene to fbo1
 		re.fbo1.render(() -> {
@@ -170,6 +173,9 @@ public class MainContext extends GameContext {
 			// re.textureRenderer.render(re.fbo2.texture(), new Matrix4f(glContext().screen, glContext())); // Bloom is currently broken
 			console.render(re);
 			ruler.render(re);
+			if (re.showDebugInfo) {
+				debugUI.render(re);
+			}
 		});
 //		re.bloomCombinationShaderProgram.use(glContext());
 //		re.fbo1.texture().bind(glContext());

--- a/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
@@ -145,6 +145,9 @@ public class MainContext extends GameContext {
 			background(0);
 			gameState.render(re);
 			playerIndicator.render(re, localPlayer.cardPlayer(gameState.world));
+			if (re.showDebugInfo) {
+				debugUI.render(re);
+			}
 			ui.render(re);
 		});
 
@@ -173,9 +176,6 @@ public class MainContext extends GameContext {
 			// re.textureRenderer.render(re.fbo2.texture(), new Matrix4f(glContext().screen, glContext())); // Bloom is currently broken
 			console.render(re);
 			ruler.render(re);
-			if (re.showDebugInfo) {
-				debugUI.render(re);
-			}
 		});
 //		re.bloomCombinationShaderProgram.use(glContext());
 //		re.fbo1.texture().bind(glContext());

--- a/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
@@ -1,6 +1,5 @@
 package nomadrealms.app.context;
 
-import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_A;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_D;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_E;
@@ -15,7 +14,6 @@ import static org.lwjgl.glfw.GLFW.GLFW_MOUSE_BUTTON_LEFT;
 import static org.lwjgl.glfw.GLFW.GLFW_MOUSE_BUTTON_RIGHT;
 
 import engine.common.math.Matrix4f;
-import engine.common.time.FPSCounter;
 import engine.context.GameContext;
 import engine.context.input.event.CharacterTypedInputEvent;
 import engine.context.input.event.InputCallbackRegistry;
@@ -27,7 +25,6 @@ import engine.context.input.event.MouseReleasedInputEvent;
 import engine.context.input.event.MouseScrolledInputEvent;
 import engine.context.input.networking.packet.address.PacketAddress;
 import engine.networking.NetworkNode;
-import engine.visuals.constraint.box.ConstraintPair;
 import engine.visuals.lwjgl.render.framebuffer.DefaultFrameBuffer;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -47,7 +44,6 @@ import nomadrealms.context.game.zone.Deck;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.particle.ParticlePool;
 import nomadrealms.render.ui.Camera;
-import nomadrealms.render.ui.content.TextContent;
 import nomadrealms.render.ui.custom.Ruler;
 import nomadrealms.render.ui.custom.console.Console;
 import nomadrealms.render.ui.custom.game.GameInterface;
@@ -78,8 +74,6 @@ public class MainContext extends GameContext {
 	private PlayerIndicator playerIndicator = new PlayerIndicator();
 	private Console console;
 	private final Ruler ruler = new Ruler();
-	private final FPSCounter fpsCounter = new FPSCounter(100);
-	private TextContent fpsText;
 	private final Queue<InputEvent> stateToUiEventChannel = new ArrayDeque<>();
 
 	private final NetworkNode networkNode = new NetworkNode();
@@ -123,8 +117,6 @@ public class MainContext extends GameContext {
 		gameState.particlePool(new ParticlePool(glContext()));
 		networkNode.init();
 		audioPlayer().playBackgroundMusic("/audio/toughened-nomad.mp3");
-		fpsText = new TextContent(() -> String.format("FPS: %.1f", fpsCounter.getFPS()), 1000, 20, re.font,
-				new ConstraintPair(absolute(20), absolute(20)), 0);
 	}
 
 	@Override
@@ -143,7 +135,7 @@ public class MainContext extends GameContext {
 
 	@Override
 	public void render(float alpha) {
-		fpsCounter.update();
+		gameState.world.debugUI().update();
 		re.updateActorTextOpacity();
 		// Render the scene to fbo1
 		re.fbo1.render(() -> {
@@ -178,9 +170,6 @@ public class MainContext extends GameContext {
 			// re.textureRenderer.render(re.fbo2.texture(), new Matrix4f(glContext().screen, glContext())); // Bloom is currently broken
 			console.render(re);
 			ruler.render(re);
-			if (re.showDebugInfo) {
-				fpsText.render(re);
-			}
 		});
 //		re.bloomCombinationShaderProgram.use(glContext());
 //		re.fbo1.texture().bind(glContext());

--- a/nomad-realms/src/main/java/nomadrealms/app/context/TerrainSandboxContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/TerrainSandboxContext.java
@@ -34,6 +34,7 @@ import nomadrealms.render.ui.content.ButtonUIContent;
 import nomadrealms.render.ui.content.ScreenContainerContent;
 import nomadrealms.render.ui.custom.Ruler;
 import nomadrealms.render.ui.custom.console.Console;
+import nomadrealms.render.ui.custom.debug.DebugUI;
 
 public class TerrainSandboxContext extends GameContext {
 
@@ -41,6 +42,7 @@ public class TerrainSandboxContext extends GameContext {
 	private GameState gameState;
 	private Console console;
 	private final Ruler ruler = new Ruler();
+	private DebugUI debugUI;
 
 	private final InputCallbackRegistry inputCallbackRegistry = new InputCallbackRegistry();
 
@@ -71,6 +73,7 @@ public class TerrainSandboxContext extends GameContext {
 		gameState = new GameState("Terrain Sandbox", new LinkedList<>(),
 				new OverworldGenerationStrategy(seed).mapInitialization(new TerrainSandboxMapInitialization()));
 		console = new Console(glContext().screen, gameState, re);
+		debugUI = new DebugUI(gameState.world);
 		console.customCommandProcessor((cmd, args) -> {
 			if (cmd.equalsIgnoreCase("REGEN")) {
 				try {
@@ -99,7 +102,7 @@ public class TerrainSandboxContext extends GameContext {
 
 	@Override
 	public void render(float alpha) {
-		gameState.world.debugUI().update();
+		debugUI.update();
 		re.fbo1.render(() -> {
 			background(0);
 			gameState.render(re);
@@ -111,6 +114,9 @@ public class TerrainSandboxContext extends GameContext {
 			console.render(re);
 			ui.render(re);
 			ruler.render(re);
+			if (re.showDebugInfo) {
+				debugUI.render(re);
+			}
 		});
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/app/context/TerrainSandboxContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/TerrainSandboxContext.java
@@ -11,7 +11,6 @@ import static org.lwjgl.glfw.GLFW.GLFW_KEY_SPACE;
 import static org.lwjgl.glfw.GLFW.GLFW_KEY_W;
 
 import engine.common.math.Matrix4f;
-import engine.common.time.FPSCounter;
 import engine.context.GameContext;
 import engine.context.input.event.CharacterTypedInputEvent;
 import engine.context.input.event.InputCallbackRegistry;
@@ -33,7 +32,6 @@ import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.ui.Camera;
 import nomadrealms.render.ui.content.ButtonUIContent;
 import nomadrealms.render.ui.content.ScreenContainerContent;
-import nomadrealms.render.ui.content.TextContent;
 import nomadrealms.render.ui.custom.Ruler;
 import nomadrealms.render.ui.custom.console.Console;
 
@@ -43,8 +41,6 @@ public class TerrainSandboxContext extends GameContext {
 	private GameState gameState;
 	private Console console;
 	private final Ruler ruler = new Ruler();
-	private final FPSCounter fpsCounter = new FPSCounter(100);
-	private TextContent fpsText;
 
 	private final InputCallbackRegistry inputCallbackRegistry = new InputCallbackRegistry();
 
@@ -66,8 +62,6 @@ public class TerrainSandboxContext extends GameContext {
 				this::togglePaused);
 		pausePlayButton.registerCallbacks(inputCallbackRegistry);
 
-		fpsText = new TextContent(() -> String.format("FPS: %.1f", fpsCounter.getFPS()), 1000, 20, re.font,
-				new ConstraintPair(absolute(20), absolute(20)), 0);
 		if (!"/audio/theme-song.mp3".equals(audioPlayer().currentAudio())) {
 			audioPlayer().playBackgroundMusic("/audio/theme-song.mp3");
 		}
@@ -105,7 +99,7 @@ public class TerrainSandboxContext extends GameContext {
 
 	@Override
 	public void render(float alpha) {
-		fpsCounter.update();
+		gameState.world.debugUI().update();
 		re.fbo1.render(() -> {
 			background(0);
 			gameState.render(re);
@@ -117,9 +111,6 @@ public class TerrainSandboxContext extends GameContext {
 			console.render(re);
 			ui.render(re);
 			ruler.render(re);
-			if (re.showDebugInfo) {
-				fpsText.render(re);
-			}
 		});
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -51,7 +51,6 @@ import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.particle.ParticlePool;
 import nomadrealms.render.particle.context.game.CardParticle;
 import nomadrealms.render.particle.spawner.BasicParticleSpawner;
-import nomadrealms.render.ui.custom.debug.DebugUI;
 import nomadrealms.render.vao.shape.HexagonVao;
 
 /**
@@ -64,8 +63,6 @@ public class World {
 	private transient ActorLookup lookup = new HashActorLookup();
 
 	private final DrawBatch tileBatch = new DrawBatch();
-
-	private DebugUI debugUI;
 
 	private GameMap map;
 	public Nomad nomad;
@@ -80,7 +77,6 @@ public class World {
 		this.state = state;
 		map = new GameMap(this, mapGenerationStrategy);
 		mapGenerationStrategy.initializeMap(this);
-		this.debugUI = new DebugUI(this);
 	}
 
 	public List<Chunk> getVisibleChunks(RenderingEnvironment re) {
@@ -123,7 +119,6 @@ public class World {
 		}
 
 		if (re.showDebugInfo) {
-			debugUI.render(re);
 			Set<Zone> visibleZones = new HashSet<>();
 			for (Chunk chunk : visibleChunks) {
 				visibleZones.add(chunk.zone());
@@ -291,7 +286,6 @@ public class World {
 	public void reindex(GameState gameState) {
 		this.state = gameState;
 		this.lookup = new HashActorLookup();
-		this.debugUI = new DebugUI(this);
 		map.reindex(this);
 		if (nomad != null) {
 			nomad.reindex(this);
@@ -327,10 +321,6 @@ public class World {
 
 	public ActorLookup lookup() {
 		return lookup;
-	}
-
-	public DebugUI debugUI() {
-		return debugUI;
 	}
 
 	public void particlePool(ParticlePool particlePool) {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -51,7 +51,7 @@ import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.particle.ParticlePool;
 import nomadrealms.render.particle.context.game.CardParticle;
 import nomadrealms.render.particle.spawner.BasicParticleSpawner;
-import nomadrealms.render.ui.custom.debug.DebugVisualTileCoordinateUI;
+import nomadrealms.render.ui.custom.debug.DebugUI;
 import nomadrealms.render.vao.shape.HexagonVao;
 
 /**
@@ -65,7 +65,7 @@ public class World {
 
 	private final DrawBatch tileBatch = new DrawBatch();
 
-	private DebugVisualTileCoordinateUI debugUI;
+	private DebugUI debugUI;
 
 	private GameMap map;
 	public Nomad nomad;
@@ -80,7 +80,7 @@ public class World {
 		this.state = state;
 		map = new GameMap(this, mapGenerationStrategy);
 		mapGenerationStrategy.initializeMap(this);
-		this.debugUI = new DebugVisualTileCoordinateUI(this);
+		this.debugUI = new DebugUI(this);
 	}
 
 	public List<Chunk> getVisibleChunks(RenderingEnvironment re) {
@@ -291,7 +291,7 @@ public class World {
 	public void reindex(GameState gameState) {
 		this.state = gameState;
 		this.lookup = new HashActorLookup();
-		this.debugUI = new DebugVisualTileCoordinateUI(this);
+		this.debugUI = new DebugUI(this);
 		map.reindex(this);
 		if (nomad != null) {
 			nomad.reindex(this);
@@ -327,6 +327,10 @@ public class World {
 
 	public ActorLookup lookup() {
 		return lookup;
+	}
+
+	public DebugUI debugUI() {
+		return debugUI;
 	}
 
 	public void particlePool(ParticlePool particlePool) {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/debug/DebugUI.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/debug/DebugUI.java
@@ -2,8 +2,10 @@ package nomadrealms.render.ui.custom.debug;
 
 import static engine.common.colour.Colour.rgb;
 import static engine.visuals.rendering.text.HorizontalAlign.CENTER;
+import static engine.visuals.rendering.text.HorizontalAlign.LEFT;
 import static engine.visuals.rendering.text.TextFormat.textFormat;
 import static engine.visuals.rendering.text.VerticalAlign.MIDDLE;
+import static engine.visuals.rendering.text.VerticalAlign.TOP;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_HORIZONTAL_SPACING;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_RADIUS;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_VERTICAL_SPACING;
@@ -13,22 +15,36 @@ import static nomadrealms.render.vao.shape.HexagonVao.SIDE_LENGTH;
 
 import java.util.List;
 
+import engine.common.time.FPSCounter;
 import nomadrealms.context.game.world.World;
 import nomadrealms.context.game.world.map.area.Chunk;
 import nomadrealms.context.game.world.map.area.Tile;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.ui.UI;
 
-public class DebugVisualTileCoordinateUI implements UI {
+public class DebugUI implements UI {
 
 	private final World world;
+	private final FPSCounter fpsCounter = new FPSCounter(100);
 
-	public DebugVisualTileCoordinateUI(World world) {
+	public DebugUI(World world) {
 		this.world = world;
+	}
+
+	public void update() {
+		fpsCounter.update();
 	}
 
 	@Override
 	public void render(RenderingEnvironment re) {
+		re.textRenderer.render(20, 20,
+				textFormat()
+						.text(String.format("FPS: %.1f", fpsCounter.getFPS()))
+						.font(re.font)
+						.fontSize(20)
+						.colour(rgb(255, 255, 255))
+						.hAlign(LEFT)
+						.vAlign(TOP));
 		List<Chunk> visibleChunks = world.getVisibleChunks(re);
 		float zoom = re.camera.zoom().get();
 		float cameraPosX = re.camera.position().vector().x();


### PR DESCRIPTION
This change centralizes the FPS counter logic into a generic DebugUI class, replacing the specific DebugVisualTileCoordinateUI. It also updates the main game contexts to use this centralized UI for debug information, improving maintainability and consistency.

---
*PR created automatically by Jules for task [812566034681104011](https://jules.google.com/task/812566034681104011) started by @Lunkle*