### PR TITLE
Implement anti-aliased hexagons using SDF shaders

### DIFF
--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
@@ -1,0 +1,98 @@
+package engine.visuals.rendering.geometry;
+
+import engine.common.colour.Colour;
+import engine.common.loader.StringLoader;
+import engine.common.math.Matrix4f;
+import engine.common.math.Vector2f;
+import engine.visuals.builtin.RectangleVertexArrayObject;
+import engine.visuals.lwjgl.GLContext;
+import engine.visuals.lwjgl.render.FragmentShader;
+import engine.visuals.lwjgl.render.Shader;
+import engine.visuals.lwjgl.render.ShaderProgram;
+import engine.visuals.lwjgl.render.VertexArrayObject;
+import engine.visuals.lwjgl.render.VertexShader;
+
+/**
+ * A {@link HexagonRenderer} that renders hexagons with optional outlines.
+ *
+ * @author Lunkle
+ */
+public class HexagonRenderer {
+
+	/**
+	 * The {@link ShaderProgram} to use when rendering hexagons.
+	 */
+	private final ShaderProgram program;
+	private final VertexArrayObject vao;
+
+	private final GLContext glContext;
+
+	public HexagonRenderer(GLContext glContext) {
+		this.glContext = glContext;
+		Shader vertex = new VertexShader()
+				.source(new StringLoader("/shaders/hexagonVertex.glsl").load())
+				.load();
+		Shader fragment = new FragmentShader()
+				.source(new StringLoader("/shaders/hexagonFragment.glsl").load())
+				.load();
+		this.program = new ShaderProgram().attach(vertex, fragment).load();
+		this.vao = RectangleVertexArrayObject.instance();
+	}
+
+	/**
+	 * Renders a hexagon with optional outline in pixel coordinates.
+	 *
+	 * @param x           the x position in pixels of the top left corner of the bounding box
+	 * @param y           the y position in pixels of the top left corner of the bounding box
+	 * @param w           the width in pixels
+	 * @param h           the height in pixels
+	 * @param fillColor   the fill color (rgba)
+	 * @param borderColor the border color (rgba)
+	 * @param borderWidth the border width in pixels (inside)
+	 */
+	public void render(float x, float y, float w, float h, int fillColor, int borderColor, float borderWidth) {
+		Matrix4f matrix4f = new Matrix4f()
+				.translate(-1, 1)
+				.scale(2, -2)
+				.scale(1 / glContext.width(), 1 / glContext.height())
+				.translate(x, y)
+				.scale(w, h);
+		render(matrix4f, w, h, fillColor, borderColor, borderWidth);
+	}
+
+	/**
+	 * Renders a hexagon with no outline in pixel coordinates.
+	 *
+	 * @param x         the x position in pixels of the top left corner of the bounding box
+	 * @param y         the y position in pixels of the top left corner of the bounding box
+	 * @param w         the width in pixels
+	 * @param h         the height in pixels
+	 * @param fillColor the fill color (rgba)
+	 */
+	public void render(float x, float y, float w, float h, int fillColor) {
+		render(x, y, w, h, fillColor, 0, 0);
+	}
+
+	/**
+	 * Renders a hexagon using a transformation matrix and extra parameters.
+	 *
+	 * @param matrix4f    the transformation matrix
+	 * @param w           the width in pixels (for SDF calculations)
+	 * @param h           the height in pixels (for SDF calculations)
+	 * @param fillColor   the fill color (rgba)
+	 * @param borderColor the border color (rgba)
+	 * @param borderWidth the border width in pixels (inside)
+	 */
+	public void render(Matrix4f matrix4f, float w, float h, int fillColor, int borderColor, float borderWidth) {
+		program.use(glContext);
+		program.uniforms()
+				.set("transform", matrix4f)
+				.set("size", new Vector2f(w, h))
+				.set("borderWidth", borderWidth)
+				.set("fillColor", Colour.toRangedVector(fillColor))
+				.set("borderColor", Colour.toRangedVector(borderColor))
+				.complete();
+		vao.draw(glContext);
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -51,7 +51,7 @@ import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.particle.ParticlePool;
 import nomadrealms.render.particle.context.game.CardParticle;
 import nomadrealms.render.particle.spawner.BasicParticleSpawner;
-import nomadrealms.render.vao.shape.HexagonVao;
+import engine.visuals.builtin.RectangleVertexArrayObject;
 
 /**
  * The world is the container for the map (to do: replace map with an object), along with the {@link Actor Actors} and
@@ -105,8 +105,10 @@ public class World {
 	public void renderMap(RenderingEnvironment re) {
 		List<Chunk> visibleChunks = getVisibleChunks(re);
 
-		tileBatch.vao(HexagonVao.instance())
-				.shaderProgram(re.instancedShaderProgram)
+		re.instancedHexagonShaderProgram.set("screenDim", new Vector2f(re.glContext.width(), re.glContext.height()));
+
+		tileBatch.vao(RectangleVertexArrayObject.instance())
+				.shaderProgram(re.instancedHexagonShaderProgram)
 				.glContext(re.glContext);
 		tileBatch.clear();
 		for (Chunk chunk : visibleChunks) {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
@@ -13,6 +13,7 @@ import engine.common.math.Vector2f;
 import engine.common.math.Vector3f;
 import engine.nengen.DrawBatch;
 import engine.serialization.Derializable;
+import engine.visuals.builtin.RectangleVertexArrayObject;
 import engine.visuals.constraint.box.ConstraintPair;
 import engine.visuals.lwjgl.render.meta.DrawFunction;
 import java.util.ArrayList;
@@ -28,7 +29,6 @@ import nomadrealms.context.game.world.map.tile.factory.TileType;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.ui.content.UIContent;
 import nomadrealms.render.ui.custom.tooltip.TooltipDeterminer;
-import nomadrealms.render.vao.shape.HexagonVao;
 
 /**
  * A tile is a hexagon-shaped smallest unit of the map. It contains items and can be walked on, as well as being
@@ -92,10 +92,11 @@ public abstract class Tile implements Target, HasTooltip {
 	public void collectData(DrawBatch batch, RenderingEnvironment re) {
 		Vector2f screenPosition = getScreenPosition(re).vector();
 		float scale = re.camera.zoom().get();
+		float w = TILE_RADIUS * 2 * scale;
+		float h = TILE_RADIUS * 2 * HEIGHT / SIDE_LENGTH * scale;
 		Matrix4f transform = new Matrix4f(
-				screenPosition.x(), screenPosition.y(),
-				TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale,
-				TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale,
+				screenPosition.x() - w * 0.5f, screenPosition.y() - h * 0.5f,
+				w, h,
 				re.glContext);
 		batch.add(transform, color);
 	}
@@ -122,17 +123,15 @@ public abstract class Tile implements Target, HasTooltip {
 	 * @param scale          the scale of the tile // TODO: not implemented
 	 */
 	public void render(RenderingEnvironment re, Vector2f screenPosition, float scale, float radians) {
-		re.defaultShaderProgram
-				.set("color", toRangedVector(color))
-				.set("transform", new Matrix4f(
-						screenPosition.x(), screenPosition.y(),
-						TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale,
-						TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale,
+		float w = TILE_RADIUS * 2 * scale;
+		float h = TILE_RADIUS * 2 * HEIGHT / SIDE_LENGTH * scale;
+		re.hexagonRenderer.render(
+				new Matrix4f(
+						screenPosition.x() - w * 0.5f, screenPosition.y() - h * 0.5f,
+						w, h,
 						re.glContext)
-						.rotate(radians, new Vector3f(0, 0, 1)))
-				.use(
-						new DrawFunction().vao(HexagonVao.instance()).glContext(re.glContext)
-				);
+						.rotate(radians, new Vector3f(0, 0, 1)),
+				w, h, color, 0, 0);
 	}
 
 	public Actor actor() {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/GrassTile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/GrassTile.java
@@ -3,7 +3,9 @@ package nomadrealms.context.game.world.map.tile;
 import static engine.common.colour.Colour.*;
 import static engine.common.java.JavaUtil.map;
 import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
+import static nomadrealms.context.game.world.map.area.Tile.TILE_RADIUS;
 import static nomadrealms.context.game.world.map.tile.factory.TileType.GRASS;
+import static nomadrealms.render.vao.shape.HexagonVao.HEIGHT;
 import static nomadrealms.render.vao.shape.HexagonVao.SIDE_LENGTH;
 
 import static java.lang.String.valueOf;
@@ -14,6 +16,7 @@ import engine.common.math.Matrix4f;
 import engine.common.math.Vector2f;
 import engine.common.math.Vector3f;
 import engine.serialization.Derializable;
+import engine.visuals.builtin.RectangleVertexArrayObject;
 import engine.visuals.constraint.box.ConstraintBox;
 import engine.visuals.constraint.box.ConstraintPair;
 import engine.visuals.lwjgl.render.meta.DrawFunction;
@@ -25,7 +28,6 @@ import nomadrealms.context.game.world.map.area.Tile;
 import nomadrealms.context.game.world.map.area.coordinate.TileCoordinate;
 import nomadrealms.context.game.world.map.tile.factory.TileType;
 import nomadrealms.render.RenderingEnvironment;
-import nomadrealms.render.vao.shape.HexagonVao;
 
 @Derializable
 public class GrassTile extends Tile {
@@ -80,17 +82,21 @@ public class GrassTile extends Tile {
 
 	@Override
 	public void render(RenderingEnvironment re, Vector2f screenPosition, float scale, float radians) {
-		re.texturedShaderProgram
-				.set("color", toRangedVector(color))
+		float w = TILE_RADIUS * 2 * scale;
+		float h = TILE_RADIUS * 2 * HEIGHT / SIDE_LENGTH * scale;
+		re.texturedHexagonShaderProgram
+				.set("fillColor", toRangedVector(color))
+				.set("borderColor", toRangedVector(0))
+				.set("borderWidth", 0f)
+				.set("size", new Vector2f(w, h))
 				.set("textureSampler", 0)
 				.set("transform", new Matrix4f(
-						screenPosition.x(), screenPosition.y(),
-						TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale,
-						TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale,
+						screenPosition.x() - w * 0.5f, screenPosition.y() - h * 0.5f,
+						w, h,
 						re.glContext)
 						.rotate(radians, new Vector3f(0, 0, 1)))
 				.use(
-						new DrawFunction().vao(HexagonVao.instance())
+						new DrawFunction().vao(RectangleVertexArrayObject.instance())
 								.textures(re.imageMap.get("grass_texture"))
 								.glContext(re.glContext)
 				);

--- a/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
@@ -19,6 +19,7 @@ import engine.visuals.lwjgl.render.ShaderProgram;
 import engine.visuals.lwjgl.render.Texture;
 import engine.visuals.lwjgl.render.VertexShader;
 import engine.visuals.lwjgl.render.framebuffer.DefaultFrameBuffer;
+import engine.visuals.rendering.geometry.HexagonRenderer;
 import engine.visuals.rendering.text.GameFont;
 import engine.visuals.rendering.geometry.RectangleRenderer;
 import engine.visuals.rendering.geometry.TriangleRenderer;
@@ -47,6 +48,7 @@ public class RenderingEnvironment {
 	public TextureRenderer textureRenderer;
 	public RectangleRenderer rectangleRenderer;
 	public TriangleRenderer triangleRenderer;
+	public HexagonRenderer hexagonRenderer;
 
 	public VertexShader defaultVertexShader;
 	public FragmentShader defaultFragmentShader;
@@ -54,7 +56,9 @@ public class RenderingEnvironment {
 	public FragmentShader circleFragmentShader;
 	public ShaderProgram circleShaderProgram;
 	public ShaderProgram texturedShaderProgram;
+	public ShaderProgram texturedHexagonShaderProgram;
 	public ShaderProgram instancedShaderProgram;
+	public ShaderProgram instancedHexagonShaderProgram;
 
 	public VertexShader bloomVertexShader;
 	public FragmentShader brightnessFragmentShader;
@@ -108,6 +112,7 @@ public class RenderingEnvironment {
 		textureRenderer = new TextureRenderer(glContext);
 		rectangleRenderer = new RectangleRenderer(glContext);
 		triangleRenderer = new TriangleRenderer(glContext);
+		hexagonRenderer = new HexagonRenderer(glContext);
 	}
 
 	private void loadShaders() {
@@ -124,6 +129,14 @@ public class RenderingEnvironment {
 		instancedShaderProgram = new ShaderProgram().attach(
 				new VertexShader().source(new StringLoader("/shaders/instancedVertex.glsl").load()).load(),
 				new FragmentShader().source(new StringLoader("/shaders/instancedFrag.glsl").load()).load()
+		).load();
+		texturedHexagonShaderProgram = new ShaderProgram().attach(
+				new VertexShader().source(new StringLoader("/shaders/hexagonVertex.glsl").load()).load(),
+				new FragmentShader().source(new StringLoader("/shaders/texturedHexagonFragment.glsl").load()).load()
+		).load();
+		instancedHexagonShaderProgram = new ShaderProgram().attach(
+				new VertexShader().source(new StringLoader("/shaders/instancedHexagonVertex.glsl").load()).load(),
+				new FragmentShader().source(new StringLoader("/shaders/instancedHexagonFragment.glsl").load()).load()
 		).load();
 
 		bloomVertexShader = new VertexShader().source(new StringLoader("/shaders/bloomVertex.glsl").load())

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/geometry/HexagonParticle.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/geometry/HexagonParticle.java
@@ -10,7 +10,6 @@ import engine.visuals.constraint.box.ConstraintBox;
 import engine.visuals.lwjgl.render.meta.DrawFunction;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.particle.Particle;
-import nomadrealms.render.vao.shape.HexagonVao;
 
 public class HexagonParticle extends Particle {
 
@@ -23,10 +22,9 @@ public class HexagonParticle extends Particle {
 
 	@Override
 	public void render(RenderingEnvironment re) {
-		re.defaultShaderProgram
-				.set("color", toRangedVector(color))
-				.set("transform", new Matrix4f(box(), re.glContext).rotate(rotation().get(), new Vector3f(0, 0, 1)))
-				.use(new DrawFunction().vao(HexagonVao.instance()).glContext(re.glContext));
+		re.hexagonRenderer.render(
+				new Matrix4f(box(), re.glContext).rotate(rotation().get(), new Vector3f(0, 0, 1)),
+				box().w().get(), box().h().get(), color, 0, 0);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/Arrow.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/Arrow.java
@@ -4,6 +4,7 @@ import static engine.common.colour.Colour.rgb;
 import static engine.common.colour.Colour.toRangedVector;
 import static engine.common.math.Matrix4f.screenToPixel;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_RADIUS;
+import static nomadrealms.render.vao.shape.HexagonVao.HEIGHT;
 import static nomadrealms.render.vao.shape.HexagonVao.SIDE_LENGTH;
 
 import engine.common.math.Matrix4f;
@@ -14,7 +15,6 @@ import engine.visuals.lwjgl.GLContext;
 import engine.visuals.lwjgl.render.meta.DrawFunction;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.ui.UI;
-import nomadrealms.render.vao.shape.HexagonVao;
 
 public class Arrow implements UI {
 
@@ -35,17 +35,15 @@ public class Arrow implements UI {
 	@Override
 	public void render(RenderingEnvironment re) {
 		if (targetCenter != null) {
-			re.defaultShaderProgram
-					.set("color", toRangedVector(rgb(255, 255, 0)))
-					.set("transform", new Matrix4f(
-							targetCenter.x().get(), targetCenter.y().get(),
-							TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get(),
-							TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get(),
-							re.glContext))
-					.use(new DrawFunction()
-							.vao(HexagonVao.instance())
-							.glContext(re.glContext)
-					);
+			float scale = re.camera.zoom().get();
+			float w = TILE_RADIUS * 2 * scale;
+			float h = TILE_RADIUS * 2 * HEIGHT / SIDE_LENGTH * scale;
+			re.hexagonRenderer.render(
+					new Matrix4f(
+							targetCenter.x().get() - w * 0.5f, targetCenter.y().get() - h * 0.5f,
+							w, h,
+							re.glContext),
+					w, h, rgb(255, 255, 0), 0, 0);
 		}
 
 		re.defaultShaderProgram

--- a/nomad-realms/src/main/resources/shaders/hexagonFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/hexagonFragment.glsl
@@ -1,0 +1,43 @@
+#version 330 core
+
+in vec2 texCoord;
+out vec4 fragColor;
+
+uniform vec2 size;          // hexagon bounding box dimensions (w, h) in pixels
+uniform float borderWidth;  // border width in pixels (inside)
+uniform vec4 fillColor;     // fill color (rgba)
+uniform vec4 borderColor;   // border color (rgba)
+
+float sdHexagon( in vec2 p, in float r )
+{
+    const vec3 k = vec3(-0.866025404,0.5,0.577350269);
+    p = abs(p);
+    p -= 2.0*min(dot(k.xy,p),0.0)*k.xy;
+    p -= vec2(clamp(p.x, -k.z*r, k.z*r), r);
+    return length(p)*sign(p.y);
+}
+
+void main() {
+    // texCoord is from [0, 1] across the entire rectangle.
+    // Convert to pixel space centered at (0, 0).
+    vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
+
+    // The game uses flat-topped hexagons. sdHexagon is pointy-topped.
+    // We swap x and y to get a flat-topped hexagon.
+    float d = sdHexagon(p.yx, size.x * 0.5);
+
+    float smoothing = 1.0;
+
+    float outerMask = smoothstep(0.0, smoothing, d);
+    float borderEdge = -borderWidth;
+    float borderMask = smoothstep(borderEdge, borderEdge + smoothing, d);
+
+    vec4 color = mix(fillColor, borderColor, borderMask);
+    color.a *= (1.0 - outerMask);
+
+    if (color.a <= 0.0) {
+        discard;
+    }
+
+    fragColor = color;
+}

--- a/nomad-realms/src/main/resources/shaders/hexagonVertex.glsl
+++ b/nomad-realms/src/main/resources/shaders/hexagonVertex.glsl
@@ -1,0 +1,13 @@
+#version 330 core
+
+layout(location = 0) in vec3 position;
+layout(location = 1) in vec2 uv;
+
+out vec2 texCoord;
+
+uniform mat4 transform;
+
+void main() {
+    gl_Position = transform * vec4(position, 1.0);
+    texCoord = uv;
+}

--- a/nomad-realms/src/main/resources/shaders/instancedHexagonFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/instancedHexagonFragment.glsl
@@ -1,0 +1,38 @@
+#version 330 core
+
+in vec2 texCoord;
+in vec4 color;
+in vec2 size;
+out vec4 fragColor;
+
+uniform vec2 screenDim;
+
+float sdHexagon( in vec2 p, in float r )
+{
+    const vec3 k = vec3(-0.866025404,0.5,0.577350269);
+    p = abs(p);
+    p -= 2.0*min(dot(k.xy,p),0.0)*k.xy;
+    p -= vec2(clamp(p.x, -k.z*r, k.z*r), r);
+    return length(p)*sign(p.y);
+}
+
+void main() {
+    // size is passed in normalized screen coordinates (0-2 range for full screen)
+    // we convert to pixels for SDF
+    vec2 pixelSize = size * screenDim * 0.5;
+    vec2 p = (texCoord - vec2(0.5, 0.5)) * pixelSize;
+
+    float d = sdHexagon(p.yx, pixelSize.x * 0.5);
+
+    float smoothing = 1.0;
+    float outerMask = smoothstep(0.0, smoothing, d);
+
+    vec4 outColor = color;
+    outColor.a *= (1.0 - outerMask);
+
+    if (outColor.a <= 0.0) {
+        discard;
+    }
+
+    fragColor = outColor;
+}

--- a/nomad-realms/src/main/resources/shaders/instancedHexagonVertex.glsl
+++ b/nomad-realms/src/main/resources/shaders/instancedHexagonVertex.glsl
@@ -1,0 +1,27 @@
+#version 330 core
+
+layout(location = 0) in vec3 position;
+layout(location = 1) in vec2 uv;
+layout(location = 2) in mat4 instanceTransform;
+layout(location = 6) in vec4 instanceColor;
+
+out vec2 texCoord;
+out vec4 color;
+out vec2 size;
+
+void main() {
+    gl_Position = instanceTransform * vec4(position, 1.0);
+    texCoord = uv;
+    color = instanceColor;
+
+    // Calculate size in pixels from the transformation matrix
+    // We assume the transform is mostly scale and translation
+    float w = length(vec3(instanceTransform[0][0], instanceTransform[0][1], instanceTransform[0][2]));
+    float h = length(vec3(instanceTransform[1][0], instanceTransform[1][1], instanceTransform[1][2]));
+    // instanceTransform maps from unit quad [0, 1] to screen coordinates [-1, 1]
+    // We need pixel dimensions for SDF.
+    // Screen coords range is 2. So we multiply by 0.5 to get normalized screen size,
+    // then we'll need to multiply by screen dimensions in fragment shader or here.
+    // Alternatively, just pass it through and use screen size in frag.
+    size = vec2(w, h);
+}

--- a/nomad-realms/src/main/resources/shaders/texturedHexagonFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/texturedHexagonFragment.glsl
@@ -1,0 +1,39 @@
+#version 330 core
+
+in vec2 texCoord;
+out vec4 fragColor;
+
+uniform vec2 size;          // hexagon bounding box dimensions (w, h) in pixels
+uniform float borderWidth;  // border width in pixels (inside)
+uniform vec4 fillColor;     // fill color (rgba)
+uniform vec4 borderColor;   // border color (rgba)
+uniform sampler2D textureSampler;
+
+float sdHexagon( in vec2 p, in float r )
+{
+    const vec3 k = vec3(-0.866025404,0.5,0.577350269);
+    p = abs(p);
+    p -= 2.0*min(dot(k.xy,p),0.0)*k.xy;
+    p -= vec2(clamp(p.x, -k.z*r, k.z*r), r);
+    return length(p)*sign(p.y);
+}
+
+void main() {
+    vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
+    float d = sdHexagon(p.yx, size.x * 0.5);
+
+    float smoothing = 1.0;
+    float outerMask = smoothstep(0.0, smoothing, d);
+    float borderEdge = -borderWidth;
+    float borderMask = smoothstep(borderEdge, borderEdge + smoothing, d);
+
+    vec4 texColor = texture(textureSampler, texCoord);
+    vec4 color = mix(fillColor * texColor, borderColor, borderMask);
+    color.a *= (1.0 - outerMask);
+
+    if (color.a <= 0.0) {
+        discard;
+    }
+
+    fragColor = color;
+}


### PR DESCRIPTION
The changes replace the previously aliased polygonal hexagon rendering with a modern shader-based approach using Signed Distance Fields (SDF). This provides smooth, anti-aliased edges for all hexagons in the game, including map tiles, UI elements (arrows), and particles.

Key changes:
- New GLSL shaders for hexagons using an SDF function to define the shape and smoothstep for anti-aliasing.
- HexagonRenderer class added to the engine's geometry rendering package.
- Map tiles now use instanced SDF rendering, ensuring crisp edges regardless of zoom or resolution.
- Textured hexagons (e.g., grass tiles) are now anti-aliased.
- Removed dependencies on the aliased HexagonVao in updated components.

---
*PR created automatically by Jules for task [4539165885723154903](https://jules.google.com/task/4539165885723154903) started by @Lunkle*