### PR TITLE
Implement Anti-Aliased Hexagons and Circles

### DIFF
--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/CircleRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/CircleRenderer.java
@@ -1,0 +1,55 @@
+package engine.visuals.rendering.geometry;
+
+import engine.common.colour.Colour;
+import engine.common.loader.StringLoader;
+import engine.common.math.Matrix4f;
+import engine.common.math.Vector2f;
+import engine.visuals.builtin.RectangleVertexArrayObject;
+import engine.visuals.lwjgl.GLContext;
+import engine.visuals.lwjgl.render.FragmentShader;
+import engine.visuals.lwjgl.render.Shader;
+import engine.visuals.lwjgl.render.ShaderProgram;
+import engine.visuals.lwjgl.render.VertexArrayObject;
+
+/**
+ * A {@link CircleRenderer} that renders circles with anti-aliasing.
+ *
+ * @author Lunkle
+ */
+public class CircleRenderer {
+
+	private static final float PADDING = 0.1f;
+
+	private final ShaderProgram program;
+	private final VertexArrayObject vao;
+	private final GLContext glContext;
+
+	public CircleRenderer(GLContext glContext, Shader vertexShader) {
+		this.glContext = glContext;
+		this.vao = RectangleVertexArrayObject.instance();
+		Shader fragment = new FragmentShader()
+				.source(new StringLoader("/shaders/circleFrag.glsl").load())
+				.load();
+		this.program = new ShaderProgram().attach(vertexShader, fragment).load();
+	}
+
+	/**
+	 * Renders a circle using a transformation matrix and extra parameters.
+	 */
+	public void render(Matrix4f matrix4f, float size, int color) {
+		float ps = size * (1 + PADDING);
+		Matrix4f paddedMatrix = new Matrix4f(matrix4f)
+				.translate(0.5f, 0.5f)
+				.scale(1 + PADDING, 1 + PADDING)
+				.translate(-0.5f, -0.5f);
+		program.use(glContext);
+		program.uniforms()
+				.set("transform", paddedMatrix)
+				.set("size", new Vector2f(ps, ps))
+				.set("radius", size * 0.5f)
+				.set("color", Colour.toRangedVector(color))
+				.complete();
+		vao.draw(glContext);
+	}
+
+}

--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
@@ -10,6 +10,7 @@ import engine.visuals.lwjgl.GLContext;
 import engine.visuals.lwjgl.render.FragmentShader;
 import engine.visuals.lwjgl.render.Shader;
 import engine.visuals.lwjgl.render.ShaderProgram;
+import engine.visuals.lwjgl.render.Texture;
 import engine.visuals.lwjgl.render.VertexArrayObject;
 import engine.visuals.lwjgl.render.VertexShader;
 
@@ -20,16 +21,17 @@ import engine.visuals.lwjgl.render.VertexShader;
  */
 public class HexagonRenderer {
 
-	/**
-	 * The {@link ShaderProgram} to use when rendering hexagons.
-	 */
 	private final ShaderProgram program;
-	private final VertexArrayObject vao;
+	private final ShaderProgram texturedProgram;
+	private final ShaderProgram instancedProgram;
 
+	private final VertexArrayObject vao;
 	private final GLContext glContext;
 
 	public HexagonRenderer(GLContext glContext) {
 		this.glContext = glContext;
+		this.vao = RectangleVertexArrayObject.instance();
+
 		Shader vertex = new VertexShader()
 				.source(new StringLoader("/shaders/hexagonVertex.glsl").load())
 				.load();
@@ -37,19 +39,23 @@ public class HexagonRenderer {
 				.source(new StringLoader("/shaders/hexagonFragment.glsl").load())
 				.load();
 		this.program = new ShaderProgram().attach(vertex, fragment).load();
-		this.vao = RectangleVertexArrayObject.instance();
+
+		Shader texturedFragment = new FragmentShader()
+				.source(new StringLoader("/shaders/texturedHexagonFragment.glsl").load())
+				.load();
+		this.texturedProgram = new ShaderProgram().attach(vertex, texturedFragment).load();
+
+		Shader instancedVertex = new VertexShader()
+				.source(new StringLoader("/shaders/instancedHexagonVertex.glsl").load())
+				.load();
+		Shader instancedFragment = new FragmentShader()
+				.source(new StringLoader("/shaders/instancedHexagonFrag.glsl").load())
+				.load();
+		this.instancedProgram = new ShaderProgram().attach(instancedVertex, instancedFragment).load();
 	}
 
 	/**
 	 * Renders a hexagon with optional outline in pixel coordinates.
-	 *
-	 * @param x           the x position in pixels of the top left corner of the bounding box
-	 * @param y           the y position in pixels of the top left corner of the bounding box
-	 * @param w           the width in pixels
-	 * @param h           the height in pixels
-	 * @param fillColor   the fill color (rgba)
-	 * @param borderColor the border color (rgba)
-	 * @param borderWidth the border width in pixels (inside)
 	 */
 	public void render(float x, float y, float w, float h, int fillColor, int borderColor, float borderWidth) {
 		Matrix4f matrix4f = new Matrix4f()
@@ -66,27 +72,7 @@ public class HexagonRenderer {
 	}
 
 	/**
-	 * Renders a hexagon with no outline in pixel coordinates.
-	 *
-	 * @param x         the x position in pixels of the top left corner of the bounding box
-	 * @param y         the y position in pixels of the top left corner of the bounding box
-	 * @param w         the width in pixels
-	 * @param h         the height in pixels
-	 * @param fillColor the fill color (rgba)
-	 */
-	public void render(float x, float y, float w, float h, int fillColor) {
-		render(x, y, w, h, fillColor, 0, 0);
-	}
-
-	/**
 	 * Renders a hexagon using a transformation matrix and extra parameters.
-	 *
-	 * @param matrix4f    the transformation matrix
-	 * @param w           the width in pixels (for SDF calculations)
-	 * @param h           the height in pixels (for SDF calculations)
-	 * @param fillColor   the fill color (rgba)
-	 * @param borderColor the border color (rgba)
-	 * @param borderWidth the border width in pixels (inside)
 	 */
 	public void render(Matrix4f matrix4f, float w, float h, int fillColor, int borderColor, float borderWidth) {
 		program.use(glContext);
@@ -98,6 +84,25 @@ public class HexagonRenderer {
 				.set("borderColor", Colour.toRangedVector(borderColor))
 				.complete();
 		vao.draw(glContext);
+	}
+
+	/**
+	 * Renders a textured hexagon using a transformation matrix and extra parameters.
+	 */
+	public void renderTextured(Matrix4f matrix4f, float w, float h, int color, Texture texture) {
+		texturedProgram.use(glContext);
+		texturedProgram.uniforms()
+				.set("transform", matrix4f)
+				.set("size", new Vector2f(w, h))
+				.set("color", Colour.toRangedVector(color))
+				.set("textureSampler", 0)
+				.complete();
+		texture.bind(glContext, 0);
+		vao.draw(glContext);
+	}
+
+	public ShaderProgram instancedProgram() {
+		return instancedProgram;
 	}
 
 }

--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
@@ -83,7 +83,7 @@ public class HexagonRenderer {
 				.translate(0.5f, 0.5f)
 				.scale(1 + PADDING, 1 + PADDING)
 				.translate(-0.5f, -0.5f);
-		renderRaw(paddedMatrix, pw, ph, w * 0.5f, fillColor, borderColor, borderWidth);
+		renderRaw(paddedMatrix, pw, ph, h * 0.5f, fillColor, borderColor, borderWidth);
 	}
 
 	/**
@@ -116,7 +116,7 @@ public class HexagonRenderer {
 		texturedProgram.uniforms()
 				.set("transform", paddedMatrix)
 				.set("size", new Vector2f(pw, ph))
-				.set("radius", w * 0.5f)
+				.set("radius", h * 0.5f)
 				.set("color", Colour.toRangedVector(color))
 				.set("textureSampler", 0)
 				.complete();
@@ -128,7 +128,7 @@ public class HexagonRenderer {
 		instancedProgram.use(glContext);
 		instancedProgram.uniforms()
 				.set("size", new Vector2f(w * (1 + PADDING), h * (1 + PADDING)))
-				.set("radius", w * 0.5f)
+				.set("radius", h * 0.5f)
 				.complete();
 	}
 

--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
@@ -21,6 +21,8 @@ import engine.visuals.lwjgl.render.VertexShader;
  */
 public class HexagonRenderer {
 
+	private static final float PADDING = 0.1f;
+
 	private final ShaderProgram program;
 	private final ShaderProgram texturedProgram;
 	private final ShaderProgram instancedProgram;
@@ -58,16 +60,13 @@ public class HexagonRenderer {
 	 * Renders a hexagon with optional outline in pixel coordinates.
 	 */
 	public void render(float x, float y, float w, float h, int fillColor, int borderColor, float borderWidth) {
-		float padding = 0.1f;
-		float pw = w * (1 + padding);
-		float ph = h * (1 + padding);
 		Matrix4f matrix4f = new Matrix4f()
 				.translate(-1, 1)
 				.scale(2, -2)
 				.scale(1 / glContext.width(), 1 / glContext.height())
-				.translate(x - (pw - w) * 0.5f, y - (ph - h) * 0.5f)
-				.scale(pw, ph);
-		render(matrix4f, pw, ph, h * 0.5f, fillColor, borderColor, borderWidth);
+				.translate(x, y)
+				.scale(w, h);
+		render(matrix4f, w, h, fillColor, borderColor, borderWidth);
 	}
 
 	public void render(ConstraintBox constraintBox, int fillColor, int borderColor, float borderWidth) {
@@ -75,13 +74,26 @@ public class HexagonRenderer {
 	}
 
 	/**
-	 * Renders a hexagon using a transformation matrix and extra parameters.
+	 * Renders a hexagon using a transformation matrix (for the unpadded shape) and extra parameters.
 	 */
-	public void render(Matrix4f matrix4f, float w, float h, float radius, int fillColor, int borderColor, float borderWidth) {
+	public void render(Matrix4f matrix4f, float w, float h, int fillColor, int borderColor, float borderWidth) {
+		float pw = w * (1 + PADDING);
+		float ph = h * (1 + PADDING);
+		Matrix4f paddedMatrix = new Matrix4f(matrix4f)
+				.translate(0.5f, 0.5f)
+				.scale(1 + PADDING, 1 + PADDING)
+				.translate(-0.5f, -0.5f);
+		renderRaw(paddedMatrix, pw, ph, h * 0.5f, fillColor, borderColor, borderWidth);
+	}
+
+	/**
+	 * Renders a hexagon using a pre-padded transformation matrix and raw parameters.
+	 */
+	public void renderRaw(Matrix4f matrix4f, float pw, float ph, float radius, int fillColor, int borderColor, float borderWidth) {
 		program.use(glContext);
 		program.uniforms()
 				.set("transform", matrix4f)
-				.set("size", new Vector2f(w, h))
+				.set("size", new Vector2f(pw, ph))
 				.set("radius", radius)
 				.set("borderWidth", borderWidth)
 				.set("fillColor", Colour.toRangedVector(fillColor))
@@ -91,14 +103,20 @@ public class HexagonRenderer {
 	}
 
 	/**
-	 * Renders a textured hexagon using a transformation matrix and extra parameters.
+	 * Renders a textured hexagon using a transformation matrix (for the unpadded shape) and extra parameters.
 	 */
-	public void renderTextured(Matrix4f matrix4f, float w, float h, float radius, int color, Texture texture) {
+	public void renderTextured(Matrix4f matrix4f, float w, float h, int color, Texture texture) {
+		float pw = w * (1 + PADDING);
+		float ph = h * (1 + PADDING);
+		Matrix4f paddedMatrix = new Matrix4f(matrix4f)
+				.translate(0.5f, 0.5f)
+				.scale(1 + PADDING, 1 + PADDING)
+				.translate(-0.5f, -0.5f);
 		texturedProgram.use(glContext);
 		texturedProgram.uniforms()
-				.set("transform", matrix4f)
-				.set("size", new Vector2f(w, h))
-				.set("radius", radius)
+				.set("transform", paddedMatrix)
+				.set("size", new Vector2f(pw, ph))
+				.set("radius", h * 0.5f)
 				.set("color", Colour.toRangedVector(color))
 				.set("textureSampler", 0)
 				.complete();
@@ -106,8 +124,22 @@ public class HexagonRenderer {
 		vao.draw(glContext);
 	}
 
+	public void prepareInstanced(float w, float h) {
+		instancedProgram.use(glContext);
+		instancedProgram.uniforms()
+				.set("size", new Vector2f(w * (1 + PADDING), h * (1 + PADDING)))
+				.set("radius", h * 0.5f);
+	}
+
 	public ShaderProgram instancedProgram() {
 		return instancedProgram;
+	}
+
+	public Matrix4f padTransform(Matrix4f transform) {
+		return new Matrix4f(transform)
+				.translate(0.5f, 0.5f)
+				.scale(1 + PADDING, 1 + PADDING)
+				.translate(-0.5f, -0.5f);
 	}
 
 }

--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
@@ -83,7 +83,7 @@ public class HexagonRenderer {
 				.translate(0.5f, 0.5f)
 				.scale(1 + PADDING, 1 + PADDING)
 				.translate(-0.5f, -0.5f);
-		renderRaw(paddedMatrix, pw, ph, h * 0.5f, fillColor, borderColor, borderWidth);
+		renderRaw(paddedMatrix, pw, ph, w * 0.5f, fillColor, borderColor, borderWidth);
 	}
 
 	/**
@@ -116,7 +116,7 @@ public class HexagonRenderer {
 		texturedProgram.uniforms()
 				.set("transform", paddedMatrix)
 				.set("size", new Vector2f(pw, ph))
-				.set("radius", h * 0.5f)
+				.set("radius", w * 0.5f)
 				.set("color", Colour.toRangedVector(color))
 				.set("textureSampler", 0)
 				.complete();
@@ -128,7 +128,8 @@ public class HexagonRenderer {
 		instancedProgram.use(glContext);
 		instancedProgram.uniforms()
 				.set("size", new Vector2f(w * (1 + PADDING), h * (1 + PADDING)))
-				.set("radius", h * 0.5f);
+				.set("radius", w * 0.5f)
+				.complete();
 	}
 
 	public ShaderProgram instancedProgram() {

--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
@@ -1,0 +1,103 @@
+package engine.visuals.rendering.geometry;
+
+import engine.common.colour.Colour;
+import engine.common.loader.StringLoader;
+import engine.common.math.Matrix4f;
+import engine.common.math.Vector2f;
+import engine.visuals.builtin.RectangleVertexArrayObject;
+import engine.visuals.constraint.box.ConstraintBox;
+import engine.visuals.lwjgl.GLContext;
+import engine.visuals.lwjgl.render.FragmentShader;
+import engine.visuals.lwjgl.render.Shader;
+import engine.visuals.lwjgl.render.ShaderProgram;
+import engine.visuals.lwjgl.render.VertexArrayObject;
+import engine.visuals.lwjgl.render.VertexShader;
+
+/**
+ * A {@link HexagonRenderer} that renders hexagons with optional outlines.
+ *
+ * @author Lunkle
+ */
+public class HexagonRenderer {
+
+	/**
+	 * The {@link ShaderProgram} to use when rendering hexagons.
+	 */
+	private final ShaderProgram program;
+	private final VertexArrayObject vao;
+
+	private final GLContext glContext;
+
+	public HexagonRenderer(GLContext glContext) {
+		this.glContext = glContext;
+		Shader vertex = new VertexShader()
+				.source(new StringLoader("/shaders/hexagonVertex.glsl").load())
+				.load();
+		Shader fragment = new FragmentShader()
+				.source(new StringLoader("/shaders/hexagonFragment.glsl").load())
+				.load();
+		this.program = new ShaderProgram().attach(vertex, fragment).load();
+		this.vao = RectangleVertexArrayObject.instance();
+	}
+
+	/**
+	 * Renders a hexagon with optional outline in pixel coordinates.
+	 *
+	 * @param x           the x position in pixels of the top left corner of the bounding box
+	 * @param y           the y position in pixels of the top left corner of the bounding box
+	 * @param w           the width in pixels
+	 * @param h           the height in pixels
+	 * @param fillColor   the fill color (rgba)
+	 * @param borderColor the border color (rgba)
+	 * @param borderWidth the border width in pixels (inside)
+	 */
+	public void render(float x, float y, float w, float h, int fillColor, int borderColor, float borderWidth) {
+		Matrix4f matrix4f = new Matrix4f()
+				.translate(-1, 1)
+				.scale(2, -2)
+				.scale(1 / glContext.width(), 1 / glContext.height())
+				.translate(x, y)
+				.scale(w, h);
+		render(matrix4f, w, h, fillColor, borderColor, borderWidth);
+	}
+
+	public void render(ConstraintBox constraintBox, int fillColor, int borderColor, float borderWidth) {
+		render(constraintBox.x().get(), constraintBox.y().get(), constraintBox.w().get(), constraintBox.h().get(), fillColor, borderColor, borderWidth);
+	}
+
+	/**
+	 * Renders a hexagon with no outline in pixel coordinates.
+	 *
+	 * @param x         the x position in pixels of the top left corner of the bounding box
+	 * @param y         the y position in pixels of the top left corner of the bounding box
+	 * @param w         the width in pixels
+	 * @param h         the height in pixels
+	 * @param fillColor the fill color (rgba)
+	 */
+	public void render(float x, float y, float w, float h, int fillColor) {
+		render(x, y, w, h, fillColor, 0, 0);
+	}
+
+	/**
+	 * Renders a hexagon using a transformation matrix and extra parameters.
+	 *
+	 * @param matrix4f    the transformation matrix
+	 * @param w           the width in pixels (for SDF calculations)
+	 * @param h           the height in pixels (for SDF calculations)
+	 * @param fillColor   the fill color (rgba)
+	 * @param borderColor the border color (rgba)
+	 * @param borderWidth the border width in pixels (inside)
+	 */
+	public void render(Matrix4f matrix4f, float w, float h, int fillColor, int borderColor, float borderWidth) {
+		program.use(glContext);
+		program.uniforms()
+				.set("transform", matrix4f)
+				.set("size", new Vector2f(w, h))
+				.set("borderWidth", borderWidth)
+				.set("fillColor", Colour.toRangedVector(fillColor))
+				.set("borderColor", Colour.toRangedVector(borderColor))
+				.complete();
+		vao.draw(glContext);
+	}
+
+}

--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
@@ -58,13 +58,16 @@ public class HexagonRenderer {
 	 * Renders a hexagon with optional outline in pixel coordinates.
 	 */
 	public void render(float x, float y, float w, float h, int fillColor, int borderColor, float borderWidth) {
+		float padding = 0.1f;
+		float pw = w * (1 + padding);
+		float ph = h * (1 + padding);
 		Matrix4f matrix4f = new Matrix4f()
 				.translate(-1, 1)
 				.scale(2, -2)
 				.scale(1 / glContext.width(), 1 / glContext.height())
-				.translate(x, y)
-				.scale(w, h);
-		render(matrix4f, w, h, fillColor, borderColor, borderWidth);
+				.translate(x - (pw - w) * 0.5f, y - (ph - h) * 0.5f)
+				.scale(pw, ph);
+		render(matrix4f, pw, ph, h * 0.5f, fillColor, borderColor, borderWidth);
 	}
 
 	public void render(ConstraintBox constraintBox, int fillColor, int borderColor, float borderWidth) {
@@ -74,11 +77,12 @@ public class HexagonRenderer {
 	/**
 	 * Renders a hexagon using a transformation matrix and extra parameters.
 	 */
-	public void render(Matrix4f matrix4f, float w, float h, int fillColor, int borderColor, float borderWidth) {
+	public void render(Matrix4f matrix4f, float w, float h, float radius, int fillColor, int borderColor, float borderWidth) {
 		program.use(glContext);
 		program.uniforms()
 				.set("transform", matrix4f)
 				.set("size", new Vector2f(w, h))
+				.set("radius", radius)
 				.set("borderWidth", borderWidth)
 				.set("fillColor", Colour.toRangedVector(fillColor))
 				.set("borderColor", Colour.toRangedVector(borderColor))
@@ -89,11 +93,12 @@ public class HexagonRenderer {
 	/**
 	 * Renders a textured hexagon using a transformation matrix and extra parameters.
 	 */
-	public void renderTextured(Matrix4f matrix4f, float w, float h, int color, Texture texture) {
+	public void renderTextured(Matrix4f matrix4f, float w, float h, float radius, int color, Texture texture) {
 		texturedProgram.use(glContext);
 		texturedProgram.uniforms()
 				.set("transform", matrix4f)
 				.set("size", new Vector2f(w, h))
+				.set("radius", radius)
 				.set("color", Colour.toRangedVector(color))
 				.set("textureSampler", 0)
 				.complete();

--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
@@ -60,12 +60,7 @@ public class HexagonRenderer {
 	 * Renders a hexagon with optional outline in pixel coordinates.
 	 */
 	public void render(float x, float y, float w, float h, int fillColor, int borderColor, float borderWidth) {
-		Matrix4f matrix4f = new Matrix4f()
-				.translate(-1, 1)
-				.scale(2, -2)
-				.scale(1 / glContext.width(), 1 / glContext.height())
-				.translate(x, y)
-				.scale(w, h);
+		Matrix4f matrix4f = new Matrix4f(x, y, w, h, glContext);
 		render(matrix4f, w, h, fillColor, borderColor, borderWidth);
 	}
 

--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
@@ -83,7 +83,7 @@ public class HexagonRenderer {
 				.translate(0.5f, 0.5f)
 				.scale(1 + PADDING, 1 + PADDING)
 				.translate(-0.5f, -0.5f);
-		renderRaw(paddedMatrix, pw, ph, h * 0.5f, fillColor, borderColor, borderWidth);
+		renderRaw(paddedMatrix, pw, ph, w * 0.5f, fillColor, borderColor, borderWidth);
 	}
 
 	/**
@@ -116,7 +116,7 @@ public class HexagonRenderer {
 		texturedProgram.uniforms()
 				.set("transform", paddedMatrix)
 				.set("size", new Vector2f(pw, ph))
-				.set("radius", h * 0.5f)
+				.set("radius", w * 0.5f)
 				.set("color", Colour.toRangedVector(color))
 				.set("textureSampler", 0)
 				.complete();
@@ -128,7 +128,7 @@ public class HexagonRenderer {
 		instancedProgram.use(glContext);
 		instancedProgram.uniforms()
 				.set("size", new Vector2f(w * (1 + PADDING), h * (1 + PADDING)))
-				.set("radius", h * 0.5f)
+				.set("radius", w * 0.5f)
 				.complete();
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -107,14 +107,15 @@ public class World {
 		List<Chunk> visibleChunks = getVisibleChunks(re);
 
 		tileBatch.vao(RectangleVertexArrayObject.instance())
-				.shaderProgram(re.instancedHexagonShaderProgram)
+				.shaderProgram(re.hexagonRenderer.instancedProgram())
 				.glContext(re.glContext);
 		tileBatch.clear();
 		for (Chunk chunk : visibleChunks) {
 			chunk.collectData(tileBatch, re);
 		}
-		float size = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get();
-		re.instancedHexagonShaderProgram.set("size", new Vector2f(size, size));
+		float height = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get();
+		float width = height / SIDE_LENGTH;
+		re.hexagonRenderer.instancedProgram().set("size", new Vector2f(width, height));
 		tileBatch.draw();
 
 		for (Chunk chunk : visibleChunks) {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -113,8 +113,8 @@ public class World {
 		for (Chunk chunk : visibleChunks) {
 			chunk.collectData(tileBatch, re);
 		}
-		float height = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get();
-		float width = height / SIDE_LENGTH;
+		float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * re.camera.zoom().get();
+		float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get();
 		re.hexagonRenderer.instancedProgram().set("size", new Vector2f(width, height));
 		tileBatch.draw();
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -49,6 +49,7 @@ import nomadrealms.context.game.zone.Deck;
 import nomadrealms.event.game.effect.EffectContext;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.particle.ParticlePool;
+import engine.visuals.builtin.RectangleVertexArrayObject;
 import nomadrealms.render.particle.context.game.CardParticle;
 import nomadrealms.render.particle.spawner.BasicParticleSpawner;
 import nomadrealms.render.vao.shape.HexagonVao;
@@ -105,13 +106,15 @@ public class World {
 	public void renderMap(RenderingEnvironment re) {
 		List<Chunk> visibleChunks = getVisibleChunks(re);
 
-		tileBatch.vao(HexagonVao.instance())
-				.shaderProgram(re.instancedShaderProgram)
+		tileBatch.vao(RectangleVertexArrayObject.instance())
+				.shaderProgram(re.instancedHexagonShaderProgram)
 				.glContext(re.glContext);
 		tileBatch.clear();
 		for (Chunk chunk : visibleChunks) {
 			chunk.collectData(tileBatch, re);
 		}
+		float size = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get();
+		re.instancedHexagonShaderProgram.set("size", new Vector2f(size, size));
 		tileBatch.draw();
 
 		for (Chunk chunk : visibleChunks) {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -115,7 +115,12 @@ public class World {
 		}
 		float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * re.camera.zoom().get();
 		float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get();
-		re.hexagonRenderer.instancedProgram().set("size", new Vector2f(width, height));
+		float padding = 0.1f;
+		float pw = width * (1 + padding);
+		float ph = height * (1 + padding);
+		re.hexagonRenderer.instancedProgram()
+				.set("size", new Vector2f(pw, ph))
+				.set("radius", height * 0.5f);
 		tileBatch.draw();
 
 		for (Chunk chunk : visibleChunks) {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -115,12 +115,7 @@ public class World {
 		}
 		float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * re.camera.zoom().get();
 		float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get();
-		float padding = 0.1f;
-		float pw = width * (1 + padding);
-		float ph = height * (1 + padding);
-		re.hexagonRenderer.instancedProgram()
-				.set("size", new Vector2f(pw, ph))
-				.set("radius", height * 0.5f);
+		re.hexagonRenderer.prepareInstanced(width, height);
 		tileBatch.draw();
 
 		for (Chunk chunk : visibleChunks) {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
@@ -93,11 +93,12 @@ public abstract class Tile implements Target, HasTooltip {
 	public void collectData(DrawBatch batch, RenderingEnvironment re) {
 		Vector2f screenPosition = getScreenPosition(re).vector();
 		float scale = re.camera.zoom().get();
-		float size = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
+		float height = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
+		float width = height / SIDE_LENGTH;
 		Matrix4f transform = new Matrix4f(
-				screenPosition.x() - size * 0.5f, screenPosition.y() - size * 0.5f,
-				size,
-				size,
+				screenPosition.x() - width * 0.5f, screenPosition.y() - height * 0.5f,
+				width,
+				height,
 				re.glContext);
 		batch.add(transform, color);
 	}
@@ -124,17 +125,18 @@ public abstract class Tile implements Target, HasTooltip {
 	 * @param scale          the scale of the tile // TODO: not implemented
 	 */
 	public void render(RenderingEnvironment re, Vector2f screenPosition, float scale, float radians) {
-		float size = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
+		float height = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
+		float width = height / SIDE_LENGTH;
 		re.hexagonRenderer.render(
 				new Matrix4f(
-						screenPosition.x() - size * 0.5f, screenPosition.y() - size * 0.5f,
-						size,
-						size,
+						screenPosition.x() - width * 0.5f, screenPosition.y() - height * 0.5f,
+						width,
+						height,
 						re.glContext)
 						.translate(0.5f, 0.5f)
 						.rotate(radians, new Vector3f(0, 0, 1))
 						.translate(-0.5f, -0.5f),
-				size, size, color, 0, 0);
+				width, height, color, 0, 0);
 	}
 
 	public Actor actor() {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
@@ -14,6 +14,7 @@ import engine.common.math.Vector3f;
 import engine.nengen.DrawBatch;
 import engine.serialization.Derializable;
 import engine.visuals.constraint.box.ConstraintPair;
+import engine.visuals.builtin.RectangleVertexArrayObject;
 import engine.visuals.lwjgl.render.meta.DrawFunction;
 import java.util.ArrayList;
 import java.util.List;
@@ -92,10 +93,11 @@ public abstract class Tile implements Target, HasTooltip {
 	public void collectData(DrawBatch batch, RenderingEnvironment re) {
 		Vector2f screenPosition = getScreenPosition(re).vector();
 		float scale = re.camera.zoom().get();
+		float size = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
 		Matrix4f transform = new Matrix4f(
-				screenPosition.x(), screenPosition.y(),
-				TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale,
-				TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale,
+				screenPosition.x() - size * 0.5f, screenPosition.y() - size * 0.5f,
+				size,
+				size,
 				re.glContext);
 		batch.add(transform, color);
 	}
@@ -122,17 +124,17 @@ public abstract class Tile implements Target, HasTooltip {
 	 * @param scale          the scale of the tile // TODO: not implemented
 	 */
 	public void render(RenderingEnvironment re, Vector2f screenPosition, float scale, float radians) {
-		re.defaultShaderProgram
-				.set("color", toRangedVector(color))
-				.set("transform", new Matrix4f(
-						screenPosition.x(), screenPosition.y(),
-						TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale,
-						TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale,
+		float size = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
+		re.hexagonRenderer.render(
+				new Matrix4f(
+						screenPosition.x() - size * 0.5f, screenPosition.y() - size * 0.5f,
+						size,
+						size,
 						re.glContext)
-						.rotate(radians, new Vector3f(0, 0, 1)))
-				.use(
-						new DrawFunction().vao(HexagonVao.instance()).glContext(re.glContext)
-				);
+						.translate(0.5f, 0.5f)
+						.rotate(radians, new Vector3f(0, 0, 1))
+						.translate(-0.5f, -0.5f),
+				size, size, color, 0, 0);
 	}
 
 	public Actor actor() {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
@@ -95,15 +95,12 @@ public abstract class Tile implements Target, HasTooltip {
 		float scale = re.camera.zoom().get();
 		float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * scale;
 		float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
-		float padding = 0.1f;
-		float pw = width * (1 + padding);
-		float ph = height * (1 + padding);
 		Matrix4f transform = new Matrix4f(
-				screenPosition.x() - pw * 0.5f, screenPosition.y() - ph * 0.5f,
-				pw,
-				ph,
+				screenPosition.x() - width * 0.5f, screenPosition.y() - height * 0.5f,
+				width,
+				height,
 				re.glContext);
-		batch.add(transform, color);
+		batch.add(re.hexagonRenderer.padTransform(transform), color);
 	}
 
 	public void renderDecorations(RenderingEnvironment re) {
@@ -130,19 +127,16 @@ public abstract class Tile implements Target, HasTooltip {
 	public void render(RenderingEnvironment re, Vector2f screenPosition, float scale, float radians) {
 		float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * scale;
 		float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
-		float padding = 0.1f;
-		float pw = width * (1 + padding);
-		float ph = height * (1 + padding);
 		re.hexagonRenderer.render(
 				new Matrix4f(
-						screenPosition.x() - pw * 0.5f, screenPosition.y() - ph * 0.5f,
-						pw,
-						ph,
+						screenPosition.x() - width * 0.5f, screenPosition.y() - height * 0.5f,
+						width,
+						height,
 						re.glContext)
 						.translate(0.5f, 0.5f)
 						.rotate(radians, new Vector3f(0, 0, 1))
 						.translate(-0.5f, -0.5f),
-				pw, ph, height * 0.5f, color, 0, 0);
+				width, height, color, 0, 0);
 	}
 
 	public Actor actor() {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
@@ -93,8 +93,8 @@ public abstract class Tile implements Target, HasTooltip {
 	public void collectData(DrawBatch batch, RenderingEnvironment re) {
 		Vector2f screenPosition = getScreenPosition(re).vector();
 		float scale = re.camera.zoom().get();
-		float height = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
-		float width = height / SIDE_LENGTH;
+		float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * scale;
+		float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
 		Matrix4f transform = new Matrix4f(
 				screenPosition.x() - width * 0.5f, screenPosition.y() - height * 0.5f,
 				width,
@@ -125,8 +125,8 @@ public abstract class Tile implements Target, HasTooltip {
 	 * @param scale          the scale of the tile // TODO: not implemented
 	 */
 	public void render(RenderingEnvironment re, Vector2f screenPosition, float scale, float radians) {
-		float height = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
-		float width = height / SIDE_LENGTH;
+		float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * scale;
+		float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
 		re.hexagonRenderer.render(
 				new Matrix4f(
 						screenPosition.x() - width * 0.5f, screenPosition.y() - height * 0.5f,

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Tile.java
@@ -95,10 +95,13 @@ public abstract class Tile implements Target, HasTooltip {
 		float scale = re.camera.zoom().get();
 		float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * scale;
 		float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
+		float padding = 0.1f;
+		float pw = width * (1 + padding);
+		float ph = height * (1 + padding);
 		Matrix4f transform = new Matrix4f(
-				screenPosition.x() - width * 0.5f, screenPosition.y() - height * 0.5f,
-				width,
-				height,
+				screenPosition.x() - pw * 0.5f, screenPosition.y() - ph * 0.5f,
+				pw,
+				ph,
 				re.glContext);
 		batch.add(transform, color);
 	}
@@ -127,16 +130,19 @@ public abstract class Tile implements Target, HasTooltip {
 	public void render(RenderingEnvironment re, Vector2f screenPosition, float scale, float radians) {
 		float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * scale;
 		float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
+		float padding = 0.1f;
+		float pw = width * (1 + padding);
+		float ph = height * (1 + padding);
 		re.hexagonRenderer.render(
 				new Matrix4f(
-						screenPosition.x() - width * 0.5f, screenPosition.y() - height * 0.5f,
-						width,
-						height,
+						screenPosition.x() - pw * 0.5f, screenPosition.y() - ph * 0.5f,
+						pw,
+						ph,
 						re.glContext)
 						.translate(0.5f, 0.5f)
 						.rotate(radians, new Vector3f(0, 0, 1))
 						.translate(-0.5f, -0.5f),
-				width, height, color, 0, 0);
+				pw, ph, height * 0.5f, color, 0, 0);
 	}
 
 	public Actor actor() {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/points/point/PointOfInterest.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/points/point/PointOfInterest.java
@@ -78,10 +78,13 @@ public class PointOfInterest {
 		float size = 100 * zoom;
 		Vector2f worldPos = position.scale(zoneSizeHorizontal, zoneSizeVertical).add(zone.pos().vector());
 		Vector2f screenPos = worldPos.sub(re.camera.position().vector()).scale(zoom).sub(size / 2, size / 2);
+		float padding = 0.1f;
+		float ps = size * (1 + padding);
 		re.circleShaderProgram
 				.set("color", toRangedVector(rgb(100, 0, 0)))
-				.set("size", new Vector2f(size, size))
-				.set("transform", new Matrix4f(screenPos.x(), screenPos.y(), size, size, re.glContext))
+				.set("size", new Vector2f(ps, ps))
+				.set("radius", size * 0.5f)
+				.set("transform", new Matrix4f(screenPos.x() - (ps - size) * 0.5f, screenPos.y() - (ps - size) * 0.5f, ps, ps, re.glContext))
 				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
 	}
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/points/point/PointOfInterest.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/points/point/PointOfInterest.java
@@ -79,12 +79,6 @@ public class PointOfInterest {
 		Vector2f worldPos = position.scale(zoneSizeHorizontal, zoneSizeVertical).add(zone.pos().vector());
 		Vector2f screenPos = worldPos.sub(re.camera.position().vector()).scale(zoom).sub(size / 2, size / 2);
 		float padding = 0.1f;
-		float ps = size * (1 + padding);
-		re.circleShaderProgram
-				.set("color", toRangedVector(rgb(100, 0, 0)))
-				.set("size", new Vector2f(ps, ps))
-				.set("radius", size * 0.5f)
-				.set("transform", new Matrix4f(screenPos.x() - (ps - size) * 0.5f, screenPos.y() - (ps - size) * 0.5f, ps, ps, re.glContext))
-				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
+		re.circleRenderer.render(new Matrix4f(screenPos.x(), screenPos.y(), size, size, re.glContext), size, rgb(100, 0, 0));
 	}
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/points/point/PointOfInterest.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/points/point/PointOfInterest.java
@@ -80,6 +80,7 @@ public class PointOfInterest {
 		Vector2f screenPos = worldPos.sub(re.camera.position().vector()).scale(zoom).sub(size / 2, size / 2);
 		re.circleShaderProgram
 				.set("color", toRangedVector(rgb(100, 0, 0)))
+				.set("size", new Vector2f(size, size))
 				.set("transform", new Matrix4f(screenPos.x(), screenPos.y(), size, size, re.glContext))
 				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
 	}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/points/point/PointOfInterest.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/points/point/PointOfInterest.java
@@ -1,7 +1,6 @@
 package nomadrealms.context.game.world.map.generation.overworld.points.point;
 
 import static engine.common.colour.Colour.rgb;
-import static engine.common.colour.Colour.toRangedVector;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_HORIZONTAL_SPACING;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_VERTICAL_SPACING;
 import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.CHUNK_SIZE;
@@ -9,8 +8,6 @@ import static nomadrealms.context.game.world.map.area.coordinate.ZoneCoordinate.
 
 import engine.common.math.Matrix4f;
 import engine.common.math.Vector2f;
-import engine.visuals.builtin.RectangleVertexArrayObject;
-import engine.visuals.lwjgl.render.meta.DrawFunction;
 import nomadrealms.context.game.world.map.area.Zone;
 import nomadrealms.context.game.world.map.generation.overworld.points.PointsGenerationStep;
 import nomadrealms.render.RenderingEnvironment;
@@ -78,7 +75,6 @@ public class PointOfInterest {
 		float size = 100 * zoom;
 		Vector2f worldPos = position.scale(zoneSizeHorizontal, zoneSizeVertical).add(zone.pos().vector());
 		Vector2f screenPos = worldPos.sub(re.camera.position().vector()).scale(zoom).sub(size / 2, size / 2);
-		float padding = 0.1f;
 		re.circleRenderer.render(new Matrix4f(screenPos.x(), screenPos.y(), size, size, re.glContext), size, rgb(100, 0, 0));
 	}
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/GrassTile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/GrassTile.java
@@ -4,6 +4,7 @@ import static engine.common.colour.Colour.*;
 import static engine.common.java.JavaUtil.map;
 import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 import static nomadrealms.context.game.world.map.tile.factory.TileType.GRASS;
+import static nomadrealms.render.vao.shape.HexagonVao.HEIGHT;
 import static nomadrealms.render.vao.shape.HexagonVao.SIDE_LENGTH;
 
 import static java.lang.String.valueOf;
@@ -81,8 +82,8 @@ public class GrassTile extends Tile {
 
 	@Override
 	public void render(RenderingEnvironment re, Vector2f screenPosition, float scale, float radians) {
-		float height = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
-		float width = height / SIDE_LENGTH;
+		float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * scale;
+		float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
 		re.hexagonRenderer.renderTextured(
 				new Matrix4f(
 						screenPosition.x() - width * 0.5f, screenPosition.y() - height * 0.5f,

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/GrassTile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/GrassTile.java
@@ -84,19 +84,16 @@ public class GrassTile extends Tile {
 	public void render(RenderingEnvironment re, Vector2f screenPosition, float scale, float radians) {
 		float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * scale;
 		float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
-		float padding = 0.1f;
-		float pw = width * (1 + padding);
-		float ph = height * (1 + padding);
 		re.hexagonRenderer.renderTextured(
 				new Matrix4f(
-						screenPosition.x() - pw * 0.5f, screenPosition.y() - ph * 0.5f,
-						pw,
-						ph,
+						screenPosition.x() - width * 0.5f, screenPosition.y() - height * 0.5f,
+						width,
+						height,
 						re.glContext)
 						.translate(0.5f, 0.5f)
 						.rotate(radians, new Vector3f(0, 0, 1))
 						.translate(-0.5f, -0.5f),
-				pw, ph, height * 0.5f, color, re.imageMap.get("grass_texture"));
+				width, height, color, re.imageMap.get("grass_texture"));
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/GrassTile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/GrassTile.java
@@ -84,16 +84,19 @@ public class GrassTile extends Tile {
 	public void render(RenderingEnvironment re, Vector2f screenPosition, float scale, float radians) {
 		float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * scale;
 		float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
+		float padding = 0.1f;
+		float pw = width * (1 + padding);
+		float ph = height * (1 + padding);
 		re.hexagonRenderer.renderTextured(
 				new Matrix4f(
-						screenPosition.x() - width * 0.5f, screenPosition.y() - height * 0.5f,
-						width,
-						height,
+						screenPosition.x() - pw * 0.5f, screenPosition.y() - ph * 0.5f,
+						pw,
+						ph,
 						re.glContext)
 						.translate(0.5f, 0.5f)
 						.rotate(radians, new Vector3f(0, 0, 1))
 						.translate(-0.5f, -0.5f),
-				width, height, color, re.imageMap.get("grass_texture"));
+				pw, ph, height * 0.5f, color, re.imageMap.get("grass_texture"));
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/GrassTile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/GrassTile.java
@@ -81,24 +81,18 @@ public class GrassTile extends Tile {
 
 	@Override
 	public void render(RenderingEnvironment re, Vector2f screenPosition, float scale, float radians) {
-		float size = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
-		re.texturedHexagonShaderProgram
-				.set("color", toRangedVector(color))
-				.set("textureSampler", 0)
-				.set("size", new Vector2f(size, size))
-				.set("transform", new Matrix4f(
-						screenPosition.x() - size * 0.5f, screenPosition.y() - size * 0.5f,
-						size,
-						size,
+		float height = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
+		float width = height / SIDE_LENGTH;
+		re.hexagonRenderer.renderTextured(
+				new Matrix4f(
+						screenPosition.x() - width * 0.5f, screenPosition.y() - height * 0.5f,
+						width,
+						height,
 						re.glContext)
 						.translate(0.5f, 0.5f)
 						.rotate(radians, new Vector3f(0, 0, 1))
-						.translate(-0.5f, -0.5f))
-				.use(
-						new DrawFunction().vao(RectangleVertexArrayObject.instance())
-								.textures(re.imageMap.get("grass_texture"))
-								.glContext(re.glContext)
-				);
+						.translate(-0.5f, -0.5f),
+				width, height, color, re.imageMap.get("grass_texture"));
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/GrassTile.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/tile/GrassTile.java
@@ -14,6 +14,7 @@ import engine.common.math.Matrix4f;
 import engine.common.math.Vector2f;
 import engine.common.math.Vector3f;
 import engine.serialization.Derializable;
+import engine.visuals.builtin.RectangleVertexArrayObject;
 import engine.visuals.constraint.box.ConstraintBox;
 import engine.visuals.constraint.box.ConstraintPair;
 import engine.visuals.lwjgl.render.meta.DrawFunction;
@@ -80,17 +81,21 @@ public class GrassTile extends Tile {
 
 	@Override
 	public void render(RenderingEnvironment re, Vector2f screenPosition, float scale, float radians) {
-		re.texturedShaderProgram
+		float size = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
+		re.texturedHexagonShaderProgram
 				.set("color", toRangedVector(color))
 				.set("textureSampler", 0)
+				.set("size", new Vector2f(size, size))
 				.set("transform", new Matrix4f(
-						screenPosition.x(), screenPosition.y(),
-						TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale,
-						TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale,
+						screenPosition.x() - size * 0.5f, screenPosition.y() - size * 0.5f,
+						size,
+						size,
 						re.glContext)
-						.rotate(radians, new Vector3f(0, 0, 1)))
+						.translate(0.5f, 0.5f)
+						.rotate(radians, new Vector3f(0, 0, 1))
+						.translate(-0.5f, -0.5f))
 				.use(
-						new DrawFunction().vao(HexagonVao.instance())
+						new DrawFunction().vao(RectangleVertexArrayObject.instance())
 								.textures(re.imageMap.get("grass_texture"))
 								.glContext(re.glContext)
 				);

--- a/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
@@ -56,9 +56,7 @@ public class RenderingEnvironment {
 	public FragmentShader circleFragmentShader;
 	public ShaderProgram circleShaderProgram;
 	public ShaderProgram texturedShaderProgram;
-	public ShaderProgram texturedHexagonShaderProgram;
 	public ShaderProgram instancedShaderProgram;
-	public ShaderProgram instancedHexagonShaderProgram;
 
 	public VertexShader bloomVertexShader;
 	public FragmentShader brightnessFragmentShader;
@@ -126,17 +124,9 @@ public class RenderingEnvironment {
 		circleShaderProgram = new ShaderProgram().attach(defaultVertexShader, circleFragmentShader).load();
 		texturedShaderProgram = new ShaderProgram().attach(TexturedTransformationVertexShader.instance(),
 				TextureFragmentShader.instance()).load();
-		texturedHexagonShaderProgram = new ShaderProgram().attach(
-				defaultVertexShader,
-				new FragmentShader().source(new StringLoader("/shaders/texturedHexagonFragment.glsl").load()).load()
-		).load();
 		instancedShaderProgram = new ShaderProgram().attach(
 				new VertexShader().source(new StringLoader("/shaders/instancedVertex.glsl").load()).load(),
 				new FragmentShader().source(new StringLoader("/shaders/instancedFrag.glsl").load()).load()
-		).load();
-		instancedHexagonShaderProgram = new ShaderProgram().attach(
-				new VertexShader().source(new StringLoader("/shaders/instancedHexagonVertex.glsl").load()).load(),
-				new FragmentShader().source(new StringLoader("/shaders/instancedHexagonFrag.glsl").load()).load()
 		).load();
 
 		bloomVertexShader = new VertexShader().source(new StringLoader("/shaders/bloomVertex.glsl").load())

--- a/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
@@ -20,6 +20,7 @@ import engine.visuals.lwjgl.render.Texture;
 import engine.visuals.lwjgl.render.VertexShader;
 import engine.visuals.lwjgl.render.framebuffer.DefaultFrameBuffer;
 import engine.visuals.rendering.text.GameFont;
+import engine.visuals.rendering.geometry.CircleRenderer;
 import engine.visuals.rendering.geometry.HexagonRenderer;
 import engine.visuals.rendering.geometry.RectangleRenderer;
 import engine.visuals.rendering.geometry.TriangleRenderer;
@@ -49,12 +50,11 @@ public class RenderingEnvironment {
 	public RectangleRenderer rectangleRenderer;
 	public TriangleRenderer triangleRenderer;
 	public HexagonRenderer hexagonRenderer;
+	public CircleRenderer circleRenderer;
 
 	public VertexShader defaultVertexShader;
 	public FragmentShader defaultFragmentShader;
 	public ShaderProgram defaultShaderProgram;
-	public FragmentShader circleFragmentShader;
-	public ShaderProgram circleShaderProgram;
 	public ShaderProgram texturedShaderProgram;
 	public ShaderProgram instancedShaderProgram;
 
@@ -111,17 +111,16 @@ public class RenderingEnvironment {
 		rectangleRenderer = new RectangleRenderer(glContext);
 		triangleRenderer = new TriangleRenderer(glContext);
 		hexagonRenderer = new HexagonRenderer(glContext);
+
+		defaultVertexShader = new VertexShader().source(new StringLoader("/shaders/defaultVertex.glsl").load())
+				.load();
+		circleRenderer = new CircleRenderer(glContext, defaultVertexShader);
 	}
 
 	private void loadShaders() {
-		defaultVertexShader = new VertexShader().source(new StringLoader("/shaders/defaultVertex.glsl").load())
-				.load();
 		defaultFragmentShader = new FragmentShader().source(new StringLoader("/shaders/defaultFrag.glsl").load())
 				.load();
 		defaultShaderProgram = new ShaderProgram().attach(defaultVertexShader, defaultFragmentShader).load();
-		circleFragmentShader = new FragmentShader().source(new StringLoader("/shaders/circleFrag.glsl").load())
-				.load();
-		circleShaderProgram = new ShaderProgram().attach(defaultVertexShader, circleFragmentShader).load();
 		texturedShaderProgram = new ShaderProgram().attach(TexturedTransformationVertexShader.instance(),
 				TextureFragmentShader.instance()).load();
 		instancedShaderProgram = new ShaderProgram().attach(

--- a/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
@@ -20,6 +20,7 @@ import engine.visuals.lwjgl.render.Texture;
 import engine.visuals.lwjgl.render.VertexShader;
 import engine.visuals.lwjgl.render.framebuffer.DefaultFrameBuffer;
 import engine.visuals.rendering.text.GameFont;
+import engine.visuals.rendering.geometry.HexagonRenderer;
 import engine.visuals.rendering.geometry.RectangleRenderer;
 import engine.visuals.rendering.geometry.TriangleRenderer;
 import engine.visuals.rendering.text.TextRenderer;
@@ -47,6 +48,7 @@ public class RenderingEnvironment {
 	public TextureRenderer textureRenderer;
 	public RectangleRenderer rectangleRenderer;
 	public TriangleRenderer triangleRenderer;
+	public HexagonRenderer hexagonRenderer;
 
 	public VertexShader defaultVertexShader;
 	public FragmentShader defaultFragmentShader;
@@ -54,7 +56,9 @@ public class RenderingEnvironment {
 	public FragmentShader circleFragmentShader;
 	public ShaderProgram circleShaderProgram;
 	public ShaderProgram texturedShaderProgram;
+	public ShaderProgram texturedHexagonShaderProgram;
 	public ShaderProgram instancedShaderProgram;
+	public ShaderProgram instancedHexagonShaderProgram;
 
 	public VertexShader bloomVertexShader;
 	public FragmentShader brightnessFragmentShader;
@@ -108,6 +112,7 @@ public class RenderingEnvironment {
 		textureRenderer = new TextureRenderer(glContext);
 		rectangleRenderer = new RectangleRenderer(glContext);
 		triangleRenderer = new TriangleRenderer(glContext);
+		hexagonRenderer = new HexagonRenderer(glContext);
 	}
 
 	private void loadShaders() {
@@ -121,9 +126,17 @@ public class RenderingEnvironment {
 		circleShaderProgram = new ShaderProgram().attach(defaultVertexShader, circleFragmentShader).load();
 		texturedShaderProgram = new ShaderProgram().attach(TexturedTransformationVertexShader.instance(),
 				TextureFragmentShader.instance()).load();
+		texturedHexagonShaderProgram = new ShaderProgram().attach(
+				defaultVertexShader,
+				new FragmentShader().source(new StringLoader("/shaders/texturedHexagonFragment.glsl").load()).load()
+		).load();
 		instancedShaderProgram = new ShaderProgram().attach(
 				new VertexShader().source(new StringLoader("/shaders/instancedVertex.glsl").load()).load(),
 				new FragmentShader().source(new StringLoader("/shaders/instancedFrag.glsl").load()).load()
+		).load();
+		instancedHexagonShaderProgram = new ShaderProgram().attach(
+				new VertexShader().source(new StringLoader("/shaders/instancedHexagonVertex.glsl").load()).load(),
+				new FragmentShader().source(new StringLoader("/shaders/instancedHexagonFrag.glsl").load()).load()
 		).load();
 
 		bloomVertexShader = new VertexShader().source(new StringLoader("/shaders/bloomVertex.glsl").load())

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/geometry/HexagonParticle.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/geometry/HexagonParticle.java
@@ -10,7 +10,6 @@ import engine.visuals.constraint.box.ConstraintBox;
 import engine.visuals.lwjgl.render.meta.DrawFunction;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.particle.Particle;
-import nomadrealms.render.vao.shape.HexagonVao;
 
 public class HexagonParticle extends Particle {
 
@@ -23,10 +22,9 @@ public class HexagonParticle extends Particle {
 
 	@Override
 	public void render(RenderingEnvironment re) {
-		re.defaultShaderProgram
-				.set("color", toRangedVector(color))
-				.set("transform", new Matrix4f(box(), re.glContext).rotate(rotation().get(), new Vector3f(0, 0, 1)))
-				.use(new DrawFunction().vao(HexagonVao.instance()).glContext(re.glContext));
+		re.hexagonRenderer.render(
+				new Matrix4f(box(), re.glContext).rotate(rotation().get(), new Vector3f(0, 0, 1)),
+				box().w().get(), box().h().get(), color, 0, 0);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/geometry/HexagonParticle.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/geometry/HexagonParticle.java
@@ -22,9 +22,18 @@ public class HexagonParticle extends Particle {
 
 	@Override
 	public void render(RenderingEnvironment re) {
+		float width = box().w().get();
+		float height = box().h().get();
+		float padding = 0.1f;
+		float pw = width * (1 + padding);
+		float ph = height * (1 + padding);
 		re.hexagonRenderer.render(
-				new Matrix4f(box(), re.glContext).rotate(rotation().get(), new Vector3f(0, 0, 1)),
-				box().w().get(), box().h().get(), color, 0, 0);
+				new Matrix4f(box(), re.glContext)
+						.translate(0.5f, 0.5f)
+						.rotate(rotation().get(), new Vector3f(0, 0, 1))
+						.scale(1 + padding, 1 + padding)
+						.translate(-0.5f, -0.5f),
+				pw, ph, height * 0.5f, color, 0, 0);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/geometry/HexagonParticle.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/geometry/HexagonParticle.java
@@ -22,18 +22,9 @@ public class HexagonParticle extends Particle {
 
 	@Override
 	public void render(RenderingEnvironment re) {
-		float width = box().w().get();
-		float height = box().h().get();
-		float padding = 0.1f;
-		float pw = width * (1 + padding);
-		float ph = height * (1 + padding);
 		re.hexagonRenderer.render(
-				new Matrix4f(box(), re.glContext)
-						.translate(0.5f, 0.5f)
-						.rotate(rotation().get(), new Vector3f(0, 0, 1))
-						.scale(1 + padding, 1 + padding)
-						.translate(-0.5f, -0.5f),
-				pw, ph, height * 0.5f, color, 0, 0);
+				new Matrix4f(box(), re.glContext).rotate(rotation().get(), new Vector3f(0, 0, 1)),
+				box().w().get(), box().h().get(), color, 0, 0);
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/Arrow.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/Arrow.java
@@ -37,16 +37,13 @@ public class Arrow implements UI {
 		if (targetCenter != null) {
 			float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * re.camera.zoom().get();
 			float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get();
-			float padding = 0.1f;
-			float pw = width * (1 + padding);
-			float ph = height * (1 + padding);
 			re.hexagonRenderer.render(
 					new Matrix4f(
-							targetCenter.x().get() - pw * 0.5f, targetCenter.y().get() - ph * 0.5f,
-							pw,
-							ph,
+							targetCenter.x().get() - width * 0.5f, targetCenter.y().get() - height * 0.5f,
+							width,
+							height,
 							re.glContext),
-					pw, ph, height * 0.5f, rgb(255, 255, 0), 0, 0);
+					width, height, rgb(255, 255, 0), 0, 0);
 		}
 
 		re.defaultShaderProgram

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/Arrow.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/Arrow.java
@@ -4,6 +4,7 @@ import static engine.common.colour.Colour.rgb;
 import static engine.common.colour.Colour.toRangedVector;
 import static engine.common.math.Matrix4f.screenToPixel;
 import static nomadrealms.context.game.world.map.area.Tile.TILE_RADIUS;
+import static nomadrealms.render.vao.shape.HexagonVao.HEIGHT;
 import static nomadrealms.render.vao.shape.HexagonVao.SIDE_LENGTH;
 
 import engine.common.math.Matrix4f;
@@ -34,14 +35,15 @@ public class Arrow implements UI {
 	@Override
 	public void render(RenderingEnvironment re) {
 		if (targetCenter != null) {
-			float size = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get();
+			float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * re.camera.zoom().get();
+			float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get();
 			re.hexagonRenderer.render(
 					new Matrix4f(
-							targetCenter.x().get() - size * 0.5f, targetCenter.y().get() - size * 0.5f,
-							size,
-							size,
+							targetCenter.x().get() - width * 0.5f, targetCenter.y().get() - height * 0.5f,
+							width,
+							height,
 							re.glContext),
-					size, size, rgb(255, 255, 0), 0, 0);
+					width, height, rgb(255, 255, 0), 0, 0);
 		}
 
 		re.defaultShaderProgram

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/Arrow.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/Arrow.java
@@ -14,7 +14,6 @@ import engine.visuals.lwjgl.GLContext;
 import engine.visuals.lwjgl.render.meta.DrawFunction;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.ui.UI;
-import nomadrealms.render.vao.shape.HexagonVao;
 
 public class Arrow implements UI {
 
@@ -35,17 +34,14 @@ public class Arrow implements UI {
 	@Override
 	public void render(RenderingEnvironment re) {
 		if (targetCenter != null) {
-			re.defaultShaderProgram
-					.set("color", toRangedVector(rgb(255, 255, 0)))
-					.set("transform", new Matrix4f(
-							targetCenter.x().get(), targetCenter.y().get(),
-							TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get(),
-							TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get(),
-							re.glContext))
-					.use(new DrawFunction()
-							.vao(HexagonVao.instance())
-							.glContext(re.glContext)
-					);
+			float size = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get();
+			re.hexagonRenderer.render(
+					new Matrix4f(
+							targetCenter.x().get() - size * 0.5f, targetCenter.y().get() - size * 0.5f,
+							size,
+							size,
+							re.glContext),
+					size, size, rgb(255, 255, 0), 0, 0);
 		}
 
 		re.defaultShaderProgram

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/Arrow.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/Arrow.java
@@ -37,13 +37,16 @@ public class Arrow implements UI {
 		if (targetCenter != null) {
 			float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * re.camera.zoom().get();
 			float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * re.camera.zoom().get();
+			float padding = 0.1f;
+			float pw = width * (1 + padding);
+			float ph = height * (1 + padding);
 			re.hexagonRenderer.render(
 					new Matrix4f(
-							targetCenter.x().get() - width * 0.5f, targetCenter.y().get() - height * 0.5f,
-							width,
-							height,
+							targetCenter.x().get() - pw * 0.5f, targetCenter.y().get() - ph * 0.5f,
+							pw,
+							ph,
 							re.glContext),
-					width, height, rgb(255, 255, 0), 0, 0);
+					pw, ph, height * 0.5f, rgb(255, 255, 0), 0, 0);
 		}
 
 		re.defaultShaderProgram

--- a/nomad-realms/src/main/resources/shaders/circleFrag.glsl
+++ b/nomad-realms/src/main/resources/shaders/circleFrag.glsl
@@ -5,6 +5,7 @@ out vec4 fragColor;
 
 uniform vec4 color;
 uniform vec2 size;          // bounding box dimensions (w, h) in pixels
+uniform float radius;       // circle radius in pixels
 
 float sdCircle(in vec2 p, in float r)
 {
@@ -14,7 +15,7 @@ float sdCircle(in vec2 p, in float r)
 void main() {
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
-    float d = sdCircle(p, size.x * 0.5);
+    float d = sdCircle(p, radius);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/hexagonFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/hexagonFragment.glsl
@@ -4,6 +4,7 @@ in vec2 texCoord;
 out vec4 fragColor;
 
 uniform vec2 size;          // bounding box dimensions (w, h) in pixels
+uniform float radius;       // hexagon radius in pixels
 uniform float borderWidth;  // border width in pixels (inside)
 uniform vec4 fillColor;     // fill color (rgba)
 uniform vec4 borderColor;   // border color (rgba)
@@ -23,7 +24,7 @@ void main() {
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
     // Flat-topped hexagon
-    float d = sdHexagon(p, size.y * 0.5);
+    float d = sdHexagon(p, radius);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/hexagonFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/hexagonFragment.glsl
@@ -23,8 +23,8 @@ void main() {
     // Convert to pixel space centered at (0, 0).
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
-    // Flat-topped hexagon
-    float d = sdHexagon(p.yx, radius);
+    // Point-topped hexagon (matches game's flat-topped when quad is square, or fits flat-topped aspect ratio)
+    float d = sdHexagon(p, radius);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/hexagonFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/hexagonFragment.glsl
@@ -1,0 +1,51 @@
+#version 330 core
+
+in vec2 texCoord;
+out vec4 fragColor;
+
+uniform vec2 size;          // bounding box dimensions (w, h) in pixels
+uniform float borderWidth;  // border width in pixels (inside)
+uniform vec4 fillColor;     // fill color (rgba)
+uniform vec4 borderColor;   // border color (rgba)
+
+float sdHexagon(in vec2 p, in float r)
+{
+    const vec3 k = vec3(-0.866025404, 0.5, 0.577350269);
+    p = abs(p);
+    p -= 2.0 * min(dot(k.xy, p), 0.0) * k.xy;
+    p -= vec2(clamp(p.x, -k.z * r, k.z * r), r);
+    return length(p) * sign(p.y);
+}
+
+void main() {
+    // texCoord is from [0, 1] across the entire rectangle.
+    // Convert to pixel space centered at (0, 0).
+    vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
+
+    // Use yx for flat-topped hexagon
+    float d = sdHexagon(p.yx, size.x * 0.5);
+
+    float smoothing = fwidth(d);
+    if (smoothing == 0.0) {
+        smoothing = 1.0;
+    }
+
+    // Outside mask: 0 inside, 1 outside (smoothed)
+    float outerMask = smoothstep(0.0, smoothing, d);
+
+    // Border mask: 0 deep inside, 1 at the border edge
+    float borderEdge = -borderWidth;
+    float borderMask = smoothstep(borderEdge, borderEdge + smoothing, d);
+
+    // Combine fill and border
+    vec4 color = mix(fillColor, borderColor, borderMask);
+
+    // Apply outer alpha
+    color.a *= (1.0 - outerMask);
+
+    if (color.a <= 0.0) {
+        discard;
+    }
+
+    fragColor = color;
+}

--- a/nomad-realms/src/main/resources/shaders/hexagonFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/hexagonFragment.glsl
@@ -24,7 +24,7 @@ void main() {
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
     // Flat-topped hexagon
-    float d = sdHexagon(p, radius);
+    float d = sdHexagon(p.yx, radius);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/hexagonFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/hexagonFragment.glsl
@@ -23,8 +23,8 @@ void main() {
     // Convert to pixel space centered at (0, 0).
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
-    // Point-topped hexagon (matches game's flat-topped when quad is square, or fits flat-topped aspect ratio)
-    float d = sdHexagon(p, radius);
+    // Flat-topped hexagon
+    float d = sdHexagon(p.yx, radius);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/hexagonFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/hexagonFragment.glsl
@@ -22,8 +22,8 @@ void main() {
     // Convert to pixel space centered at (0, 0).
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
-    // Use yx for flat-topped hexagon
-    float d = sdHexagon(p.yx, size.x * 0.5);
+    // Flat-topped hexagon
+    float d = sdHexagon(p, size.y * 0.5);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/hexagonVertex.glsl
+++ b/nomad-realms/src/main/resources/shaders/hexagonVertex.glsl
@@ -1,0 +1,13 @@
+#version 330 core
+
+layout(location = 0) in vec3 position;
+layout(location = 1) in vec2 uv;
+
+out vec2 texCoord;
+
+uniform mat4 transform;
+
+void main() {
+    gl_Position = transform * vec4(position, 1.0);
+    texCoord = uv;
+}

--- a/nomad-realms/src/main/resources/shaders/instancedHexagonFrag.glsl
+++ b/nomad-realms/src/main/resources/shaders/instancedHexagonFrag.glsl
@@ -18,8 +18,8 @@ float sdHexagon(in vec2 p, in float r)
 void main() {
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
-    // Use yx for flat-topped hexagon
-    float d = sdHexagon(p.yx, size.x * 0.5);
+    // Flat-topped hexagon
+    float d = sdHexagon(p, size.y * 0.5);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/instancedHexagonFrag.glsl
+++ b/nomad-realms/src/main/resources/shaders/instancedHexagonFrag.glsl
@@ -20,7 +20,7 @@ void main() {
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
     // Flat-topped hexagon
-    float d = sdHexagon(p, radius);
+    float d = sdHexagon(p.yx, radius);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/instancedHexagonFrag.glsl
+++ b/nomad-realms/src/main/resources/shaders/instancedHexagonFrag.glsl
@@ -1,20 +1,25 @@
 #version 330 core
 
 in vec2 texCoord;
+in vec4 color;
 out vec4 fragColor;
 
-uniform vec4 color;
 uniform vec2 size;          // bounding box dimensions (w, h) in pixels
 
-float sdCircle(in vec2 p, in float r)
+float sdHexagon(in vec2 p, in float r)
 {
-    return length(p) - r;
+    const vec3 k = vec3(-0.866025404, 0.5, 0.577350269);
+    p = abs(p);
+    p -= 2.0 * min(dot(k.xy, p), 0.0) * k.xy;
+    p -= vec2(clamp(p.x, -k.z * r, k.z * r), r);
+    return length(p) * sign(p.y);
 }
 
 void main() {
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
-    float d = sdCircle(p, size.x * 0.5);
+    // Use yx for flat-topped hexagon
+    float d = sdHexagon(p.yx, size.x * 0.5);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/instancedHexagonFrag.glsl
+++ b/nomad-realms/src/main/resources/shaders/instancedHexagonFrag.glsl
@@ -19,8 +19,8 @@ float sdHexagon(in vec2 p, in float r)
 void main() {
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
-    // Flat-topped hexagon
-    float d = sdHexagon(p.yx, radius);
+    // Point-topped hexagon (matches game's flat-topped when quad is square, or fits flat-topped aspect ratio)
+    float d = sdHexagon(p, radius);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/instancedHexagonFrag.glsl
+++ b/nomad-realms/src/main/resources/shaders/instancedHexagonFrag.glsl
@@ -19,8 +19,8 @@ float sdHexagon(in vec2 p, in float r)
 void main() {
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
-    // Point-topped hexagon (matches game's flat-topped when quad is square, or fits flat-topped aspect ratio)
-    float d = sdHexagon(p, radius);
+    // Flat-topped hexagon
+    float d = sdHexagon(p.yx, radius);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/instancedHexagonFrag.glsl
+++ b/nomad-realms/src/main/resources/shaders/instancedHexagonFrag.glsl
@@ -5,6 +5,7 @@ in vec4 color;
 out vec4 fragColor;
 
 uniform vec2 size;          // bounding box dimensions (w, h) in pixels
+uniform float radius;       // hexagon radius in pixels
 
 float sdHexagon(in vec2 p, in float r)
 {
@@ -19,7 +20,7 @@ void main() {
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
     // Flat-topped hexagon
-    float d = sdHexagon(p, size.y * 0.5);
+    float d = sdHexagon(p, radius);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/instancedHexagonVertex.glsl
+++ b/nomad-realms/src/main/resources/shaders/instancedHexagonVertex.glsl
@@ -1,0 +1,15 @@
+#version 330 core
+
+layout(location = 0) in vec3 position;
+layout(location = 1) in vec2 uv;
+layout(location = 2) in mat4 instanceTransform;
+layout(location = 6) in vec4 instanceColor;
+
+out vec2 texCoord;
+out vec4 color;
+
+void main() {
+    gl_Position = instanceTransform * vec4(position, 1.0);
+    texCoord = uv;
+    color = instanceColor;
+}

--- a/nomad-realms/src/main/resources/shaders/texturedHexagonFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/texturedHexagonFragment.glsl
@@ -4,6 +4,7 @@ in vec2 texCoord;
 out vec4 fragColor;
 
 uniform vec2 size;          // bounding box dimensions (w, h) in pixels
+uniform float radius;       // hexagon radius in pixels
 uniform vec4 color;         // tint color
 uniform sampler2D textureSampler;
 
@@ -19,7 +20,7 @@ float sdHexagon(in vec2 p, in float r)
 void main() {
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
-    float d = sdHexagon(p, size.y * 0.5);
+    float d = sdHexagon(p, radius);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/texturedHexagonFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/texturedHexagonFragment.glsl
@@ -19,7 +19,7 @@ float sdHexagon(in vec2 p, in float r)
 void main() {
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
-    float d = sdHexagon(p.yx, size.x * 0.5);
+    float d = sdHexagon(p, size.y * 0.5);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/texturedHexagonFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/texturedHexagonFragment.glsl
@@ -20,7 +20,7 @@ float sdHexagon(in vec2 p, in float r)
 void main() {
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
-    float d = sdHexagon(p.yx, radius);
+    float d = sdHexagon(p, radius);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {

--- a/nomad-realms/src/main/resources/shaders/texturedHexagonFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/texturedHexagonFragment.glsl
@@ -3,18 +3,23 @@
 in vec2 texCoord;
 out vec4 fragColor;
 
-uniform vec4 color;
 uniform vec2 size;          // bounding box dimensions (w, h) in pixels
+uniform vec4 color;         // tint color
+uniform sampler2D textureSampler;
 
-float sdCircle(in vec2 p, in float r)
+float sdHexagon(in vec2 p, in float r)
 {
-    return length(p) - r;
+    const vec3 k = vec3(-0.866025404, 0.5, 0.577350269);
+    p = abs(p);
+    p -= 2.0 * min(dot(k.xy, p), 0.0) * k.xy;
+    p -= vec2(clamp(p.x, -k.z * r, k.z * r), r);
+    return length(p) * sign(p.y);
 }
 
 void main() {
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
-    float d = sdCircle(p, size.x * 0.5);
+    float d = sdHexagon(p.yx, size.x * 0.5);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {
@@ -23,7 +28,8 @@ void main() {
 
     float outerMask = smoothstep(0.0, smoothing, d);
 
-    vec4 finalColor = color;
+    vec4 texColor = texture(textureSampler, texCoord);
+    vec4 finalColor = texColor * color;
     finalColor.a *= (1.0 - outerMask);
 
     if (finalColor.a <= 0.0) {

--- a/nomad-realms/src/main/resources/shaders/texturedHexagonFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/texturedHexagonFragment.glsl
@@ -20,7 +20,7 @@ float sdHexagon(in vec2 p, in float r)
 void main() {
     vec2 p = (texCoord - vec2(0.5, 0.5)) * size;
 
-    float d = sdHexagon(p, radius);
+    float d = sdHexagon(p.yx, radius);
 
     float smoothing = fwidth(d);
     if (smoothing == 0.0) {


### PR DESCRIPTION
I have implemented anti-aliased edges for hexagons and circles as requested. 

The core of the solution involves transitioning from polygonal meshes (HexagonVao) to a Signed Distance Field (SDF) approach rendered on a unit quad. This allows for high-quality, resolution-independent anti-aliasing using the `fwidth()` function in the fragment shaders.

Highlights:
1.  **New Hexagon Shaders:** Created a suite of shaders (`hexagonFragment.glsl`, `instancedHexagonFrag.glsl`, `texturedHexagonFragment.glsl`) to handle solid, instanced, and textured hexagon rendering with smooth edges.
2.  **HexagonRenderer:** Introduced a new renderer class in the geometry package to simplify drawing hexagons, matching the style of the existing `RectangleRenderer` and `TriangleRenderer`.
3.  **Circle Refactoring:** Updated the circle shader to use the same SDF-based anti-aliasing technique for consistent visual quality across the game.
4.  **Full Integration:** Refactored all existing call-sites (map tiles, particles, UI arrows, points of interest) to use the new smooth rendering paths.
5.  **Performance:** Maintained performance by leveraging instanced rendering for the map while switching to the more visually pleasing SDF method.

I've verified the changes through compilation and relevant unit tests.

---
*PR created automatically by Jules for task [18225696760011074776](https://jules.google.com/task/18225696760011074776) started by @Lunkle*