### PR TITLE
Add startup automation scripts for server and clients

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,6 +1,4 @@
 @echo off
-:: Compile and install all modules
-call mvn install -DskipTests
 
 :: Start the server
 echo Starting Server...

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,19 @@
+@echo off
+:: Compile and install all modules
+call mvn install -DskipTests
+
+:: Start the server
+echo Starting Server...
+start /b cmd /c "mvn -f nomad-realms-server/pom.xml exec:java -Dexec.mainClass=nomadrealms.ServerMain > server.log 2>&1"
+
+:: Wait for server to initialize
+timeout /t 5 /nobreak > nul
+
+:: Start two client instances
+echo Starting Client 1...
+start /b cmd /c "mvn -f nomad-realms/pom.xml exec:java -Dexec.mainClass=nomadrealms.app.NomadRealmsMain > client1.log 2>&1"
+
+echo Starting Client 2...
+start /b cmd /c "mvn -f nomad-realms/pom.xml exec:java -Dexec.mainClass=nomadrealms.app.NomadRealmsMain > client2.log 2>&1"
+
+echo Server and clients are starting. Check *.log files for output.

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-# Compile and install all modules
-mvn install -DskipTests
 
 # Start the server
 echo "Starting Server..."

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Compile and install all modules
+mvn install -DskipTests
+
+# Start the server
+echo "Starting Server..."
+mvn -f nomad-realms-server/pom.xml exec:java -Dexec.mainClass=nomadrealms.ServerMain > server.log 2>&1 &
+
+# Wait for server to initialize
+sleep 5
+
+# Start two client instances
+echo "Starting Client 1..."
+mvn -f nomad-realms/pom.xml exec:java -Dexec.mainClass=nomadrealms.app.NomadRealmsMain > client1.log 2>&1 &
+
+echo "Starting Client 2..."
+mvn -f nomad-realms/pom.xml exec:java -Dexec.mainClass=nomadrealms.app.NomadRealmsMain > client2.log 2>&1 &
+
+echo "Server and clients are starting. Check *.log files for output."


### PR DESCRIPTION
I have added `start.sh` and `start.bat` scripts to the root directory. These scripts automate the process of building the project and launching one server instance and two client instances. This is useful for quickly setting up a local multiplayer testing environment. The scripts redirect process output to separate log files (`server.log`, `client1.log`, `client2.log`) to keep the console clean.

---
*PR created automatically by Jules for task [11427697657600785950](https://jules.google.com/task/11427697657600785950) started by @Lunkle*