### PR TITLE
Improve speech bubble rendering and junction masking

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/speech/SpeechBubble.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/speech/SpeechBubble.java
@@ -60,14 +60,22 @@ public class SpeechBubble implements UI {
 				actorPos.x() - tailSize / 2, bubbleY + bubbleH - 1,
 				actorPos.x() + tailSize / 2, bubbleY + bubbleH - 1,
 				actorPos.x(), bubbleY + bubbleH + tailSize,
-				rgb(245, 245, 220), rgb(0, 0, 0), 1 * scale
+				rgb(255, 255, 255), rgb(0, 0, 0), 1 * scale
 		);
 
 		// Render bubble
 		re.rectangleRenderer.render(
 				bubbleX, bubbleY, bubbleW, bubbleH,
 				10 * scale,
-				rgb(245, 245, 220), rgb(0, 0, 0), 2 * scale
+				rgb(255, 255, 255), rgb(0, 0, 0), 2 * scale
+		);
+
+		// Render inner triangle to cover junction
+		re.triangleRenderer.render(
+				actorPos.x() - tailSize / 2 + 1.5f * scale, bubbleY + bubbleH - 2 * scale,
+				actorPos.x() + tailSize / 2 - 1.5f * scale, bubbleY + bubbleH - 2 * scale,
+				actorPos.x(), bubbleY + bubbleH + tailSize - 1.5f * scale,
+				rgb(255, 255, 255)
 		);
 
 		// Render text

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/speech/SpeechBubble.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/speech/SpeechBubble.java
@@ -5,6 +5,7 @@ import static engine.visuals.rendering.text.TextFormat.textFormat;
 
 import engine.common.math.Vector2f;
 import engine.visuals.rendering.text.TextFormat;
+import engine.visuals.rendering.text.TextRenderer;
 import nomadrealms.context.game.actor.Actor;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.ui.UI;
@@ -43,7 +44,7 @@ public class SpeechBubble implements UI {
 				.colour(rgb(0, 0, 0))
 				.lineWidth(wrapWidth);
 
-		Vector2f textSize = re.textRenderer.calculateTextSize(format);
+		Vector2f textSize = TextRenderer.calculateTextSize(format);
 
 		float padding = 10 * scale;
 		float bubbleW = textSize.x() + padding * 2;
@@ -52,30 +53,35 @@ public class SpeechBubble implements UI {
 		Vector2f actorPos = actor.getScreenPosition(re).vector();
 
 		float bubbleX = actorPos.x() - bubbleW / 2;
-		float bubbleY = actorPos.y() - bubbleH - 40 * scale; // Positioned above head
+		float bubbleY = actorPos.y() - bubbleH - 30 * scale; // Positioned above head
+
+		float borderSize = 2 * scale;
 
 		// Render tail
 		float tailSize = 15 * scale;
 		re.triangleRenderer.render(
-				actorPos.x() - tailSize / 2, bubbleY + bubbleH - 1,
-				actorPos.x() + tailSize / 2, bubbleY + bubbleH - 1,
-				actorPos.x(), bubbleY + bubbleH + tailSize,
-				rgb(255, 255, 255), rgb(0, 0, 0), 1 * scale
+				actorPos.x() - tailSize / 2, bubbleY + bubbleH,
+				actorPos.x() + tailSize / 2, bubbleY + bubbleH,
+				actorPos.x(), bubbleY + bubbleH + tailSize / 3,
+				rgb(255, 255, 255), rgb(0, 0, 0), borderSize
 		);
 
 		// Render bubble
 		re.rectangleRenderer.render(
 				bubbleX, bubbleY, bubbleW, bubbleH,
 				10 * scale,
-				rgb(255, 255, 255), rgb(0, 0, 0), 2 * scale
+				rgb(255, 255, 255), rgb(0, 0, 0), borderSize
 		);
 
 		// Render inner triangle to cover junction
 		re.triangleRenderer.render(
-				actorPos.x() - tailSize / 2 + 1.5f * scale, bubbleY + bubbleH - 2 * scale,
-				actorPos.x() + tailSize / 2 - 1.5f * scale, bubbleY + bubbleH - 2 * scale,
-				actorPos.x(), bubbleY + bubbleH + tailSize - 1.5f * scale,
-				rgb(255, 255, 255)
+//				actorPos.x() - tailSize / 2 + borderSize / 2, bubbleY + bubbleH - 2 * scale,
+//				actorPos.x() + tailSize / 2 - borderSize / 2, bubbleY + bubbleH - 2 * scale,
+//				actorPos.x(), bubbleY + bubbleH + tailSize / 3 - borderSize / 2,
+				actorPos.x() - tailSize / 2, bubbleY + bubbleH - borderSize,
+				actorPos.x() + tailSize / 2, bubbleY + bubbleH - borderSize,
+				actorPos.x(), bubbleY + bubbleH + tailSize / 3 - borderSize,
+				rgb(255, 255, 205)
 		);
 
 		// Render text


### PR DESCRIPTION
This PR improves the visual quality of speech bubbles in the game. It updates the fill color of the speech bubble and its tail to white and introduces an additional inner triangle that masks the border line where the tail meets the main bubble body. This ensures a clean, seamless look for the speech bubbles.

---
*PR created automatically by Jules for task [14607710733447249327](https://jules.google.com/task/14607710733447249327) started by @Lunkle*