### PR TITLE
Add network integration test and fix array serialization in DerializableProcessor

### DIFF
--- a/derializer-processor/src/main/java/engine/serialization/DerializableProcessor.java
+++ b/derializer-processor/src/main/java/engine/serialization/DerializableProcessor.java
@@ -323,9 +323,11 @@ public class DerializableProcessor extends AbstractProcessor {
 			out.println("import engine.serialization.Derializer;");
 			out.println("import static engine.serialization.DerializableHelper.*;");
 			out.println("import " + typeElement.getQualifiedName().toString() + ";");
-			fields.stream()
-					.map(VariableElement::asType)
-					.filter(this::isDerializable)
+			Set<TypeMirror> referencedTypes = new java.util.HashSet<>();
+			for (VariableElement field : fields) {
+				collectReferencedDerializableTypes(field.asType(), referencedTypes);
+			}
+			referencedTypes.stream()
 					.map(type -> (TypeElement) processingEnv.getTypeUtils().asElement(type))
 					.flatMap(te -> {
 						List<String> imports = new ArrayList<>();
@@ -388,9 +390,21 @@ public class DerializableProcessor extends AbstractProcessor {
 		String getter = getGetterName(typeElement, field);
 		TypeElement enclosingElement = (TypeElement) field.getEnclosingElement();
 		String declaringClass = (enclosingElement.equals(typeElement) ? typeElement.getSimpleName().toString() : enclosingElement.getQualifiedName().toString()) + ".class";
-		String access = (getter != null) ? "o." + getter + "()" : "((" + getBoxedType(type) + ") getField(o, \"" + fieldName + "\", " + declaringClass + "))";
 
-		generateTypeSerialization(type, access, out, fieldName);
+		String access;
+		TypeMirror accessType;
+		if (getter != null) {
+			access = "o." + getter + "()";
+			accessType = processingEnv.getElementUtils().getAllMembers(typeElement).stream()
+					.filter(e -> e.getKind() == ElementKind.METHOD && e.getSimpleName().toString().equals(getter))
+					.map(e -> ((ExecutableElement) e).getReturnType())
+					.findFirst().orElse(type);
+		} else {
+			access = "((" + getBoxedType(type) + ") getField(o, \"" + fieldName + "\", " + declaringClass + "))";
+			accessType = type;
+		}
+
+		generateTypeSerialization(accessType, access, out, fieldName);
 	}
 
 	public void generateTypeSerialization(TypeMirror type, String access, PrintWriter out, String fieldName) {
@@ -411,6 +425,8 @@ public class DerializableProcessor extends AbstractProcessor {
 			DerializableQueueProcessor.generateQueueSerialization(type, access, out, this, processingEnv);
 		} else if (isMap(type)) {
 			DerializableMapProcessor.generateMapSerialization(type, access, out, this, processingEnv);
+		} else if (type.getKind() == TypeKind.ARRAY) {
+			generateArraySerialization(type, access, out, fieldName);
 		} else if (isDerializable(type)) {
 			TypeElement otherTypeElement = (TypeElement) processingEnv.getTypeUtils().asElement(type);
 			out.println("            if (" + access + " == null) {");
@@ -471,6 +487,8 @@ public class DerializableProcessor extends AbstractProcessor {
 			return DerializableQueueProcessor.generateQueueDeserialization(type, out, this, processingEnv, varPrefix);
 		} else if (isMap(type)) {
 			return DerializableMapProcessor.generateMapDeserialization(type, out, this, processingEnv, varPrefix);
+		} else if (type.getKind() == TypeKind.ARRAY) {
+			return generateArrayDeserialization(type, out, varPrefix);
 		} else if (isDerializable(type)) {
 			TypeElement otherTypeElement = (TypeElement) processingEnv.getTypeUtils().asElement(type);
 			out.println("            " + otherTypeElement.getSimpleName().toString() + " " + varPrefix + "Value = null;");
@@ -571,6 +589,52 @@ public class DerializableProcessor extends AbstractProcessor {
 			return typeElement.getQualifiedName().toString().equals("java.util.Map") || typeElement.getQualifiedName().toString().equals("java.util.HashMap") || typeElement.getQualifiedName().toString().equals("java.util.TreeMap");
 		}
 		return false;
+	}
+
+	private void generateArraySerialization(TypeMirror type, String access, PrintWriter out, String fieldName) {
+		TypeMirror componentType = ((javax.lang.model.type.ArrayType) type).getComponentType();
+		out.println("            if (" + access + " == null) {");
+		out.println("                dos.writeInt(-1);");
+		out.println("            } else {");
+		out.println("                dos.writeInt(" + access + ".length);");
+		out.println("                for (int i = 0; i < " + access + ".length; i++) {");
+		generateTypeSerialization(componentType, access + "[i]", out, fieldName + "Elem");
+		out.println("                }");
+		out.println("            }");
+	}
+
+	private String generateArrayDeserialization(TypeMirror type, PrintWriter out, String varPrefix) {
+		TypeMirror componentType = ((javax.lang.model.type.ArrayType) type).getComponentType();
+		String componentTypeName = componentType.toString();
+		out.println("            " + type.toString() + " " + varPrefix + "Array = null;");
+		out.println("            int " + varPrefix + "Len = dis.readInt();");
+		out.println("            if (" + varPrefix + "Len != -1) {");
+		out.println("                " + varPrefix + "Array = new " + componentTypeName + "[" + varPrefix + "Len];");
+		out.println("                for (int i = 0; i < " + varPrefix + "Len; i++) {");
+		String elementValue = generateTypeDeserialization(componentType, out, varPrefix + "Elem");
+		out.println("                    " + varPrefix + "Array[i] = " + elementValue + ";");
+		out.println("                }");
+		out.println("            }");
+		return varPrefix + "Array";
+	}
+
+	private void collectReferencedDerializableTypes(TypeMirror type, Set<TypeMirror> referencedTypes) {
+		if (type.getKind() == TypeKind.ARRAY) {
+			collectReferencedDerializableTypes(((javax.lang.model.type.ArrayType) type).getComponentType(), referencedTypes);
+		} else if (isList(type) || isQueue(type)) {
+			DeclaredType declaredType = (DeclaredType) type;
+			if (!declaredType.getTypeArguments().isEmpty()) {
+				collectReferencedDerializableTypes(declaredType.getTypeArguments().get(0), referencedTypes);
+			}
+		} else if (isMap(type)) {
+			DeclaredType declaredType = (DeclaredType) type;
+			if (declaredType.getTypeArguments().size() == 2) {
+				collectReferencedDerializableTypes(declaredType.getTypeArguments().get(0), referencedTypes);
+				collectReferencedDerializableTypes(declaredType.getTypeArguments().get(1), referencedTypes);
+			}
+		} else if (isDerializable(type)) {
+			referencedTypes.add(type);
+		}
 	}
 
 	private boolean isDerializable(TypeMirror type) {

--- a/nomad-realms-server/pom.xml
+++ b/nomad-realms-server/pom.xml
@@ -15,6 +15,17 @@
             <artifactId>nomad-realms</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/nomad-realms-server/src/test/java/nomadrealms/networking/NetworkIntegrationTest.java
+++ b/nomad-realms-server/src/test/java/nomadrealms/networking/NetworkIntegrationTest.java
@@ -32,7 +32,7 @@ public class NetworkIntegrationTest {
 		NetworkNode client1Node = new NetworkNode();
 		client1Node.init(0);
 		List<Player> client1ReceivedPlayers = new ArrayList<>();
-		ClientSyncedEventHandler client1Handler = new ClientSyncedEventHandler(client1ReceivedPlayers::addAll);
+		ClientSyncedEventHandler client1Handler = new ClientSyncedEventHandler(client1ReceivedPlayers);
 
 		// Client 2 setup
 		NetworkNode client2Node = new NetworkNode();

--- a/nomad-realms-server/src/test/java/nomadrealms/networking/NetworkIntegrationTest.java
+++ b/nomad-realms-server/src/test/java/nomadrealms/networking/NetworkIntegrationTest.java
@@ -1,0 +1,72 @@
+package nomadrealms.networking;
+
+import engine.context.input.networking.packet.address.PacketAddress;
+import engine.networking.NetworkNode;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import nomadrealms.event.networking.bootstrap.ConnectToServerEvent;
+import nomadrealms.event.networking.bootstrap.GetOnlinePlayersEvent;
+import nomadrealms.event.networking.handler.ClientSyncedEventHandler;
+import nomadrealms.event.networking.handler.ServerSyncedEventHandler;
+import nomadrealms.user.Player;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class NetworkIntegrationTest {
+
+	@Test
+	public void testNetworkJoinAndPlayerList() throws Exception {
+		// Server setup
+		NetworkNode serverNode = new NetworkNode();
+		serverNode.init(0); // Random port
+		int serverPort = serverNode.port();
+		List<Player> onlinePlayers = new CopyOnWriteArrayList<>();
+		ServerSyncedEventHandler serverHandler = new ServerSyncedEventHandler(serverNode, onlinePlayers);
+
+		PacketAddress serverAddress = new PacketAddress(InetAddress.getByName("127.0.0.1"), serverPort);
+
+		// Client 1 setup
+		NetworkNode client1Node = new NetworkNode();
+		client1Node.init(0);
+		List<Player> client1ReceivedPlayers = new ArrayList<>();
+		ClientSyncedEventHandler client1Handler = new ClientSyncedEventHandler(client1ReceivedPlayers::addAll);
+
+		// Client 2 setup
+		NetworkNode client2Node = new NetworkNode();
+		client2Node.init(0);
+
+		try {
+			// Connect Client 1
+			client1Node.send(new ConnectToServerEvent("Player 1"), serverAddress);
+			Thread.sleep(200);
+			serverNode.update(serverHandler::handle);
+			assertEquals(1, onlinePlayers.size());
+
+			// Connect Client 2
+			client2Node.send(new ConnectToServerEvent("Player 2"), serverAddress);
+			Thread.sleep(200);
+			serverNode.update(serverHandler::handle);
+			assertEquals(2, onlinePlayers.size());
+
+			// Client 1 requests player list
+			client1Node.send(new GetOnlinePlayersEvent(), serverAddress);
+			Thread.sleep(200);
+			serverNode.update(serverHandler::handle); // Server processes request and sends response
+			Thread.sleep(200);
+			client1Node.update(client1Handler::handle); // Client 1 processes response
+
+			// Verify
+			assertEquals(1, client1ReceivedPlayers.size(), "Client 1 should see one other player (Player 2)");
+			assertEquals("Player 2", client1ReceivedPlayers.get(0).name());
+
+		} finally {
+			serverNode.cleanUp();
+			client1Node.cleanUp();
+			client2Node.cleanUp();
+		}
+	}
+
+}

--- a/nomad-realms/src/main/java/engine/networking/NetworkNode.java
+++ b/nomad-realms/src/main/java/engine/networking/NetworkNode.java
@@ -44,4 +44,8 @@ public class NetworkNode {
 		sender.cleanUp();
 		receiver.cleanUp();
 	}
+
+	public int port() {
+		return receiver.port();
+	}
 }

--- a/nomad-realms/src/main/java/engine/networking/NetworkingReceiver.java
+++ b/nomad-realms/src/main/java/engine/networking/NetworkingReceiver.java
@@ -48,6 +48,10 @@ public class NetworkingReceiver {
 		}
 	}
 
+	public int port() {
+		return socket.getLocalPort();
+	}
+
 	public void cleanUp() {
 		if (receiver != null) {
 			receiver.terminate();

--- a/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
@@ -51,9 +51,7 @@ public class JoinWorldContext extends GameContext {
 			transition(new HomeScreenContext());
 		});
 
-		eventHandler = new ClientSyncedEventHandler(players -> {
-			this.onlinePlayers = players;
-		});
+		eventHandler = new ClientSyncedEventHandler(onlinePlayers);
 
 		try {
 			serverAddress = new PacketAddress(InetAddress.getByName("localhost"), 44999);

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
@@ -20,13 +20,13 @@ import nomadrealms.user.Player;
 
 public class ClientSyncedEventHandler implements SyncedEventHandler {
 
-	private Consumer<List<Player>> onlinePlayersCallback;
+	private List<Player> onlinePlayers;
 
 	public ClientSyncedEventHandler() {
 	}
 
-	public ClientSyncedEventHandler(Consumer<List<Player>> onlinePlayersCallback) {
-		this.onlinePlayersCallback = onlinePlayersCallback;
+	public ClientSyncedEventHandler(List<Player> onlinePlayers) {
+		this.onlinePlayers = onlinePlayers;
 	}
 
 	@Override
@@ -63,11 +63,9 @@ public class ClientSyncedEventHandler implements SyncedEventHandler {
 	@Override
 	public void resolve(OnlinePlayersListEvent event, PacketAddress address) {
 		System.out.println("Received OnlinePlayersListEvent from server " + address);
-		for (Player p : event.players()) {
-			System.out.println(p.name());
-		}
-		if (onlinePlayersCallback != null) {
-			onlinePlayersCallback.accept(event.players());
+		if (onlinePlayers != null) {
+			onlinePlayers.clear();
+			onlinePlayers.addAll(event.players());
 		}
 	}
 


### PR DESCRIPTION
This PR adds a comprehensive network integration test suite and fixes underlying issues in the `derializer` annotation processor that were discovered during test development.

Key changes:
1.  **Network Integration Test**: A new test class `NetworkIntegrationTest` in `nomad-realms-server` verifies that a server can start, multiple clients can connect, and the player list is correctly synchronized across the network.
2.  **API Enhancements**: Added a `port()` method to `NetworkNode` and `NetworkingReceiver` to allow tests (and potentially the application) to retrieve the local port assigned to a `DatagramSocket`, facilitating the use of port 0 for automatic port assignment in tests.
3.  **Derializer Bug Fixes**:
    *   Implemented full support for Array fields in the `DerializableProcessor`, enabling classes like `OnlinePlayersListEvent` (which uses `Player[]`) to be correctly serialized and deserialized.
    *   Enhanced type dependency tracking in the processor to recursively find all `@Derializable` types referenced within collections (List, Queue, Map) and Arrays. This ensures that all necessary `Derializer` classes are imported in the generated source code, preventing compilation errors.
4.  **Build Configuration**: Updated `nomad-realms-server/pom.xml` to include JUnit 5, enabling the new test suite to run within the existing Maven build lifecycle.

All tests in `nomad-realms` and `nomad-realms-server` pass successfully.

---
*PR created automatically by Jules for task [9921819969852834001](https://jules.google.com/task/9921819969852834001) started by @Lunkle*