### PR TITLE
Support for Java arrays in Derializer

### DIFF
--- a/derializer-processor/src/main/java/engine/serialization/DerializableArrayProcessor.java
+++ b/derializer-processor/src/main/java/engine/serialization/DerializableArrayProcessor.java
@@ -1,0 +1,82 @@
+package engine.serialization;
+
+import java.io.PrintWriter;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.TypeKind;
+import javax.annotation.processing.ProcessingEnvironment;
+
+public class DerializableArrayProcessor {
+
+    public static void generateArraySerialization(TypeMirror type, String access, PrintWriter out, DerializableProcessor processor, ProcessingEnvironment env) {
+        if (type.getKind() != TypeKind.ARRAY) {
+            env.getMessager().printMessage(javax.tools.Diagnostic.Kind.ERROR, "Type must be an array type");
+            return;
+        }
+
+        ArrayType arrayType = (ArrayType) type;
+        TypeMirror elementType = arrayType.getComponentType();
+
+        out.println("            if (" + access + " == null) {");
+        out.println("                dos.writeInt(-1);");
+        out.println("            } else {");
+        out.println("                dos.writeInt(" + access + ".length);");
+
+        String loopVar = "e_" + Math.abs(access.hashCode());
+        loopVar = loopVar.replace(".", "_").replace("(", "_").replace(")", "_").replace("-", "m");
+        out.println("                for (" + processor.getBoxedType(elementType) + " " + loopVar + " : " + access + ") {");
+        processor.generateTypeSerialization(elementType, loopVar, out, "Array element");
+        out.println("                }");
+        out.println("            }");
+    }
+
+    public static String generateArrayDeserialization(TypeMirror type, PrintWriter out, DerializableProcessor processor, ProcessingEnvironment env, String varPrefix) {
+        if (type.getKind() != TypeKind.ARRAY) {
+            env.getMessager().printMessage(javax.tools.Diagnostic.Kind.ERROR, "Type must be an array type");
+            return null;
+        }
+
+        ArrayType arrayType = (ArrayType) type;
+        TypeMirror elementType = arrayType.getComponentType();
+
+        String lenVar = varPrefix + "Len";
+        String arrayVar = varPrefix + "Array";
+
+        out.println("            int " + lenVar + " = dis.readInt();");
+        out.println("            " + type.toString() + " " + arrayVar + " = null;");
+        out.println("            if (" + lenVar + " != -1) {");
+
+        String creation;
+        if (elementType.getKind() == TypeKind.ARRAY) {
+             // For multi-dimensional arrays, we need to find the base type and dimensions
+             TypeMirror baseType = elementType;
+             int dims = 1;
+             while (baseType.getKind() == TypeKind.ARRAY) {
+                 baseType = ((ArrayType) baseType).getComponentType();
+                 dims++;
+             }
+             StringBuilder brackets = new StringBuilder("[" + lenVar + "]");
+             for (int i = 0; i < dims - 1; i++) {
+                 brackets.append("[]");
+             }
+             creation = "new " + baseType.toString() + brackets.toString();
+        } else {
+             creation = "new " + elementType.toString() + "[" + lenVar + "]";
+        }
+
+        out.println("                " + arrayVar + " = " + creation + ";");
+        String loopVar = varPrefix + "I";
+        out.println("                for (int " + loopVar + " = 0; " + loopVar + " < " + lenVar + "; " + loopVar + "++) {");
+
+        String elemVar = processor.generateTypeDeserialization(elementType, out, varPrefix + "Elem");
+
+        if (elemVar != null) {
+            out.println("                    " + arrayVar + "[" + loopVar + "] = " + elemVar + ";");
+        }
+
+        out.println("                }");
+        out.println("            }");
+
+        return arrayVar;
+    }
+}

--- a/derializer-processor/src/main/java/engine/serialization/DerializableProcessor.java
+++ b/derializer-processor/src/main/java/engine/serialization/DerializableProcessor.java
@@ -19,6 +19,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -325,8 +326,8 @@ public class DerializableProcessor extends AbstractProcessor {
 			out.println("import " + typeElement.getQualifiedName().toString() + ";");
 			fields.stream()
 					.map(VariableElement::asType)
-					.filter(this::isDerializable)
-					.map(type -> (TypeElement) processingEnv.getTypeUtils().asElement(type))
+					.flatMap(this::getDerializableTypes)
+					.distinct()
 					.flatMap(te -> {
 						List<String> imports = new ArrayList<>();
 						imports.add(te.getQualifiedName().toString());
@@ -388,7 +389,15 @@ public class DerializableProcessor extends AbstractProcessor {
 		String getter = getGetterName(typeElement, field);
 		TypeElement enclosingElement = (TypeElement) field.getEnclosingElement();
 		String declaringClass = (enclosingElement.equals(typeElement) ? typeElement.getSimpleName().toString() : enclosingElement.getQualifiedName().toString()) + ".class";
-		String access = (getter != null) ? "o." + getter + "()" : "((" + getBoxedType(type) + ") getField(o, \"" + fieldName + "\", " + declaringClass + "))";
+
+		ExecutableElement getterMethod = getGetterMethod(typeElement, field);
+		String access;
+		if (getterMethod != null) {
+			access = "o." + getterMethod.getSimpleName().toString() + "()";
+			type = getterMethod.getReturnType();
+		} else {
+			access = "((" + getBoxedType(type) + ") getField(o, \"" + fieldName + "\", " + declaringClass + "))";
+		}
 
 		generateTypeSerialization(type, access, out, fieldName);
 	}
@@ -407,6 +416,8 @@ public class DerializableProcessor extends AbstractProcessor {
 			out.println("            write(" + access + ", dos);");
 		} else if (isList(type)) {
 			DerializableListProcessor.generateListSerialization(type, access, out, this, processingEnv);
+		} else if (isArray(type)) {
+			DerializableArrayProcessor.generateArraySerialization(type, access, out, this, processingEnv);
 		} else if (isQueue(type)) {
 			DerializableQueueProcessor.generateQueueSerialization(type, access, out, this, processingEnv);
 		} else if (isMap(type)) {
@@ -467,6 +478,8 @@ public class DerializableProcessor extends AbstractProcessor {
 			return "readString(dis)";
 		} else if (isList(type)) {
 			return DerializableListProcessor.generateListDeserialization(type, out, this, processingEnv, varPrefix);
+		} else if (isArray(type)) {
+			return DerializableArrayProcessor.generateArrayDeserialization(type, out, this, processingEnv, varPrefix);
 		} else if (isQueue(type)) {
 			return DerializableQueueProcessor.generateQueueDeserialization(type, out, this, processingEnv, varPrefix);
 		} else if (isMap(type)) {
@@ -485,13 +498,21 @@ public class DerializableProcessor extends AbstractProcessor {
 	}
 
 	private String getGetterName(TypeElement typeElement, VariableElement field) {
+		ExecutableElement method = getGetterMethod(typeElement, field);
+		return method != null ? method.getSimpleName().toString() : null;
+	}
+
+	private ExecutableElement getGetterMethod(TypeElement typeElement, VariableElement field) {
 		String name = field.getSimpleName().toString();
 		String capitalized = capitalize(name);
 		if (field.asType().getKind() == TypeKind.BOOLEAN) {
-			if (existsMethod(typeElement, "is" + capitalized)) return "is" + capitalized;
+			ExecutableElement method = getMethod(typeElement, "is" + capitalized);
+			if (method != null) return method;
 		}
-		if (existsMethod(typeElement, "get" + capitalized)) return "get" + capitalized;
-		if (existsMethod(typeElement, name)) return name;
+		ExecutableElement method = getMethod(typeElement, "get" + capitalized);
+		if (method != null) return method;
+		method = getMethod(typeElement, name);
+		if (method != null) return method;
 		return null;
 	}
 
@@ -504,6 +525,10 @@ public class DerializableProcessor extends AbstractProcessor {
 	}
 
 	private boolean existsMethod(TypeElement type, String name, TypeMirror... params) {
+		return getMethod(type, name, params) != null;
+	}
+
+	private ExecutableElement getMethod(TypeElement type, String name, TypeMirror... params) {
 		for (Element enclosed : processingEnv.getElementUtils().getAllMembers(type)) {
 			if (enclosed.getKind() == ElementKind.METHOD && enclosed.getSimpleName().toString().equals(name)) {
 				ExecutableElement method = (ExecutableElement) enclosed;
@@ -521,11 +546,11 @@ public class DerializableProcessor extends AbstractProcessor {
 					}
 				}
 				if (typesMatch) {
-					return true;
+					return method;
 				}
 			}
 		}
-		return false;
+		return null;
 	}
 
 	private String capitalize(String s) {
@@ -535,6 +560,27 @@ public class DerializableProcessor extends AbstractProcessor {
 
 	private boolean isString(TypeMirror type) {
 		return type.toString().equals("java.lang.String");
+	}
+
+	private java.util.stream.Stream<TypeElement> getDerializableTypes(TypeMirror type) {
+		List<TypeElement> result = new ArrayList<>();
+		if (isDerializable(type)) {
+			result.add((TypeElement) processingEnv.getTypeUtils().asElement(type));
+		}
+		if (type.getKind() == TypeKind.DECLARED) {
+			DeclaredType declaredType = (DeclaredType) type;
+			for (TypeMirror typeArgument : declaredType.getTypeArguments()) {
+				getDerializableTypes(typeArgument).forEach(result::add);
+			}
+		} else if (type.getKind() == TypeKind.ARRAY) {
+			ArrayType arrayType = (ArrayType) type;
+			getDerializableTypes(arrayType.getComponentType()).forEach(result::add);
+		}
+		return result.stream();
+	}
+
+	private boolean isArray(TypeMirror type) {
+		return type.getKind() == TypeKind.ARRAY;
 	}
 
 	private boolean isList(TypeMirror type) {

--- a/nomad-realms/src/test/java/engine/serialization/CollectionTestClass.java
+++ b/nomad-realms/src/test/java/engine/serialization/CollectionTestClass.java
@@ -9,6 +9,9 @@ public class CollectionTestClass {
     private List<ShadowChild> childList;
     private Map<String, Integer> stringIntMap;
     private Map<String, ShadowChild> stringChildMap;
+    private int[] intArray;
+    private String[] stringArray;
+    private ShadowChild[] childArray;
 
     public List<String> getStringList() { return stringList; }
     public void setStringList(List<String> stringList) { this.stringList = stringList; }
@@ -21,4 +24,13 @@ public class CollectionTestClass {
 
     public Map<String, ShadowChild> getStringChildMap() { return stringChildMap; }
     public void setStringChildMap(Map<String, ShadowChild> stringChildMap) { this.stringChildMap = stringChildMap; }
+
+    public int[] getIntArray() { return intArray; }
+    public void setIntArray(int[] intArray) { this.intArray = intArray; }
+
+    public String[] getStringArray() { return stringArray; }
+    public void setStringArray(String[] stringArray) { this.stringArray = stringArray; }
+
+    public ShadowChild[] getChildArray() { return childArray; }
+    public void setChildArray(ShadowChild[] childArray) { this.childArray = childArray; }
 }

--- a/nomad-realms/src/test/java/engine/serialization/DerializableTest.java
+++ b/nomad-realms/src/test/java/engine/serialization/DerializableTest.java
@@ -1,5 +1,6 @@
 package engine.serialization;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -113,6 +114,15 @@ public class DerializableTest {
         stringChildMap.put("second", c2);
         original.setStringChildMap(stringChildMap);
 
+        int[] intArray = {1, 2, 3};
+        original.setIntArray(intArray);
+
+        String[] stringArray = {"a", "b", "c"};
+        original.setStringArray(stringArray);
+
+        ShadowChild[] childArray = {c1, c2};
+        original.setChildArray(childArray);
+
         byte[] bytes = CollectionTestClassDerializer.serialize(original);
         CollectionTestClass deserialized = CollectionTestClassDerializer.deserialize(bytes);
 
@@ -134,5 +144,14 @@ public class DerializableTest {
         assertEquals(20, deserialized.getStringChildMap().get("first").getChildVal());
         assertEquals(30, deserialized.getStringChildMap().get("second").getParentVal());
         assertEquals(40, deserialized.getStringChildMap().get("second").getChildVal());
+
+        assertArrayEquals(intArray, deserialized.getIntArray());
+        assertArrayEquals(stringArray, deserialized.getStringArray());
+        assertNotNull(deserialized.getChildArray());
+        assertEquals(2, deserialized.getChildArray().length);
+        assertEquals(10, deserialized.getChildArray()[0].getParentVal());
+        assertEquals(20, deserialized.getChildArray()[0].getChildVal());
+        assertEquals(30, deserialized.getChildArray()[1].getParentVal());
+        assertEquals(40, deserialized.getChildArray()[1].getChildVal());
     }
 }


### PR DESCRIPTION
This PR adds support for Java arrays to the `Derializer` system. Key changes include:
- `DerializableArrayProcessor`: A new processor to generate serialization and deserialization logic for arrays, including primitive, object, and multidimensional arrays.
- `DerializableProcessor`: Updated to utilize the new array processor and improved to correctly handle imports for `@Derializable` types used within arrays or as generic arguments in collections. It also now better handles cases where a getter returns a different type (e.g., a collection) than the underlying array field.
- `CollectionTestClass` & `DerializableTest`: Updated to include and verify array serialization support.

---
*PR created automatically by Jules for task [3041853763761177125](https://jules.google.com/task/3041853763761177125) started by @Lunkle*