### PR TITLE
Make gamestate randomness deterministic

### DIFF
--- a/nomad-realms/src/main/java/engine/common/math/SerializableRandom.java
+++ b/nomad-realms/src/main/java/engine/common/math/SerializableRandom.java
@@ -1,10 +1,11 @@
 package engine.common.math;
 
-import java.util.concurrent.atomic.AtomicLong;
+import engine.serialization.Derializable;
 
-class SerializableRandom {
+@Derializable
+public class SerializableRandom {
 
-	private AtomicLong seed;
+	private long seed;
 
 	private static final long multiplier = 0x5DEECE66DL;
 	private static final long addend = 0xBL;
@@ -14,17 +15,12 @@ class SerializableRandom {
 	}
 
 	public SerializableRandom(long seed) {
-		this.seed = new AtomicLong(seed);
+		this.seed = (seed ^ multiplier) & mask;
 	}
 
 	protected int next(int bits) {
-		long oldseed, nextseed;
-		AtomicLong seed = this.seed;
-		do {
-			oldseed = seed.get();
-			nextseed = (oldseed * multiplier + addend) & mask;
-		} while (!seed.compareAndSet(oldseed, nextseed));
-		return (int) (nextseed >>> (48 - bits));
+		seed = (seed * multiplier + addend) & mask;
+		return (int) (seed >>> (48 - bits));
 	}
 
 	public int nextInt() {
@@ -53,8 +49,16 @@ class SerializableRandom {
 		return ((long) (next(32)) << 32) + next(32);
 	}
 
+	public float nextFloat() {
+		return next(24) / ((float) (1 << 24));
+	}
+
+	public double nextDouble() {
+		return (((long) (next(26)) << 27) + next(27)) / (double) (1L << 53);
+	}
+
 	public long seed() {
-		return seed.get();
+		return seed;
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/CardPlayerAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/CardPlayerAI.java
@@ -16,7 +16,6 @@ public abstract class CardPlayerAI {
 
 	public CardPlayerAI(CardPlayer self) {
 		this.self = self;
-		thinkingTime = resetThinkingTime();
 	}
 
 	public final void doUpdate(GameState state) {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/CreatureAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/CreatureAI.java
@@ -60,7 +60,7 @@ public class CreatureAI extends CardPlayerAI {
 			if (validTargets.isEmpty()) {
 				return;
 			}
-			target = validTargets.get((int) (Math.random() * validTargets.size()));
+			target = validTargets.get(self.tile().chunk().zone().rng().nextInt(validTargets.size()));
 		}
 
 		self.addNextPlay(new CardPlayedEvent(cardToPlay, self, target));

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/FeralMonkeyAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/FeralMonkeyAI.java
@@ -95,7 +95,7 @@ public class FeralMonkeyAI extends CardPlayerAI {
 
 	@Override
 	protected int resetThinkingTime() {
-		return (int) (Math.random() * 2) + 10;
+		return self.tile().chunk().zone().rng().nextInt(2) + 10;
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/StupidAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/StupidAI.java
@@ -31,7 +31,7 @@ public class StupidAI extends CardPlayerAI {
 
 	@Override
 	protected int resetThinkingTime() {
-		return (int) (Math.random() * 20) + 24;
+		return self.tile().chunk().zone().rng().nextInt(20) + 24;
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/VillageChiefAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/VillageChiefAI.java
@@ -2,8 +2,8 @@ package nomadrealms.context.game.actor.ai;
 
 import static java.util.Arrays.asList;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.actor.types.cardplayer.CardPlayer;
@@ -39,24 +39,25 @@ public class VillageChiefAI extends CardPlayerAI {
 		if (cardToPlay == null) {
 			return;
 		}
-		List<Tile> neighbors = asList(
-				self.tile().dl(state.world),
-				self.tile().dm(state.world),
-				self.tile().dr(state.world),
-				self.tile().ul(state.world),
-				self.tile().um(state.world),
-				self.tile().ur(state.world)
-		);
-		Collections.shuffle(neighbors);
-		neighbors.stream()
+		List<Tile> neighbors = Stream.of(
+						self.tile().dl(state.world),
+						self.tile().dm(state.world),
+						self.tile().dr(state.world),
+						self.tile().ul(state.world),
+						self.tile().um(state.world),
+						self.tile().ur(state.world)
+				)
 				.filter(tile -> tile != null && tile.actor() == null)
-				.findFirst()
-				.ifPresent(targetTile -> self.addNextPlay(new CardPlayedEvent(cardToPlay, self, targetTile)));
+				.toList();
+		if (!neighbors.isEmpty()) {
+			Tile targetTile = neighbors.get(self.tile().chunk().zone().rng().nextInt(neighbors.size()));
+			self.addNextPlay(new CardPlayedEvent(cardToPlay, self, targetTile));
+		}
 	}
 
 	// Probably change this later
 	@Override
 	protected int resetThinkingTime() {
-        return (int) (Math.random() * 2) + 10;
+		return self.tile().chunk().zone().rng().nextInt(2) + 10;
 	}
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/VillageChiefAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/VillageChiefAI.java
@@ -3,6 +3,7 @@ package nomadrealms.context.game.actor.ai;
 import static java.util.Arrays.asList;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import nomadrealms.context.game.GameState;
@@ -48,7 +49,7 @@ public class VillageChiefAI extends CardPlayerAI {
 						self.tile().ur(state.world)
 				)
 				.filter(tile -> tile != null && tile.actor() == null)
-				.toList();
+				.collect(Collectors.toList());
 		if (!neighbors.isEmpty()) {
 			Tile targetTile = neighbors.get(self.tile().chunk().zone().rng().nextInt(neighbors.size()));
 			self.addNextPlay(new CardPlayedEvent(cardToPlay, self, targetTile));

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/VillageLumberjackAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/VillageLumberjackAI.java
@@ -5,6 +5,7 @@ import static nomadrealms.context.game.item.Item.OAK_LOG;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import nomadrealms.context.game.GameState;
@@ -86,7 +87,7 @@ public class VillageLumberjackAI extends CardPlayerAI {
 							self.tile().ur(state.world)
 					)
 					.filter(tile -> tile != null && tile.actor() == null)
-					.toList();
+					.collect(Collectors.toList());
 			if (!neighbors.isEmpty()) {
 				Tile randomTile = neighbors.get(self.tile().chunk().zone().rng().nextInt(neighbors.size()));
 				self.addNextPlay(new CardPlayedEvent(meanderCard, self, randomTile));

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/VillageLumberjackAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/VillageLumberjackAI.java
@@ -77,23 +77,26 @@ public class VillageLumberjackAI extends CardPlayerAI {
 		// 4. Meander if nothing else to do
 		WorldCard meanderCard = self.deckCollection().deck1().peek();
 		if (meanderCard != null) {
-			Optional<Tile> randomTile = Stream.of(
-						self.tile().dl(state.world),
-						self.tile().dm(state.world),
-						self.tile().dr(state.world),
-						self.tile().ul(state.world),
-						self.tile().um(state.world),
-						self.tile().ur(state.world)
-				)
+			List<Tile> neighbors = Stream.of(
+							self.tile().dl(state.world),
+							self.tile().dm(state.world),
+							self.tile().dr(state.world),
+							self.tile().ul(state.world),
+							self.tile().um(state.world),
+							self.tile().ur(state.world)
+					)
 					.filter(tile -> tile != null && tile.actor() == null)
-					.findAny();
-			randomTile.ifPresent(tile -> self.addNextPlay(new CardPlayedEvent(meanderCard, self, tile)));
+					.toList();
+			if (!neighbors.isEmpty()) {
+				Tile randomTile = neighbors.get(self.tile().chunk().zone().rng().nextInt(neighbors.size()));
+				self.addNextPlay(new CardPlayedEvent(meanderCard, self, randomTile));
+			}
 		}
 	}
 
 	@Override
 	protected int resetThinkingTime() {
-		return (int) (Math.random() * 5) + 15;
+		return self.tile().chunk().zone().rng().nextInt(5) + 15;
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/WolfAI.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/ai/WolfAI.java
@@ -94,7 +94,7 @@ public class WolfAI extends CardPlayerAI {
 
 	@Override
 	protected int resetThinkingTime() {
-		return (int) (Math.random() * 2) + 10;
+		return self.tile().chunk().zone().rng().nextInt(2) + 10;
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Farmer.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Farmer.java
@@ -86,7 +86,7 @@ public class Farmer extends CardPlayer {
 			thinkingTime--;
 			return;
 		}
-		thinkingTime = (int) (Math.random() * 20) + 15;
+		thinkingTime = tile().chunk().zone().rng().nextInt(20) + 15;
 		WorldCard cardToPlay = deckCollection().deck1().peek();
 		switch (cardToPlay.card().targetingInfo().targetType()) {
 			case HEXAGON:

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/effect/PlayCardEffect.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/effect/PlayCardEffect.java
@@ -9,7 +9,6 @@ import static nomadrealms.context.game.card.target.TargetType.NONE;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Random;
 
 import nomadrealms.context.game.actor.Actor;
 import nomadrealms.context.game.actor.types.cardplayer.CardPlayer;
@@ -51,8 +50,7 @@ public class PlayCardEffect extends Effect {
 		if (validTargets.isEmpty()) {
 			return null;
 		}
-		// TODO: use zone random for deterministic rng
-		return validTargets.get(new Random().nextInt(validTargets.size()));
+		return validTargets.get(source.tile().chunk().zone().rng().nextInt(validTargets.size()));
 	}
 
 	public static List<Target> getValidTargets(World world, CardPlayer source, WorldCard card) {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/effect/RestockEffect.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/effect/RestockEffect.java
@@ -16,7 +16,7 @@ public class RestockEffect extends Effect {
 
 	@Override
 	public void resolve(World world) {
-		deck.restock(((CardPlayer) source()).deckCollection().discardZone());
+		deck.restock(((CardPlayer) source()).deckCollection().discardZone(), source().tile().chunk().zone().rng());
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/query/math/RandomIntQuery.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/query/math/RandomIntQuery.java
@@ -3,7 +3,6 @@ package nomadrealms.context.game.card.query.math;
 import static java.util.Collections.singletonList;
 
 import java.util.List;
-import java.util.Random;
 
 import nomadrealms.context.game.card.query.Query;
 import nomadrealms.event.game.effect.EffectContext;
@@ -12,7 +11,6 @@ public class RandomIntQuery implements Query<Integer> {
 
 	private final int min;
 	private final int max;
-	private final Random random = new Random();
 
 	public RandomIntQuery(int min, int max) {
 		this.min = min;
@@ -21,6 +19,6 @@ public class RandomIntQuery implements Query<Integer> {
 
 	@Override
 	public List<Integer> find(EffectContext context) {
-		return singletonList(random.nextInt(max - min + 1) + min);
+		return singletonList(context.source().tile().chunk().zone().rng().nextInt(max - min + 1) + min);
 	}
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -16,6 +16,7 @@ import static java.util.Collections.singletonList;
 
 import engine.common.math.Vector2f;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -149,15 +150,17 @@ public class World {
 	}
 
 	public void update(InputEventFrame inputEventFrame) {
-		Set<Actor> actorsToUpdate = new HashSet<>();
+		Set<Actor> actorsToUpdateSet = new HashSet<>();
 		if (nomad != null && nomad.tile() != null) {
 			List<Chunk> surroundingChunks = nomad.tile().chunk().getSurroundingChunks();
 			for (Chunk chunk : surroundingChunks) {
 				if (chunk != null) {
-					actorsToUpdate.addAll(chunk.actors());
+					actorsToUpdateSet.addAll(chunk.actors());
 				}
 			}
 		}
+		List<Actor> actorsToUpdate = new ArrayList<>(actorsToUpdateSet);
+		actorsToUpdate.sort(Comparator.comparing(a -> a.uuid()));
 		for (Actor actor : actorsToUpdate) {
 			if (actor.dead()) {
 				continue;

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Zone.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/area/Zone.java
@@ -5,9 +5,9 @@ import static nomadrealms.context.game.world.map.area.Tile.TILE_VERTICAL_SPACING
 import static nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate.CHUNK_SIZE;
 import static nomadrealms.context.game.world.map.area.coordinate.ZoneCoordinate.ZONE_SIZE;
 
+import engine.common.math.SerializableRandom;
 import engine.common.math.Vector2f;
 import engine.visuals.constraint.box.ConstraintPair;
-import java.util.Random;
 import nomadrealms.context.game.world.World;
 import nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate;
 import nomadrealms.context.game.world.map.area.coordinate.TileCoordinate;
@@ -40,8 +40,7 @@ public class Zone {
 
 	private GenerationProcess generationProcess;
 
-	private transient Random rng;
-	private int rngCounter = 0;
+	private SerializableRandom rng;
 
 	/**
 	 * No-arg constructor for serialization.
@@ -58,9 +57,8 @@ public class Zone {
 	 * cannot be serialized.
 	 */
 	public void initRNG(long worldSeed) {
-		this.rng = new Random(coord.rngSeed(worldSeed));
-		for (int i = 0; i < rngCounter; i++) {
-			rng.nextInt();
+		if (rng == null) {
+			this.rng = new SerializableRandom(coord.rngSeed(worldSeed));
 		}
 	}
 
@@ -87,6 +85,10 @@ public class Zone {
 
 	public float nextRandomFloat() {
 		return rng.nextFloat();
+	}
+
+	public SerializableRandom rng() {
+		return rng;
 	}
 
 
@@ -173,7 +175,9 @@ public class Zone {
 	 */
 	public void reindex(World world) {
 		this.region = world.getRegion(coord.region());
-		initRNG(world.generation().parameters().seed());
+		if (rng == null) {
+			initRNG(world.generation().parameters().seed());
+		}
 		for (Chunk[] chunkRow : chunks) {
 			for (Chunk chunk : chunkRow) {
 				if (chunk != null) {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/zone/Deck.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/zone/Deck.java
@@ -1,5 +1,6 @@
 package nomadrealms.context.game.zone;
 
+import engine.common.math.SerializableRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,22 +20,22 @@ public class Deck extends WorldCardZone {
 		return this;
 	}
 
-	public void shuffle() {
+	public void shuffle(SerializableRandom rng) {
 		List<WorldCard> newCards = new ArrayList<>();
 		while (!cards.isEmpty()) {
-			int index = (int) (Math.random() * cards.size());
+			int index = rng.nextInt(cards.size());
 			newCards.add(cards.remove(index));
 		}
 		cards = newCards;
 	}
 
-	public void restock(WorldCardZone sharedDiscard) {
+	public void restock(WorldCardZone sharedDiscard, SerializableRandom rng) {
 		List<WorldCard> myDiscardedCards = sharedDiscard.getCards().stream()
 				.filter(card -> card.deck() == this)
 				.collect(Collectors.toList());
 		sharedDiscard.removeCards(myDiscardedCards);
 		addCards(myDiscardedCards);
-		shuffle();
+		shuffle(rng);
 		events.send(new RestockCardZoneEvent<>(this));
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/math/generation/map/OpenSimplexNoise.java
+++ b/nomad-realms/src/main/java/nomadrealms/math/generation/map/OpenSimplexNoise.java
@@ -1,5 +1,7 @@
 package nomadrealms.math.generation.map;
 
+import engine.common.math.SerializableRandom;
+
 /*
  * OpenSimplex (Simplectic) Noise in Java.
  * (v1.0.1 With new gradient set and corresponding normalization factor, 9/19/14)
@@ -27,14 +29,14 @@ public class OpenSimplexNoise {
 
     //Initializes the class using a permutation array generated from a 64-bit seed.
     //Generates a proper permutation (i.e. doesn't merely perform N successive pair swaps on a base array)
-    //Uses java.util.Random
+    //Uses SerializableRandom
     public OpenSimplexNoise(long seed) {
         perm = new short[256];
         permGradIndex3D = new short[256];
         short[] source = new short[256];
         for (short i = 0; i < 256; i++)
             source[i] = i;
-        java.util.Random random = new java.util.Random(seed);
+        SerializableRandom random = new SerializableRandom(seed);
         for (int i = 255; i >= 0; i--) {
             int r = random.nextInt(i + 1);
             perm[i] = source[r];


### PR DESCRIPTION
This PR ensures all game-state-affecting randomness is deterministic and uses the zone's RNG. Key changes include:
- Refactoring `SerializableRandom` to be a public `@Derializable` utility.
- Integrating `SerializableRandom` into the `Zone` class.
- Sorting actors by UUID in `World.update()` to guarantee deterministic RNG consumption order.
- Updating AI classes, card queries/effects, and deck shuffling to use the zone's RNG.
- Making `OpenSimplexNoise` deterministic while keeping visual-only variations (like grass types) non-deterministic as requested.

---
*PR created automatically by Jules for task [7141149173588994933](https://jules.google.com/task/7141149173588994933) started by @Lunkle*