### PR TITLE
UDP Hole Punching for Peer-to-Peer Connectivity

### DIFF
--- a/nomad-realms-server/src/main/java/nomadrealms/event/networking/handler/ServerSyncedEventHandler.java
+++ b/nomad-realms-server/src/main/java/nomadrealms/event/networking/handler/ServerSyncedEventHandler.java
@@ -25,6 +25,7 @@ import nomadrealms.event.networking.HolePunchInitiationInfoPackageEvent;
 import nomadrealms.event.networking.HolePunchInitiationIntentEvent;
 import nomadrealms.event.networking.HolePunchEvent;
 import nomadrealms.event.networking.HolePunchSuccessConfirmationEvent;
+import nomadrealms.event.networking.HolePunchSuccessAcknowledgementEvent;
 import nomadrealms.user.Player;
 
 public class ServerSyncedEventHandler implements SyncedEventHandler {
@@ -144,6 +145,10 @@ public class ServerSyncedEventHandler implements SyncedEventHandler {
 
 	@Override
 	public void resolve(HolePunchSuccessConfirmationEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(HolePunchSuccessAcknowledgementEvent event, PacketAddress address) {
 	}
 
 }

--- a/nomad-realms-server/src/main/java/nomadrealms/event/networking/handler/ServerSyncedEventHandler.java
+++ b/nomad-realms-server/src/main/java/nomadrealms/event/networking/handler/ServerSyncedEventHandler.java
@@ -2,7 +2,10 @@ package nomadrealms.event.networking.handler;
 
 import engine.context.input.networking.packet.address.PacketAddress;
 import engine.networking.NetworkNode;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import nomadrealms.context.game.event.CardPlayedEvent;
 import nomadrealms.context.game.event.DropItemEvent;
@@ -17,6 +20,11 @@ import nomadrealms.event.networking.bootstrap.ConnectToServerEvent;
 import nomadrealms.event.networking.bootstrap.DisconnectFromServerEvent;
 import nomadrealms.event.networking.bootstrap.GetOnlinePlayersEvent;
 import nomadrealms.event.networking.bootstrap.OnlinePlayersListEvent;
+import nomadrealms.event.networking.HolePunchInitiationEvent;
+import nomadrealms.event.networking.HolePunchInitiationInfoPackageEvent;
+import nomadrealms.event.networking.HolePunchInitiationIntentEvent;
+import nomadrealms.event.networking.HolePunchEvent;
+import nomadrealms.event.networking.HolePunchSuccessConfirmationEvent;
 import nomadrealms.user.Player;
 
 public class ServerSyncedEventHandler implements SyncedEventHandler {
@@ -98,6 +106,44 @@ public class ServerSyncedEventHandler implements SyncedEventHandler {
 
 	@Override
 	public void resolve(InteractEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(HolePunchInitiationEvent event, PacketAddress address) {
+		Player initiator = onlinePlayers.stream()
+				.filter(player -> player.address().equals(address))
+				.findFirst()
+				.orElse(null);
+		if (initiator == null) {
+			return;
+		}
+
+		Map<UUID, PacketAddress> nonceToAddress = new HashMap<>();
+		for (Player otherPlayer : onlinePlayers) {
+			if (otherPlayer.address().equals(address)) {
+				continue;
+			}
+			UUID nonce = UUID.randomUUID();
+			nonceToAddress.put(nonce, otherPlayer.address());
+			networkNode.send(new HolePunchInitiationIntentEvent(nonce, initiator), otherPlayer.address());
+		}
+		networkNode.send(new HolePunchInitiationInfoPackageEvent(nonceToAddress), address);
+	}
+
+	@Override
+	public void resolve(HolePunchInitiationInfoPackageEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(HolePunchInitiationIntentEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(HolePunchEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(HolePunchSuccessConfirmationEvent event, PacketAddress address) {
 	}
 
 }

--- a/nomad-realms-server/src/test/java/nomadrealms/networking/NetworkIntegrationTest.java
+++ b/nomad-realms-server/src/test/java/nomadrealms/networking/NetworkIntegrationTest.java
@@ -29,10 +29,10 @@ public class NetworkIntegrationTest {
 		PacketAddress serverAddress = new PacketAddress(InetAddress.getByName("127.0.0.1"), serverPort);
 
 		// Client 1 setup
-		NetworkNode client1Node = new NetworkNode();
-		client1Node.init(0);
+		NetworkState client1State = new NetworkState();
+		client1State.init();
 		List<Player> client1ReceivedPlayers = new ArrayList<>();
-		ClientSyncedEventHandler client1Handler = new ClientSyncedEventHandler(client1ReceivedPlayers);
+		ClientSyncedEventHandler client1Handler = new ClientSyncedEventHandler(client1ReceivedPlayers, client1State);
 
 		// Client 2 setup
 		NetworkNode client2Node = new NetworkNode();
@@ -40,7 +40,7 @@ public class NetworkIntegrationTest {
 
 		try {
 			// Connect Client 1
-			client1Node.send(new ConnectToServerEvent("Player 1"), serverAddress);
+			client1State.send(new ConnectToServerEvent("Player 1"), serverAddress);
 			Thread.sleep(200);
 			serverNode.update(serverHandler::handle);
 			assertEquals(1, onlinePlayers.size());
@@ -53,7 +53,7 @@ public class NetworkIntegrationTest {
 
 			// Verify Client 1 automatically received update
 			Thread.sleep(200);
-			client1Node.update(client1Handler::handle); // Client 1 processes response
+			client1State.update(client1Handler::handle); // Client 1 processes response
 
 			// Verify
 			assertEquals(1, client1ReceivedPlayers.size(), "Client 1 should see one other player (Player 2) automatically");
@@ -61,7 +61,7 @@ public class NetworkIntegrationTest {
 
 		} finally {
 			serverNode.cleanUp();
-			client1Node.cleanUp();
+			client1State.cleanUp();
 			client2Node.cleanUp();
 		}
 	}

--- a/nomad-realms-server/src/test/java/nomadrealms/networking/NetworkIntegrationTest.java
+++ b/nomad-realms-server/src/test/java/nomadrealms/networking/NetworkIntegrationTest.java
@@ -10,6 +10,7 @@ import nomadrealms.event.networking.bootstrap.ConnectToServerEvent;
 import nomadrealms.event.networking.bootstrap.GetOnlinePlayersEvent;
 import nomadrealms.event.networking.handler.ClientSyncedEventHandler;
 import nomadrealms.event.networking.handler.ServerSyncedEventHandler;
+import nomadrealms.networking.NetworkGraph;
 import nomadrealms.user.Player;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +30,7 @@ public class NetworkIntegrationTest {
 		PacketAddress serverAddress = new PacketAddress(InetAddress.getByName("127.0.0.1"), serverPort);
 
 		// Client 1 setup
-		NetworkState client1State = new NetworkState();
+		NetworkGraph client1State = new NetworkGraph();
 		client1State.init();
 		List<Player> client1ReceivedPlayers = new ArrayList<>();
 		ClientSyncedEventHandler client1Handler = new ClientSyncedEventHandler(client1ReceivedPlayers, client1State);

--- a/nomad-realms-server/src/test/java/nomadrealms/networking/NetworkIntegrationTest.java
+++ b/nomad-realms-server/src/test/java/nomadrealms/networking/NetworkIntegrationTest.java
@@ -30,10 +30,10 @@ public class NetworkIntegrationTest {
 		PacketAddress serverAddress = new PacketAddress(InetAddress.getByName("127.0.0.1"), serverPort);
 
 		// Client 1 setup
-		NetworkGraph client1State = new NetworkGraph();
-		client1State.init();
+		NetworkGraph client1Graph = new NetworkGraph();
+		client1Graph.init();
 		List<Player> client1ReceivedPlayers = new ArrayList<>();
-		ClientSyncedEventHandler client1Handler = new ClientSyncedEventHandler(client1ReceivedPlayers, client1State);
+		ClientSyncedEventHandler client1Handler = new ClientSyncedEventHandler(client1ReceivedPlayers, client1Graph);
 
 		// Client 2 setup
 		NetworkNode client2Node = new NetworkNode();
@@ -41,7 +41,7 @@ public class NetworkIntegrationTest {
 
 		try {
 			// Connect Client 1
-			client1State.send(new ConnectToServerEvent("Player 1"), serverAddress);
+			client1Graph.send(new ConnectToServerEvent("Player 1"), serverAddress);
 			Thread.sleep(200);
 			serverNode.update(serverHandler::handle);
 			assertEquals(1, onlinePlayers.size());
@@ -54,7 +54,7 @@ public class NetworkIntegrationTest {
 
 			// Verify Client 1 automatically received update
 			Thread.sleep(200);
-			client1State.update(client1Handler::handle); // Client 1 processes response
+			client1Graph.update(client1Handler::handle); // Client 1 processes response
 
 			// Verify
 			assertEquals(1, client1ReceivedPlayers.size(), "Client 1 should see one other player (Player 2) automatically");
@@ -62,7 +62,7 @@ public class NetworkIntegrationTest {
 
 		} finally {
 			serverNode.cleanUp();
-			client1State.cleanUp();
+			client1Graph.cleanUp();
 			client2Node.cleanUp();
 		}
 	}

--- a/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
@@ -25,7 +25,7 @@ import nomadrealms.event.networking.bootstrap.GetOnlinePlayersEvent;
 import nomadrealms.event.networking.handler.ClientSyncedEventHandler;
 import nomadrealms.networking.Connection;
 import nomadrealms.networking.ConnectionState;
-import nomadrealms.networking.NetworkState;
+import nomadrealms.networking.NetworkGraph;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.ui.custom.join.JoinWorldInterface;
 import nomadrealms.user.Player;
@@ -33,7 +33,7 @@ import nomadrealms.user.Player;
 public class JoinWorldContext extends GameContext {
 
 	private RenderingEnvironment re;
-	private final NetworkState networkState = new NetworkState();
+	private final NetworkGraph networkState = new NetworkGraph();
 	private ClientSyncedEventHandler eventHandler;
 	private List<Player> onlinePlayers = new ArrayList<>();
 

--- a/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
@@ -9,18 +9,23 @@ import engine.context.input.event.MouseMovedInputEvent;
 import engine.context.input.event.MousePressedInputEvent;
 import engine.context.input.event.MouseReleasedInputEvent;
 import engine.context.input.networking.packet.address.PacketAddress;
-import engine.networking.NetworkNode;
 import engine.visuals.rendering.text.TextFormat;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import nomadrealms.event.networking.HolePunchEvent;
+import nomadrealms.event.networking.HolePunchInitiationEvent;
+import nomadrealms.event.networking.HolePunchSuccessConfirmationEvent;
 import nomadrealms.event.networking.PingSyncedEvent;
 import nomadrealms.event.networking.bootstrap.ConnectToServerEvent;
 import nomadrealms.event.networking.bootstrap.DisconnectFromServerEvent;
 import nomadrealms.event.networking.bootstrap.GetOnlinePlayersEvent;
 import nomadrealms.event.networking.handler.ClientSyncedEventHandler;
+import nomadrealms.networking.Connection;
+import nomadrealms.networking.ConnectionState;
+import nomadrealms.networking.NetworkState;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.ui.custom.join.JoinWorldInterface;
 import nomadrealms.user.Player;
@@ -28,7 +33,7 @@ import nomadrealms.user.Player;
 public class JoinWorldContext extends GameContext {
 
 	private RenderingEnvironment re;
-	private final NetworkNode networkNode = new NetworkNode();
+	private final NetworkState networkState = new NetworkState();
 	private ClientSyncedEventHandler eventHandler;
 	private List<Player> onlinePlayers = new ArrayList<>();
 
@@ -41,26 +46,31 @@ public class JoinWorldContext extends GameContext {
 	@Override
 	public void init() {
 		re = new RenderingEnvironment(glContext(), config(), mouse());
-		networkNode.init();
+		networkState.init();
 
 		joinWorldInterface = new JoinWorldInterface(re, glContext(), inputCallbackRegistry);
 		joinWorldInterface.initHomeButton(() -> {
 			if (serverAddress != null && playerName != null) {
-				networkNode.send(new DisconnectFromServerEvent(playerName), serverAddress);
+				networkState.send(new DisconnectFromServerEvent(playerName), serverAddress);
 			}
 			transition(new HomeScreenContext());
 		});
+		joinWorldInterface.initConnectToPeersButton(() -> {
+			if (serverAddress != null) {
+				networkState.send(new HolePunchInitiationEvent(), serverAddress);
+			}
+		});
 
-		eventHandler = new ClientSyncedEventHandler(onlinePlayers);
+		eventHandler = new ClientSyncedEventHandler(onlinePlayers, networkState);
 
 		try {
 			serverAddress = new PacketAddress(InetAddress.getByName("localhost"), 44999);
 			playerName = "Player-" + UUID.randomUUID().toString().substring(0, 4);
 
 			System.out.println("Sending PingSyncedEvent to " + serverAddress);
-			networkNode.send(new PingSyncedEvent("Ping from PingApp", System.currentTimeMillis()), serverAddress);
+			networkState.send(new PingSyncedEvent("Ping from PingApp", System.currentTimeMillis()), serverAddress);
 			System.out.println("Sending connect event to " + serverAddress);
-			networkNode.send(new ConnectToServerEvent(playerName), serverAddress);
+			networkState.send(new ConnectToServerEvent(playerName), serverAddress);
 		} catch (UnknownHostException e) {
 			e.printStackTrace();
 		}
@@ -69,19 +79,26 @@ public class JoinWorldContext extends GameContext {
 	@Override
 	public void update() {
 		if (initialized()) {
-			networkNode.update(eventHandler::handle);
+			networkState.update(eventHandler::handle);
+			for (Connection connection : networkState.connections()) {
+				if (connection.state() == ConnectionState.LISTENING) {
+					networkState.send(new HolePunchEvent(connection.nonce()), connection.targetAddress());
+				} else if (connection.state() == ConnectionState.RECEIVING) {
+					networkState.send(new HolePunchSuccessConfirmationEvent(connection.nonce()), connection.targetAddress());
+				}
+			}
 		}
 	}
 
 	@Override
 	public void render(float alpha) {
 		background(rgb(50, 50, 50));
-		joinWorldInterface.render(re, onlinePlayers);
+		joinWorldInterface.render(re, onlinePlayers, networkState.connections());
 	}
 
 	@Override
 	public void cleanUp() {
-		networkNode.cleanUp();
+		networkState.cleanUp();
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import nomadrealms.event.networking.HolePunchEvent;
 import nomadrealms.event.networking.HolePunchInitiationEvent;
 import nomadrealms.event.networking.HolePunchSuccessConfirmationEvent;
+import nomadrealms.event.networking.HolePunchSuccessAcknowledgementEvent;
 import nomadrealms.event.networking.PingSyncedEvent;
 import nomadrealms.event.networking.bootstrap.ConnectToServerEvent;
 import nomadrealms.event.networking.bootstrap.DisconnectFromServerEvent;
@@ -85,6 +86,9 @@ public class JoinWorldContext extends GameContext {
 					networkGraph.send(new HolePunchEvent(connection.nonce()), connection.targetAddress());
 				} else if (connection.state() == ConnectionState.RECEIVING) {
 					networkGraph.send(new HolePunchSuccessConfirmationEvent(connection.nonce()), connection.targetAddress());
+				} else if (connection.state() == ConnectionState.HEALTHY && connection.ackFramesLeft() > 0) {
+					networkGraph.send(new HolePunchSuccessAcknowledgementEvent(connection.nonce()), connection.targetAddress());
+					connection.ackFramesLeft(connection.ackFramesLeft() - 1);
 				}
 			}
 		}

--- a/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
@@ -86,9 +86,6 @@ public class JoinWorldContext extends GameContext {
 					networkGraph.send(new HolePunchEvent(connection.nonce()), connection.targetAddress());
 				} else if (connection.state() == ConnectionState.RECEIVING) {
 					networkGraph.send(new HolePunchSuccessConfirmationEvent(connection.nonce()), connection.targetAddress());
-				} else if (connection.state() == ConnectionState.HEALTHY && connection.ackFramesLeft() > 0) {
-					networkGraph.send(new HolePunchSuccessAcknowledgementEvent(connection.nonce()), connection.targetAddress());
-					connection.ackFramesLeft(connection.ackFramesLeft() - 1);
 				}
 			}
 		}

--- a/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/JoinWorldContext.java
@@ -33,7 +33,7 @@ import nomadrealms.user.Player;
 public class JoinWorldContext extends GameContext {
 
 	private RenderingEnvironment re;
-	private final NetworkGraph networkState = new NetworkGraph();
+	private final NetworkGraph networkGraph = new NetworkGraph();
 	private ClientSyncedEventHandler eventHandler;
 	private List<Player> onlinePlayers = new ArrayList<>();
 
@@ -46,31 +46,31 @@ public class JoinWorldContext extends GameContext {
 	@Override
 	public void init() {
 		re = new RenderingEnvironment(glContext(), config(), mouse());
-		networkState.init();
+		networkGraph.init();
 
 		joinWorldInterface = new JoinWorldInterface(re, glContext(), inputCallbackRegistry);
 		joinWorldInterface.initHomeButton(() -> {
 			if (serverAddress != null && playerName != null) {
-				networkState.send(new DisconnectFromServerEvent(playerName), serverAddress);
+				networkGraph.send(new DisconnectFromServerEvent(playerName), serverAddress);
 			}
 			transition(new HomeScreenContext());
 		});
 		joinWorldInterface.initConnectToPeersButton(() -> {
 			if (serverAddress != null) {
-				networkState.send(new HolePunchInitiationEvent(), serverAddress);
+				networkGraph.send(new HolePunchInitiationEvent(), serverAddress);
 			}
 		});
 
-		eventHandler = new ClientSyncedEventHandler(onlinePlayers, networkState);
+		eventHandler = new ClientSyncedEventHandler(onlinePlayers, networkGraph);
 
 		try {
 			serverAddress = new PacketAddress(InetAddress.getByName("localhost"), 44999);
 			playerName = "Player-" + UUID.randomUUID().toString().substring(0, 4);
 
 			System.out.println("Sending PingSyncedEvent to " + serverAddress);
-			networkState.send(new PingSyncedEvent("Ping from PingApp", System.currentTimeMillis()), serverAddress);
+			networkGraph.send(new PingSyncedEvent("Ping from PingApp", System.currentTimeMillis()), serverAddress);
 			System.out.println("Sending connect event to " + serverAddress);
-			networkState.send(new ConnectToServerEvent(playerName), serverAddress);
+			networkGraph.send(new ConnectToServerEvent(playerName), serverAddress);
 		} catch (UnknownHostException e) {
 			e.printStackTrace();
 		}
@@ -79,12 +79,12 @@ public class JoinWorldContext extends GameContext {
 	@Override
 	public void update() {
 		if (initialized()) {
-			networkState.update(eventHandler::handle);
-			for (Connection connection : networkState.connections()) {
+			networkGraph.update(eventHandler::handle);
+			for (Connection connection : networkGraph.connections()) {
 				if (connection.state() == ConnectionState.LISTENING) {
-					networkState.send(new HolePunchEvent(connection.nonce()), connection.targetAddress());
+					networkGraph.send(new HolePunchEvent(connection.nonce()), connection.targetAddress());
 				} else if (connection.state() == ConnectionState.RECEIVING) {
-					networkState.send(new HolePunchSuccessConfirmationEvent(connection.nonce()), connection.targetAddress());
+					networkGraph.send(new HolePunchSuccessConfirmationEvent(connection.nonce()), connection.targetAddress());
 				}
 			}
 		}
@@ -93,12 +93,12 @@ public class JoinWorldContext extends GameContext {
 	@Override
 	public void render(float alpha) {
 		background(rgb(50, 50, 50));
-		joinWorldInterface.render(re, onlinePlayers, networkState.connections());
+		joinWorldInterface.render(re, onlinePlayers, networkGraph.connections());
 	}
 
 	@Override
 	public void cleanUp() {
-		networkState.cleanUp();
+		networkGraph.cleanUp();
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchEvent.java
@@ -4,6 +4,13 @@ import engine.context.input.networking.packet.address.PacketAddress;
 import engine.serialization.Derializable;
 import java.util.UUID;
 
+/**
+ * Sent between clients to perform the actual UDP hole punching.
+ * <p>
+ * Sender: Client
+ * <p>
+ * Receiver: Client
+ */
 @Derializable
 public class HolePunchEvent implements SyncedEvent {
 

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchEvent.java
@@ -1,0 +1,28 @@
+package nomadrealms.event.networking;
+
+import engine.context.input.networking.packet.address.PacketAddress;
+import engine.serialization.Derializable;
+import java.util.UUID;
+
+@Derializable
+public class HolePunchEvent implements SyncedEvent {
+
+	private UUID nonce;
+
+	public HolePunchEvent() {
+	}
+
+	public HolePunchEvent(UUID nonce) {
+		this.nonce = nonce;
+	}
+
+	public UUID nonce() {
+		return nonce;
+	}
+
+	@Override
+	public void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchInitiationEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchInitiationEvent.java
@@ -3,6 +3,13 @@ package nomadrealms.event.networking;
 import engine.context.input.networking.packet.address.PacketAddress;
 import engine.serialization.Derializable;
 
+/**
+ * Sent by a client to the server to initiate the UDP hole punching process with all other online players.
+ * <p>
+ * Sender: Client
+ * <p>
+ * Receiver: Server
+ */
 @Derializable
 public class HolePunchInitiationEvent implements SyncedEvent {
 

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchInitiationEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchInitiationEvent.java
@@ -1,0 +1,17 @@
+package nomadrealms.event.networking;
+
+import engine.context.input.networking.packet.address.PacketAddress;
+import engine.serialization.Derializable;
+
+@Derializable
+public class HolePunchInitiationEvent implements SyncedEvent {
+
+	public HolePunchInitiationEvent() {
+	}
+
+	@Override
+	public void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchInitiationInfoPackageEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchInitiationInfoPackageEvent.java
@@ -5,6 +5,13 @@ import engine.serialization.Derializable;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * Sent by the server to the initiating client, containing the nonce and public IP address for each peer.
+ * <p>
+ * Sender: Server
+ * <p>
+ * Receiver: Client (Initiator)
+ */
 @Derializable
 public class HolePunchInitiationInfoPackageEvent implements SyncedEvent {
 

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchInitiationInfoPackageEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchInitiationInfoPackageEvent.java
@@ -1,0 +1,29 @@
+package nomadrealms.event.networking;
+
+import engine.context.input.networking.packet.address.PacketAddress;
+import engine.serialization.Derializable;
+import java.util.Map;
+import java.util.UUID;
+
+@Derializable
+public class HolePunchInitiationInfoPackageEvent implements SyncedEvent {
+
+	private Map<UUID, PacketAddress> nonceToAddress;
+
+	public HolePunchInitiationInfoPackageEvent() {
+	}
+
+	public HolePunchInitiationInfoPackageEvent(Map<UUID, PacketAddress> nonceToAddress) {
+		this.nonceToAddress = nonceToAddress;
+	}
+
+	public Map<UUID, PacketAddress> nonceToAddress() {
+		return nonceToAddress;
+	}
+
+	@Override
+	public void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchInitiationIntentEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchInitiationIntentEvent.java
@@ -1,0 +1,35 @@
+package nomadrealms.event.networking;
+
+import engine.context.input.networking.packet.address.PacketAddress;
+import engine.serialization.Derializable;
+import java.util.UUID;
+import nomadrealms.user.Player;
+
+@Derializable
+public class HolePunchInitiationIntentEvent implements SyncedEvent {
+
+	private UUID nonce;
+	private Player initiator;
+
+	public HolePunchInitiationIntentEvent() {
+	}
+
+	public HolePunchInitiationIntentEvent(UUID nonce, Player initiator) {
+		this.nonce = nonce;
+		this.initiator = initiator;
+	}
+
+	public UUID nonce() {
+		return nonce;
+	}
+
+	public Player initiator() {
+		return initiator;
+	}
+
+	@Override
+	public void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchInitiationIntentEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchInitiationIntentEvent.java
@@ -5,6 +5,13 @@ import engine.serialization.Derializable;
 import java.util.UUID;
 import nomadrealms.user.Player;
 
+/**
+ * Sent by the server to all peers of an initiating client to inform them about the intent to hole punch.
+ * <p>
+ * Sender: Server
+ * <p>
+ * Receiver: Client (Peer)
+ */
 @Derializable
 public class HolePunchInitiationIntentEvent implements SyncedEvent {
 

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchSuccessAcknowledgementEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchSuccessAcknowledgementEvent.java
@@ -1,0 +1,35 @@
+package nomadrealms.event.networking;
+
+import engine.context.input.networking.packet.address.PacketAddress;
+import engine.serialization.Derializable;
+import java.util.UUID;
+
+/**
+ * Sent as an acknowledgement of receiving a {@link HolePunchSuccessConfirmationEvent}.
+ * <p>
+ * Sender: Client
+ * <p>
+ * Receiver: Client
+ */
+@Derializable
+public class HolePunchSuccessAcknowledgementEvent implements SyncedEvent {
+
+	private UUID nonce;
+
+	public HolePunchSuccessAcknowledgementEvent() {
+	}
+
+	public HolePunchSuccessAcknowledgementEvent(UUID nonce) {
+		this.nonce = nonce;
+	}
+
+	public UUID nonce() {
+		return nonce;
+	}
+
+	@Override
+	public void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchSuccessConfirmationEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchSuccessConfirmationEvent.java
@@ -1,0 +1,28 @@
+package nomadrealms.event.networking;
+
+import engine.context.input.networking.packet.address.PacketAddress;
+import engine.serialization.Derializable;
+import java.util.UUID;
+
+@Derializable
+public class HolePunchSuccessConfirmationEvent implements SyncedEvent {
+
+	private UUID nonce;
+
+	public HolePunchSuccessConfirmationEvent() {
+	}
+
+	public HolePunchSuccessConfirmationEvent(UUID nonce) {
+		this.nonce = nonce;
+	}
+
+	public UUID nonce() {
+		return nonce;
+	}
+
+	@Override
+	public void accept(SyncedEventHandler handler, PacketAddress address) {
+		handler.resolve(this, address);
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchSuccessConfirmationEvent.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/HolePunchSuccessConfirmationEvent.java
@@ -4,6 +4,13 @@ import engine.context.input.networking.packet.address.PacketAddress;
 import engine.serialization.Derializable;
 import java.util.UUID;
 
+/**
+ * Sent between clients once a {@link HolePunchEvent} has been received, confirming a successful hole punch.
+ * <p>
+ * Sender: Client
+ * <p>
+ * Receiver: Client
+ */
 @Derializable
 public class HolePunchSuccessConfirmationEvent implements SyncedEvent {
 

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/SyncedEventHandler.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/SyncedEventHandler.java
@@ -51,4 +51,6 @@ public interface SyncedEventHandler {
 
 	void resolve(HolePunchSuccessConfirmationEvent event, PacketAddress address);
 
+	void resolve(HolePunchSuccessAcknowledgementEvent event, PacketAddress address);
+
 }

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/SyncedEventHandler.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/SyncedEventHandler.java
@@ -41,4 +41,14 @@ public interface SyncedEventHandler {
 
 	void resolve(InteractEvent event, PacketAddress address);
 
+	void resolve(HolePunchInitiationEvent event, PacketAddress address);
+
+	void resolve(HolePunchInitiationInfoPackageEvent event, PacketAddress address);
+
+	void resolve(HolePunchInitiationIntentEvent event, PacketAddress address);
+
+	void resolve(HolePunchEvent event, PacketAddress address);
+
+	void resolve(HolePunchSuccessConfirmationEvent event, PacketAddress address);
+
 }

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
@@ -23,6 +23,7 @@ import nomadrealms.event.networking.HolePunchInitiationInfoPackageEvent;
 import nomadrealms.event.networking.HolePunchInitiationIntentEvent;
 import nomadrealms.event.networking.HolePunchEvent;
 import nomadrealms.event.networking.HolePunchSuccessConfirmationEvent;
+import nomadrealms.event.networking.HolePunchSuccessAcknowledgementEvent;
 import nomadrealms.networking.Connection;
 import nomadrealms.networking.ConnectionState;
 import nomadrealms.networking.NetworkGraph;
@@ -144,6 +145,17 @@ public class ClientSyncedEventHandler implements SyncedEventHandler {
 	public void resolve(HolePunchSuccessConfirmationEvent event, PacketAddress address) {
 		networkGraph.getConnection(event.nonce()).ifPresent(connection -> {
 			connection.state(ConnectionState.HEALTHY);
+			connection.ackFramesLeft(60);
+			connection.targetAddress(address);
+			connection.player().address(address);
+		});
+	}
+
+	@Override
+	public void resolve(HolePunchSuccessAcknowledgementEvent event, PacketAddress address) {
+		networkGraph.getConnection(event.nonce()).ifPresent(connection -> {
+			connection.state(ConnectionState.HEALTHY);
+			connection.ackFramesLeft(0);
 			connection.targetAddress(address);
 			connection.player().address(address);
 		});

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
@@ -2,6 +2,8 @@ package nomadrealms.event.networking.handler;
 
 import engine.context.input.networking.packet.address.PacketAddress;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.function.Consumer;
 import nomadrealms.context.game.event.CardPlayedEvent;
 import nomadrealms.context.game.event.DropItemEvent;
@@ -16,17 +18,27 @@ import nomadrealms.event.networking.bootstrap.ConnectToServerEvent;
 import nomadrealms.event.networking.bootstrap.DisconnectFromServerEvent;
 import nomadrealms.event.networking.bootstrap.GetOnlinePlayersEvent;
 import nomadrealms.event.networking.bootstrap.OnlinePlayersListEvent;
+import nomadrealms.event.networking.HolePunchInitiationEvent;
+import nomadrealms.event.networking.HolePunchInitiationInfoPackageEvent;
+import nomadrealms.event.networking.HolePunchInitiationIntentEvent;
+import nomadrealms.event.networking.HolePunchEvent;
+import nomadrealms.event.networking.HolePunchSuccessConfirmationEvent;
+import nomadrealms.networking.Connection;
+import nomadrealms.networking.ConnectionState;
+import nomadrealms.networking.NetworkState;
 import nomadrealms.user.Player;
 
 public class ClientSyncedEventHandler implements SyncedEventHandler {
 
 	private List<Player> onlinePlayers;
+	private NetworkState networkState;
 
 	public ClientSyncedEventHandler() {
 	}
 
-	public ClientSyncedEventHandler(List<Player> onlinePlayers) {
+	public ClientSyncedEventHandler(List<Player> onlinePlayers, NetworkState networkState) {
 		this.onlinePlayers = onlinePlayers;
+		this.networkState = networkState;
 	}
 
 	@Override
@@ -83,6 +95,58 @@ public class ClientSyncedEventHandler implements SyncedEventHandler {
 
 	@Override
 	public void resolve(InteractEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(HolePunchInitiationEvent event, PacketAddress address) {
+	}
+
+	@Override
+	public void resolve(HolePunchInitiationInfoPackageEvent event, PacketAddress address) {
+		for (Map.Entry<UUID, PacketAddress> entry : event.nonceToAddress().entrySet()) {
+			UUID nonce = entry.getKey();
+			PacketAddress peerAddress = entry.getValue();
+			Player peer = onlinePlayers.stream()
+					.filter(p -> p.address().equals(peerAddress))
+					.findFirst()
+					.orElse(null);
+			if (peer != null) {
+				networkState.addConnection(new Connection(peer, nonce));
+			}
+		}
+	}
+
+	@Override
+	public void resolve(HolePunchInitiationIntentEvent event, PacketAddress address) {
+		Player initiatorFromEvent = event.initiator();
+		Player initiator = onlinePlayers.stream()
+				.filter(p -> p.name().equals(initiatorFromEvent.name()))
+				.findFirst()
+				.orElseGet(() -> {
+					onlinePlayers.add(initiatorFromEvent);
+					return initiatorFromEvent;
+				});
+		networkState.addConnection(new Connection(initiator, event.nonce()));
+	}
+
+	@Override
+	public void resolve(HolePunchEvent event, PacketAddress address) {
+		networkState.getConnection(event.nonce()).ifPresent(connection -> {
+			if (connection.state() == ConnectionState.LISTENING) {
+				connection.state(ConnectionState.RECEIVING);
+				connection.targetAddress(address);
+				connection.player().address(address);
+			}
+		});
+	}
+
+	@Override
+	public void resolve(HolePunchSuccessConfirmationEvent event, PacketAddress address) {
+		networkState.getConnection(event.nonce()).ifPresent(connection -> {
+			connection.state(ConnectionState.HEALTHY);
+			connection.targetAddress(address);
+			connection.player().address(address);
+		});
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
@@ -31,14 +31,14 @@ import nomadrealms.user.Player;
 public class ClientSyncedEventHandler implements SyncedEventHandler {
 
 	private List<Player> onlinePlayers;
-	private NetworkGraph networkState;
+	private NetworkGraph networkGraph;
 
 	public ClientSyncedEventHandler() {
 	}
 
-	public ClientSyncedEventHandler(List<Player> onlinePlayers, NetworkGraph networkState) {
+	public ClientSyncedEventHandler(List<Player> onlinePlayers, NetworkGraph networkGraph) {
 		this.onlinePlayers = onlinePlayers;
-		this.networkState = networkState;
+		this.networkGraph = networkGraph;
 	}
 
 	@Override
@@ -111,7 +111,7 @@ public class ClientSyncedEventHandler implements SyncedEventHandler {
 					.findFirst()
 					.orElse(null);
 			if (peer != null) {
-				networkState.addConnection(new Connection(peer, nonce));
+				networkGraph.addConnection(new Connection(peer, nonce));
 			}
 		}
 	}
@@ -126,12 +126,12 @@ public class ClientSyncedEventHandler implements SyncedEventHandler {
 					onlinePlayers.add(initiatorFromEvent);
 					return initiatorFromEvent;
 				});
-		networkState.addConnection(new Connection(initiator, event.nonce()));
+		networkGraph.addConnection(new Connection(initiator, event.nonce()));
 	}
 
 	@Override
 	public void resolve(HolePunchEvent event, PacketAddress address) {
-		networkState.getConnection(event.nonce()).ifPresent(connection -> {
+		networkGraph.getConnection(event.nonce()).ifPresent(connection -> {
 			if (connection.state() == ConnectionState.LISTENING) {
 				connection.state(ConnectionState.RECEIVING);
 				connection.targetAddress(address);
@@ -142,7 +142,7 @@ public class ClientSyncedEventHandler implements SyncedEventHandler {
 
 	@Override
 	public void resolve(HolePunchSuccessConfirmationEvent event, PacketAddress address) {
-		networkState.getConnection(event.nonce()).ifPresent(connection -> {
+		networkGraph.getConnection(event.nonce()).ifPresent(connection -> {
 			connection.state(ConnectionState.HEALTHY);
 			connection.targetAddress(address);
 			connection.player().address(address);

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
@@ -145,9 +145,9 @@ public class ClientSyncedEventHandler implements SyncedEventHandler {
 	public void resolve(HolePunchSuccessConfirmationEvent event, PacketAddress address) {
 		networkGraph.getConnection(event.nonce()).ifPresent(connection -> {
 			connection.state(ConnectionState.HEALTHY);
-			connection.ackFramesLeft(60);
 			connection.targetAddress(address);
 			connection.player().address(address);
+			networkGraph.send(new HolePunchSuccessAcknowledgementEvent(event.nonce()), address);
 		});
 	}
 
@@ -155,7 +155,6 @@ public class ClientSyncedEventHandler implements SyncedEventHandler {
 	public void resolve(HolePunchSuccessAcknowledgementEvent event, PacketAddress address) {
 		networkGraph.getConnection(event.nonce()).ifPresent(connection -> {
 			connection.state(ConnectionState.HEALTHY);
-			connection.ackFramesLeft(0);
 			connection.targetAddress(address);
 			connection.player().address(address);
 		});

--- a/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
+++ b/nomad-realms/src/main/java/nomadrealms/event/networking/handler/ClientSyncedEventHandler.java
@@ -25,18 +25,18 @@ import nomadrealms.event.networking.HolePunchEvent;
 import nomadrealms.event.networking.HolePunchSuccessConfirmationEvent;
 import nomadrealms.networking.Connection;
 import nomadrealms.networking.ConnectionState;
-import nomadrealms.networking.NetworkState;
+import nomadrealms.networking.NetworkGraph;
 import nomadrealms.user.Player;
 
 public class ClientSyncedEventHandler implements SyncedEventHandler {
 
 	private List<Player> onlinePlayers;
-	private NetworkState networkState;
+	private NetworkGraph networkState;
 
 	public ClientSyncedEventHandler() {
 	}
 
-	public ClientSyncedEventHandler(List<Player> onlinePlayers, NetworkState networkState) {
+	public ClientSyncedEventHandler(List<Player> onlinePlayers, NetworkGraph networkState) {
 		this.onlinePlayers = onlinePlayers;
 		this.networkState = networkState;
 	}

--- a/nomad-realms/src/main/java/nomadrealms/networking/Connection.java
+++ b/nomad-realms/src/main/java/nomadrealms/networking/Connection.java
@@ -1,0 +1,45 @@
+package nomadrealms.networking;
+
+import engine.context.input.networking.packet.address.PacketAddress;
+import java.util.UUID;
+import nomadrealms.user.Player;
+
+public class Connection {
+
+	private final Player player;
+	private final UUID nonce;
+	private ConnectionState state;
+	private PacketAddress targetAddress;
+
+	public Connection(Player player, UUID nonce) {
+		this.player = player;
+		this.nonce = nonce;
+		this.state = ConnectionState.LISTENING;
+		this.targetAddress = player.address();
+	}
+
+	public Player player() {
+		return player;
+	}
+
+	public UUID nonce() {
+		return nonce;
+	}
+
+	public ConnectionState state() {
+		return state;
+	}
+
+	public void state(ConnectionState state) {
+		this.state = state;
+	}
+
+	public PacketAddress targetAddress() {
+		return targetAddress;
+	}
+
+	public void targetAddress(PacketAddress targetAddress) {
+		this.targetAddress = targetAddress;
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/networking/Connection.java
+++ b/nomad-realms/src/main/java/nomadrealms/networking/Connection.java
@@ -9,6 +9,7 @@ public class Connection {
 	private final Player player;
 	private final UUID nonce;
 	private ConnectionState state;
+	private int ackFramesLeft;
 	private PacketAddress targetAddress;
 
 	public Connection(Player player, UUID nonce) {
@@ -32,6 +33,14 @@ public class Connection {
 
 	public void state(ConnectionState state) {
 		this.state = state;
+	}
+
+	public int ackFramesLeft() {
+		return ackFramesLeft;
+	}
+
+	public void ackFramesLeft(int ackFramesLeft) {
+		this.ackFramesLeft = ackFramesLeft;
 	}
 
 	public PacketAddress targetAddress() {

--- a/nomad-realms/src/main/java/nomadrealms/networking/Connection.java
+++ b/nomad-realms/src/main/java/nomadrealms/networking/Connection.java
@@ -9,7 +9,6 @@ public class Connection {
 	private final Player player;
 	private final UUID nonce;
 	private ConnectionState state;
-	private int ackFramesLeft;
 	private PacketAddress targetAddress;
 
 	public Connection(Player player, UUID nonce) {
@@ -33,14 +32,6 @@ public class Connection {
 
 	public void state(ConnectionState state) {
 		this.state = state;
-	}
-
-	public int ackFramesLeft() {
-		return ackFramesLeft;
-	}
-
-	public void ackFramesLeft(int ackFramesLeft) {
-		this.ackFramesLeft = ackFramesLeft;
 	}
 
 	public PacketAddress targetAddress() {

--- a/nomad-realms/src/main/java/nomadrealms/networking/ConnectionState.java
+++ b/nomad-realms/src/main/java/nomadrealms/networking/ConnectionState.java
@@ -1,0 +1,7 @@
+package nomadrealms.networking;
+
+public enum ConnectionState {
+	LISTENING,
+	RECEIVING,
+	HEALTHY
+}

--- a/nomad-realms/src/main/java/nomadrealms/networking/NetworkGraph.java
+++ b/nomad-realms/src/main/java/nomadrealms/networking/NetworkGraph.java
@@ -10,7 +10,7 @@ import java.util.function.BiConsumer;
 import nomadrealms.event.networking.SyncedEvent;
 import nomadrealms.user.Player;
 
-public class NetworkState {
+public class NetworkGraph {
 
 	private final NetworkNode networkNode = new NetworkNode();
 	private final List<Connection> connections = new ArrayList<>();

--- a/nomad-realms/src/main/java/nomadrealms/networking/NetworkState.java
+++ b/nomad-realms/src/main/java/nomadrealms/networking/NetworkState.java
@@ -1,0 +1,54 @@
+package nomadrealms.networking;
+
+import engine.context.input.networking.packet.address.PacketAddress;
+import engine.networking.NetworkNode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import nomadrealms.event.networking.SyncedEvent;
+import nomadrealms.user.Player;
+
+public class NetworkState {
+
+	private final NetworkNode networkNode = new NetworkNode();
+	private final List<Connection> connections = new ArrayList<>();
+
+	public void init() {
+		networkNode.init();
+	}
+
+	public void update(BiConsumer<SyncedEvent, PacketAddress> handler) {
+		networkNode.update(handler);
+	}
+
+	public void send(SyncedEvent event, PacketAddress address) {
+		networkNode.send(event, address);
+	}
+
+	public void cleanUp() {
+		networkNode.cleanUp();
+	}
+
+	public List<Connection> connections() {
+		return connections;
+	}
+
+	public void addConnection(Connection connection) {
+		connections.add(connection);
+	}
+
+	public Optional<Connection> getConnection(UUID nonce) {
+		return connections.stream()
+				.filter(c -> c.nonce().equals(nonce))
+				.findFirst();
+	}
+
+	public Optional<Connection> getConnection(Player player) {
+		return connections.stream()
+				.filter(c -> c.player().name().equals(player.name()))
+				.findFirst();
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/join/JoinWorldInterface.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/join/JoinWorldInterface.java
@@ -9,6 +9,8 @@ import engine.visuals.constraint.box.ConstraintPair;
 import engine.visuals.lwjgl.GLContext;
 import engine.visuals.rendering.text.TextFormat;
 import java.util.List;
+import java.util.Optional;
+import nomadrealms.networking.Connection;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.ui.content.ButtonUIContent;
 import nomadrealms.render.ui.content.ScreenContainerContent;
@@ -18,6 +20,7 @@ public class JoinWorldInterface {
 
 	private final ScreenContainerContent joinWorldScreen;
 	private final ButtonUIContent returnHomeButton;
+	private final ButtonUIContent connectToPeersButton;
 
 	public JoinWorldInterface(RenderingEnvironment re, GLContext glContext, InputCallbackRegistry registry) {
 
@@ -32,13 +35,24 @@ public class JoinWorldInterface {
 						dimensions
 				), null);
 		returnHomeButton.registerCallbacks(registry);
+
+		connectToPeersButton = new ButtonUIContent(joinWorldScreen, "Connect to Peers",
+				new ConstraintBox(
+						new ConstraintPair(screen.right().add(absolute(-220)), screen.bottom().add(absolute(-70))),
+						dimensions
+				), null);
+		connectToPeersButton.registerCallbacks(registry);
 	}
 
 	public void initHomeButton(Runnable onClick) {
 		returnHomeButton.setCallbacks(onClick);
 	}
 
-	public void render(RenderingEnvironment re, List<Player> onlinePlayers) {
+	public void initConnectToPeersButton(Runnable onClick) {
+		connectToPeersButton.setCallbacks(onClick);
+	}
+
+	public void render(RenderingEnvironment re, List<Player> onlinePlayers, List<Connection> connections) {
 		joinWorldScreen.render(re);
 
 		float startX = 20;
@@ -60,9 +74,13 @@ public class JoinWorldInterface {
 		// Draw Player List
 		float yOffset = startY + 40;
 		for (Player p : onlinePlayers) {
+			Optional<Connection> connection = connections.stream()
+					.filter(c -> c.player().name().equals(p.name()))
+					.findFirst();
+			String status = connection.map(c -> " [" + c.state() + "]").orElse("");
 			re.textRenderer.render(startX + 10, yOffset,
 					TextFormat.textFormat()
-							.text(p.name() + " (" + p.address() + ")")
+							.text(p.name() + " (" + p.address() + ")" + status)
 							.font(re.font)
 							.fontSize(16)
 							.colour(Colour.rgb(200, 200, 200)));

--- a/nomad-realms/src/main/java/nomadrealms/user/Player.java
+++ b/nomad-realms/src/main/java/nomadrealms/user/Player.java
@@ -30,6 +30,10 @@ public class Player {
 		return address;
 	}
 
+	public void address(PacketAddress address) {
+		this.address = address;
+	}
+
 	public CardPlayer cardPlayer(World world) {
 		if (cardPlayerUuid == null) {
 			return null;


### PR DESCRIPTION
This change implements a server-mediated UDP hole punching protocol to allow direct peer-to-peer communication between players. 

Key components:
1. **NetworkState manager**: Centralizes connection management and wraps `NetworkNode`.
2. **Hole Punch Handshake**: A multi-step protocol involving the server to exchange nonces and discovered IP addresses.
3. **Dynamic NAT traversal**: Clients update peer addresses based on received packets to handle WAN port mapping.
4. **UI integration**: Added a new button in the join world screen and status indicators for each online player.

---
*PR created automatically by Jules for task [7095652798248176476](https://jules.google.com/task/7095652798248176476) started by @Lunkle*