### PR TITLE
Refactor speech bubble logic to Actor base class

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/Actor.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/Actor.java
@@ -21,11 +21,13 @@ import nomadrealms.context.game.event.Target;
 import nomadrealms.context.game.item.Inventory;
 import nomadrealms.context.game.world.World;
 import nomadrealms.context.game.world.map.area.Tile;
+import nomadrealms.context.game.actor.types.HasSpeech;
 import nomadrealms.context.game.world.map.area.coordinate.TileCoordinate;
 import nomadrealms.event.game.effect.EffectContext;
 import nomadrealms.render.Renderable;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.particle.NullParticlePool;
+import nomadrealms.render.ui.custom.speech.SpeechBubble;
 import nomadrealms.render.particle.ParticlePool;
 import nomadrealms.render.particle.spawner.BasicParticleSpawner;
 
@@ -35,10 +37,11 @@ import nomadrealms.render.particle.spawner.BasicParticleSpawner;
  *
  * @author Lunkle
  */
-public abstract class Actor implements HasPosition, HasHealth, HasInventory, Target, Renderable {
+public abstract class Actor implements HasPosition, HasHealth, HasInventory, Target, Renderable, HasSpeech {
 
 	private final UUID uuid = UUID.randomUUID();
 	private transient ParticlePool particlePool = new NullParticlePool();
+	private transient SpeechBubble speech = new SpeechBubble(this);
 
 	protected String name;
 	protected int health;
@@ -87,6 +90,16 @@ public abstract class Actor implements HasPosition, HasHealth, HasInventory, Tar
 
 	public Status status() {
 		return status;
+	}
+
+	@Override
+	public void render(RenderingEnvironment re) {
+		speech().render(re);
+	}
+
+	@Override
+	public SpeechBubble speech() {
+		return speech;
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/CardPlayer.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/CardPlayer.java
@@ -27,9 +27,7 @@ import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.ui.custom.speech.SpeechBubble;
 
 @Derializable
-public abstract class CardPlayer extends Actor implements HasSpeech {
-
-	private transient SpeechBubble speech = new SpeechBubble(this);
+public abstract class CardPlayer extends Actor {
 	
 	private final CardPlayerActionScheduler actionScheduler = new CardPlayerActionScheduler();
 
@@ -146,12 +144,7 @@ public abstract class CardPlayer extends Actor implements HasSpeech {
 	public void render(RenderingEnvironment re) {
 		cardStack().render(re, getScreenPosition(re));
 		status().render(re, getScreenPosition(re));
-		speech().render(re);
-	}
-
-	@Override
-	public SpeechBubble speech() {
-		return speech;
+		super.render(re);
 	}
 
 	public int mana() {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/Structure.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/structure/Structure.java
@@ -26,17 +26,7 @@ import nomadrealms.render.particle.NullParticlePool;
 import nomadrealms.render.particle.ParticlePool;
 import nomadrealms.render.ui.custom.speech.SpeechBubble;
 
-public abstract class Structure extends Actor implements HasSpeech {
-
-	private transient final UUID uuid = UUID.randomUUID();
-
-	private transient ParticlePool particlePool = new NullParticlePool();
-	private transient final SpeechBubble speech = new SpeechBubble(this);
-
-	private TileCoordinate tileCoord;
-	private transient Tile tile;
-	private Inventory inventory;
-	private final Status status = new Status();
+public abstract class Structure extends Actor {
 
 	protected final String image;
 	private final int constructionTime;
@@ -59,12 +49,7 @@ public abstract class Structure extends Actor implements HasSpeech {
 				screenPosition.y() - 0.7f * scale,
 				scale, scale
 		);
-		speech.render(re);
-	}
-
-	@Override
-	public SpeechBubble speech() {
-		return speech;
+		super.render(re);
 	}
 
 	// TODO perhaps reconsider having previousTile for structures


### PR DESCRIPTION
The speech bubble logic was previously duplicated in both `CardPlayer` and `Structure` classes. This PR refactors the logic by moving the `SpeechBubble` field and its corresponding `render` and `speech()` methods into the `Actor` base class. This ensures that all entities extending `Actor` can support speech bubbles without redundant code. Additionally, several shadowed fields in the `Structure` class that were already present in `Actor` have been removed to improve code clarity and maintainability. All existing subclasses have been verified to call `super.render()` where necessary to maintain visual consistency.

---
*PR created automatically by Jules for task [18138262116806788952](https://jules.google.com/task/18138262116806788952) started by @Lunkle*