### PR TITLE
Rename ImageCropBox to CropBox and introduce CroppedTexture

### DIFF
--- a/nomad-realms/src/main/java/engine/visuals/lwjgl/render/CroppedTexture.java
+++ b/nomad-realms/src/main/java/engine/visuals/lwjgl/render/CroppedTexture.java
@@ -1,0 +1,37 @@
+package engine.visuals.lwjgl.render;
+
+import engine.visuals.rendering.texture.CropBox;
+
+public class CroppedTexture {
+
+	private Texture texture;
+	private CropBox cropBox;
+
+	public CroppedTexture(Texture texture) {
+		this(texture, CropBox.IDENTITY);
+	}
+
+	public CroppedTexture(Texture texture, CropBox cropBox) {
+		this.texture = texture;
+		this.cropBox = cropBox;
+	}
+
+	public Texture texture() {
+		return texture;
+	}
+
+	public CroppedTexture texture(Texture texture) {
+		this.texture = texture;
+		return this;
+	}
+
+	public CropBox cropBox() {
+		return cropBox;
+	}
+
+	public CroppedTexture cropBox(CropBox cropBox) {
+		this.cropBox = cropBox;
+		return this;
+	}
+
+}

--- a/nomad-realms/src/main/java/engine/visuals/rendering/texture/CropBox.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/texture/CropBox.java
@@ -5,19 +5,19 @@ import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 import engine.visuals.constraint.box.ConstraintBox;
 
 /**
- * An {@link ImageCropBox} stores a {@link ConstraintBox} that indicates the cropping of an image.
+ * A {@link CropBox} stores a {@link ConstraintBox} that indicates the cropping of an image.
  *
  * @author Lunkle
  */
-public class ImageCropBox {
+public class CropBox {
 
-	public static final ImageCropBox IDENTITY = new ImageCropBox(new ConstraintBox(absolute(0), absolute(0), absolute(1), absolute(1)));
+	public static final CropBox IDENTITY = new CropBox(new ConstraintBox(absolute(0), absolute(0), absolute(1), absolute(1)));
 
 	private final ConstraintBox constraintBox;
 	private boolean flipHorizontal;
 	private boolean flipVertical;
 
-	public ImageCropBox(ConstraintBox constraintBox) {
+	public CropBox(ConstraintBox constraintBox) {
 		this.constraintBox = constraintBox;
 	}
 
@@ -32,12 +32,12 @@ public class ImageCropBox {
 		return box;
 	}
 
-	public ImageCropBox flipHorizontal() {
+	public CropBox flipHorizontal() {
 		flipHorizontal = true;
 		return this;
 	}
 
-	public ImageCropBox flipVertical() {
+	public CropBox flipVertical() {
 		flipVertical = true;
 		return this;
 	}

--- a/nomad-realms/src/main/java/engine/visuals/rendering/texture/TextureRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/texture/TextureRenderer.java
@@ -10,6 +10,7 @@ import engine.visuals.builtin.TextureFragmentShader;
 import engine.visuals.builtin.TexturedTransformationVertexShader;
 import engine.visuals.constraint.box.ConstraintBox;
 import engine.visuals.lwjgl.GLContext;
+import engine.visuals.lwjgl.render.CroppedTexture;
 import engine.visuals.lwjgl.render.Shader;
 import engine.visuals.lwjgl.render.ShaderProgram;
 import engine.visuals.lwjgl.render.Texture;
@@ -57,8 +58,8 @@ public class TextureRenderer {
 		render(texture, constraintBox.x().get(), constraintBox.y().get(), constraintBox.w().get(), constraintBox.h().get());
 	}
 
-	public void render(Texture texture, ConstraintBox constraintBox, ImageCropBox crop) {
-		render(texture, constraintBox.x().get(), constraintBox.y().get(), constraintBox.w().get(), constraintBox.h().get(), crop);
+	public void render(CroppedTexture texture, ConstraintBox constraintBox) {
+		render(texture, constraintBox.x().get(), constraintBox.y().get(), constraintBox.w().get(), constraintBox.h().get());
 	}
 
 	/**
@@ -71,10 +72,14 @@ public class TextureRenderer {
 	 * @param h       the height in pixels
 	 */
 	public void render(Texture texture, float x, float y, float w, float h) {
-		render(texture, x, y, w, h, ImageCropBox.IDENTITY);
+		render(texture, x, y, w, h, CropBox.IDENTITY);
 	}
 
-	public void render(Texture texture, float x, float y, float w, float h, ImageCropBox crop) {
+	public void render(CroppedTexture texture, float x, float y, float w, float h) {
+		render(texture.texture(), x, y, w, h, texture.cropBox());
+	}
+
+	private void render(Texture texture, float x, float y, float w, float h, CropBox crop) {
 		// By default, the rectangle VAO is positioned at (0, 0) in normalized device coordinates with the other corner
 		// at (1, 1) which is the top right corner.
 		// This matrix does the following:
@@ -99,18 +104,26 @@ public class TextureRenderer {
 	 * @param matrix4f the transformation matrix
 	 */
 	public void render(Texture texture, Matrix4f matrix4f) {
-		render(texture, matrix4f, ImageCropBox.IDENTITY);
+		render(texture, matrix4f, CropBox.IDENTITY);
 	}
 
-	public void render(Texture texture, Matrix4f matrix4f, ImageCropBox crop) {
+	public void render(CroppedTexture texture, Matrix4f matrix4f) {
+		render(texture.texture(), matrix4f, texture.cropBox());
+	}
+
+	private void render(Texture texture, Matrix4f matrix4f, CropBox crop) {
 		render(texture, matrix4f, crop, diffuse);
 	}
 
 	public void render(Texture texture, Matrix4f matrix4f, int color) {
-		render(texture, matrix4f, ImageCropBox.IDENTITY, color);
+		render(texture, matrix4f, CropBox.IDENTITY, color);
 	}
 
-	public void render(Texture texture, Matrix4f matrix4f, ImageCropBox crop, int color) {
+	public void render(CroppedTexture texture, Matrix4f matrix4f, int color) {
+		render(texture.texture(), matrix4f, texture.cropBox(), color);
+	}
+
+	private void render(Texture texture, Matrix4f matrix4f, CropBox crop, int color) {
 		program.use(glContext);
 		texture.bind();
 		program.uniforms()

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/StackIcon.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/StackIcon.java
@@ -12,8 +12,9 @@ import engine.visuals.builtin.RectangleVertexArrayObject;
 import engine.visuals.constraint.Constraint;
 import engine.visuals.constraint.box.ConstraintBox;
 import engine.visuals.constraint.misc.TimedConstraint;
+import engine.visuals.lwjgl.render.CroppedTexture;
 import engine.visuals.lwjgl.render.meta.DrawFunction;
-import engine.visuals.rendering.texture.ImageCropBox;
+import engine.visuals.rendering.texture.CropBox;
 import nomadrealms.context.game.actor.types.cardplayer.CardPlayer;
 import nomadrealms.context.game.card.UICard;
 import nomadrealms.context.game.event.Target;
@@ -63,9 +64,11 @@ public class StackIcon implements UI {
 				.set("transform", new Matrix4f(constraintBox, re.glContext))
 				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
 		re.textureRenderer.render(
-				re.imageMap.get(entry.event().card().card().artwork()),
-				new Matrix4f(constraintBox, re.glContext),
-				new ImageCropBox(new ConstraintBox(absolute(0.1f), absolute(0.1f), absolute(0.8f), absolute(0.8f)))
+				new CroppedTexture(
+						re.imageMap.get(entry.event().card().card().artwork()),
+						new CropBox(new ConstraintBox(absolute(0.1f), absolute(0.1f), absolute(0.8f), absolute(0.8f)))
+				),
+				new Matrix4f(constraintBox, re.glContext)
 		);
 
 		if (constraintBox.contains(re.is.mouse.coordinate())) {


### PR DESCRIPTION
This change renames `ImageCropBox` to `CropBox` for brevity and introduces a `CroppedTexture` class that bundles a `Texture` with its `CropBox`. The `TextureRenderer` has been updated to accept `CroppedTexture` in its public API, while the previous methods taking a separate `CropBox` have been made private to encourage the use of the new wrapper class. Existing usages, such as in `StackIcon`, have been updated accordingly.

---
*PR created automatically by Jules for task [13803223906830669942](https://jules.google.com/task/13803223906830669942) started by @Lunkle*