### PR TITLE
Refactor imageMap to use CroppedTexture and Sprite Sheets

### DIFF
--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/HexagonRenderer.java
@@ -4,15 +4,18 @@ import engine.common.colour.Colour;
 import engine.common.loader.StringLoader;
 import engine.common.math.Matrix4f;
 import engine.common.math.Vector2f;
+import engine.common.math.Vector4f;
 import engine.visuals.builtin.RectangleVertexArrayObject;
 import engine.visuals.constraint.box.ConstraintBox;
 import engine.visuals.lwjgl.GLContext;
+import engine.visuals.lwjgl.render.CroppedTexture;
 import engine.visuals.lwjgl.render.FragmentShader;
 import engine.visuals.lwjgl.render.Shader;
 import engine.visuals.lwjgl.render.ShaderProgram;
 import engine.visuals.lwjgl.render.Texture;
 import engine.visuals.lwjgl.render.VertexArrayObject;
 import engine.visuals.lwjgl.render.VertexShader;
+import engine.visuals.rendering.texture.CropBox;
 
 /**
  * A {@link HexagonRenderer} that renders hexagons with optional outlines.
@@ -101,6 +104,14 @@ public class HexagonRenderer {
 	 * Renders a textured hexagon using a transformation matrix (for the unpadded shape) and extra parameters.
 	 */
 	public void renderTextured(Matrix4f matrix4f, float w, float h, int color, Texture texture) {
+		renderTextured(matrix4f, w, h, color, texture, CropBox.IDENTITY);
+	}
+
+	public void renderTextured(Matrix4f matrix4f, float w, float h, int color, CroppedTexture texture) {
+		renderTextured(matrix4f, w, h, color, texture.texture(), texture.cropBox());
+	}
+
+	public void renderTextured(Matrix4f matrix4f, float w, float h, int color, Texture texture, CropBox crop) {
 		float pw = w * (1 + PADDING);
 		float ph = h * (1 + PADDING);
 		Matrix4f paddedMatrix = new Matrix4f(matrix4f)
@@ -114,6 +125,7 @@ public class HexagonRenderer {
 				.set("radius", h * 0.5f)
 				.set("color", Colour.toRangedVector(color))
 				.set("textureSampler", 0)
+				.set("crop", new Vector4f(crop.constraintBox()))
 				.complete();
 		texture.bind(glContext, 0);
 		vao.draw(glContext);

--- a/nomad-realms/src/main/java/engine/visuals/rendering/texture/CropBox.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/texture/CropBox.java
@@ -42,4 +42,13 @@ public class CropBox {
 		return this;
 	}
 
+	public CropBox subBox(float x, float y, float w, float h) {
+		return new CropBox(new ConstraintBox(
+				absolute(constraintBox.x().get() + x * constraintBox.w().get()),
+				absolute(constraintBox.y().get() + y * constraintBox.h().get()),
+				absolute(w * constraintBox.w().get()),
+				absolute(h * constraintBox.h().get())
+		));
+	}
+
 }

--- a/nomad-realms/src/main/java/engine/visuals/rendering/texture/TextureRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/texture/TextureRenderer.java
@@ -40,17 +40,28 @@ public class TextureRenderer {
 	}
 
 	public void render(Texture texture, float x, float y, float w, float h, ShaderProgram program) {
+		render(texture, x, y, w, h, CropBox.IDENTITY, program);
+	}
+
+	public void render(CroppedTexture texture, float x, float y, float w, float h, ShaderProgram program) {
+		render(texture.texture(), x, y, w, h, texture.cropBox(), program);
+	}
+
+	private void render(Texture texture, float x, float y, float w, float h, CropBox crop, ShaderProgram program) {
 		Matrix4f matrix4f = new Matrix4f()
 				.translate(-1, 1)
 				.scale(2, -2)
 				.scale(1 / glContext.width(), 1 / glContext.height())
 				.translate(x, y)
 				.scale(w, h);
-		program
-				.set("transform", matrix4f)
-				.set("textureSampler", 0);
 		program.use(glContext);
 		texture.bind();
+		program.uniforms()
+				.set("transform", matrix4f)
+				.set("textureSampler", 0)
+				.set("color", Colour.toRangedVector(diffuse))
+				.set("crop", new Vector4f(crop.constraintBox()))
+				.complete();
 		vao.draw(glContext);
 	}
 
@@ -136,8 +147,20 @@ public class TextureRenderer {
 	}
 
 	public void render(Texture texture, ShaderProgram program) {
+		render(texture, CropBox.IDENTITY, program);
+	}
+
+	public void render(CroppedTexture texture, ShaderProgram program) {
+		render(texture.texture(), texture.cropBox(), program);
+	}
+
+	public void render(Texture texture, CropBox crop, ShaderProgram program) {
 		program.use(glContext);
 		texture.bind();
+		program.uniforms()
+				.set("textureSampler", 0)
+				.set("crop", new Vector4f(crop.constraintBox()))
+				.complete();
 		vao.draw(glContext);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/weather/Clouds.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/weather/Clouds.java
@@ -8,6 +8,7 @@ import static engine.common.colour.Colour.rgba;
 import static java.lang.Math.min;
 
 import engine.common.math.Vector2f;
+import engine.visuals.lwjgl.render.CroppedTexture;
 import engine.visuals.lwjgl.render.Texture;
 import nomadrealms.context.game.GameState;
 import nomadrealms.render.RenderingEnvironment;
@@ -32,9 +33,9 @@ public class Clouds {
 				(int) (alpha * 255)
 		);
 
-		Texture cloudTexture = re.imageMap.get("clouds");
-		float texWidth = cloudTexture.width() / 3f;
-		float texHeight = cloudTexture.height() / 3f;
+		CroppedTexture cloudTexture = re.imageMap.get("clouds");
+		float texWidth = cloudTexture.texture().width() / 3f;
+		float texHeight = cloudTexture.texture().height() / 3f;
 
 		Vector2f cameraPos = re.is.camera.position().vector();
 		// Parallax factor > 1 means clouds move faster than the world (closer to camera)

--- a/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
@@ -14,6 +14,7 @@ import nomadrealms.context.game.interaction.InteractionState;
 import engine.visuals.builtin.TextureFragmentShader;
 import engine.visuals.builtin.TexturedTransformationVertexShader;
 import engine.visuals.lwjgl.GLContext;
+import engine.visuals.lwjgl.render.CroppedTexture;
 import engine.visuals.lwjgl.render.FragmentShader;
 import engine.visuals.lwjgl.render.FrameBufferObject;
 import engine.visuals.lwjgl.render.ShaderProgram;
@@ -26,6 +27,7 @@ import engine.visuals.rendering.geometry.HexagonRenderer;
 import engine.visuals.rendering.geometry.RectangleRenderer;
 import engine.visuals.rendering.geometry.TriangleRenderer;
 import engine.visuals.rendering.text.TextRenderer;
+import engine.visuals.rendering.texture.SpriteSheet;
 import engine.visuals.rendering.texture.TextureRenderer;
 import java.util.HashMap;
 import java.util.Map;
@@ -69,7 +71,7 @@ public class RenderingEnvironment {
 	public ShaderProgram bloomCombinationShaderProgram;
 
 	public GameFont font;
-	public Map<Object, Texture> imageMap = new HashMap<>();
+	public Map<Object, CroppedTexture> imageMap = new HashMap<>();
 
 	public InteractionState is;
 
@@ -139,97 +141,83 @@ public class RenderingEnvironment {
 	}
 
 	private void loadImages() {
-		imageMap.put("button", new Texture().image(loadImage("/images/button.png")).load());
+		imageMap.put("button", new CroppedTexture(new Texture().image(loadImage("/images/button.png")).load()));
 
-		imageMap.put("nomad", new Texture().image(loadImage("/images/nomad.png")).load());
-		imageMap.put("farmer", new Texture().image(loadImage("/images/farmer.png")).load());
-		imageMap.put("villager_lumberjack", new Texture().image(loadImage("/images/villager_lumberjack.png")).load());
-		imageMap.put("chief", new Texture().image(loadImage("/images/chief.png")).load());
-		imageMap.put("feral_monkey", new Texture().image(loadImage("/images/feral_monkey.png")).load());
-		imageMap.put("wolf", new Texture().image(loadImage("/images/wolf.png")).load());
-		imageMap.put("spiderling", new Texture().image(loadImage("/images/spiderling.png")).load());
-		imageMap.put("oak_log", new Texture().image(loadImage("/images/oak_log.png")).load());
-		imageMap.put("wheat_seed", new Texture().image(loadImage("/images/wheat_seed.png")).load());
-		imageMap.put("gold_coin", new Texture().image(loadImage("/images/wheat_seed.png")).load());
-		imageMap.put("rock_1", new Texture().image(loadImage("/images/rock_1.png")).load());
-		imageMap.put("tree_1", new Texture().image(loadImage("/images/tree_1.png")).load());
-		imageMap.put("fence", new Texture().image(loadImage("/images/fence.png")).load());
-		imageMap.put("oak_tree", new Texture().image(loadImage("/images/oak_tree.png")).load());
-		imageMap.put("pine_tree", new Texture().image(loadImage("/images/pine_tree.png")).load());
-		imageMap.put("chest", new Texture().image(loadImage("/images/chest.png")).load());
-		imageMap.put("deathbloom", new Texture().image(loadImage("/images/deathbloom.png")).load());
+		imageMap.put("nomad", new CroppedTexture(new Texture().image(loadImage("/images/nomad.png")).load()));
+		imageMap.put("farmer", new CroppedTexture(new Texture().image(loadImage("/images/farmer.png")).load()));
+		imageMap.put("villager_lumberjack", new CroppedTexture(new Texture().image(loadImage("/images/villager_lumberjack.png")).load()));
+		imageMap.put("chief", new CroppedTexture(new Texture().image(loadImage("/images/chief.png")).load()));
+		imageMap.put("feral_monkey", new CroppedTexture(new Texture().image(loadImage("/images/feral_monkey.png")).load()));
+		imageMap.put("wolf", new CroppedTexture(new Texture().image(loadImage("/images/wolf.png")).load()));
+		imageMap.put("spiderling", new CroppedTexture(new Texture().image(loadImage("/images/spiderling.png")).load()));
+		imageMap.put("oak_log", new CroppedTexture(new Texture().image(loadImage("/images/oak_log.png")).load()));
+		imageMap.put("wheat_seed", new CroppedTexture(new Texture().image(loadImage("/images/wheat_seed.png")).load()));
+		imageMap.put("gold_coin", new CroppedTexture(new Texture().image(loadImage("/images/wheat_seed.png")).load()));
+		imageMap.put("rock_1", new CroppedTexture(new Texture().image(loadImage("/images/rock_1.png")).load()));
+		imageMap.put("tree_1", new CroppedTexture(new Texture().image(loadImage("/images/tree_1.png")).load()));
+		imageMap.put("fence", new CroppedTexture(new Texture().image(loadImage("/images/fence.png")).load()));
+		imageMap.put("oak_tree", new CroppedTexture(new Texture().image(loadImage("/images/oak_tree.png")).load()));
+		imageMap.put("pine_tree", new CroppedTexture(new Texture().image(loadImage("/images/pine_tree.png")).load()));
+		imageMap.put("chest", new CroppedTexture(new Texture().image(loadImage("/images/chest.png")).load()));
+		imageMap.put("deathbloom", new CroppedTexture(new Texture().image(loadImage("/images/deathbloom.png")).load()));
 
-		imageMap.put("grass_1", new Texture().image(loadImage("/images/decoration/grass_1.png")).load());
-		imageMap.put("grass_2", new Texture().image(loadImage("/images/decoration/grass_2.png")).load());
-		imageMap.put("grass_3", new Texture().image(loadImage("/images/decoration/grass_3.png")).load());
-		imageMap.put("grass_4", new Texture().image(loadImage("/images/decoration/grass_4.png")).load());
-		imageMap.put("grass_5", new Texture().image(loadImage("/images/decoration/grass_5.png")).load());
-		imageMap.put("grass_texture", new Texture().image(loadImage("/images/textures/grass_texture.png")).load());
+		imageMap.put("grass_1", new CroppedTexture(new Texture().image(loadImage("/images/decoration/grass_1.png")).load()));
+		imageMap.put("grass_2", new CroppedTexture(new Texture().image(loadImage("/images/decoration/grass_2.png")).load()));
+		imageMap.put("grass_3", new CroppedTexture(new Texture().image(loadImage("/images/decoration/grass_3.png")).load()));
+		imageMap.put("grass_4", new CroppedTexture(new Texture().image(loadImage("/images/decoration/grass_4.png")).load()));
+		imageMap.put("grass_5", new CroppedTexture(new Texture().image(loadImage("/images/decoration/grass_5.png")).load()));
+		imageMap.put("grass_texture", new CroppedTexture(new Texture().image(loadImage("/images/textures/grass_texture.png")).load()));
 
-		imageMap.put("clouds", new Texture().image(loadImage("/images/clouds.png")).load());
+		imageMap.put("clouds", new CroppedTexture(new Texture().image(loadImage("/images/clouds.png")).load()));
 
-		imageMap.put("up_arrow", new Texture().image(loadImage("/images/icons/ui/up.png")).load());
-		imageMap.put("triangle_indicator", new Texture().image(loadImage("/images/triangle_indicator.png")).load());
+		imageMap.put("up_arrow", new CroppedTexture(new Texture().image(loadImage("/images/icons/ui/up.png")).load()));
+		imageMap.put("triangle_indicator", new CroppedTexture(new Texture().image(loadImage("/images/triangle_indicator.png")).load()));
 
-		imageMap.put("directional_fire_small",
-				new Texture().image(loadImage("/images/particles/directional_fire_small.png")).load());
-		imageMap.put("pill",
-				new Texture().image(loadImage("/images/particles/pill.png")).load());
-		imageMap.put("small_gold_coin_0",
-				new Texture().image(loadImage("/images/particles/small_gold_coin_0.png")).load());
-		imageMap.put("small_gold_coin_1",
-				new Texture().image(loadImage("/images/particles/small_gold_coin_1.png")).load());
-		imageMap.put("small_gold_coin_2",
-				new Texture().image(loadImage("/images/particles/small_gold_coin_2.png")).load());
-		imageMap.put("small_gold_coin_3",
-				new Texture().image(loadImage("/images/particles/small_gold_coin_3.png")).load());
-		imageMap.put("small_gold_coin_4",
-				new Texture().image(loadImage("/images/particles/small_gold_coin_4.png")).load());
-		imageMap.put("small_gold_coin_5",
-				new Texture().image(loadImage("/images/particles/small_gold_coin_5.png")).load());
+		SpriteSheet particleSpriteSheet = SpriteSheet.load("/images/particles/particles.png", "/images/particles/particles.txt");
+		imageMap.putAll(particleSpriteSheet.sprites());
 
 		imageMap.put("electrostatic_zapper",
-				new Texture().image(loadImage("/images/electrostatic_zapper.png")).load());
-		imageMap.put("card_back", new Texture().image(loadImage("/images/card/card_back.png")).load());
-		imageMap.put("card_base", new Texture().image(loadImage("/images/card/card_base.png")).load());
-		imageMap.put("card_bookmarks", new Texture().image(loadImage("/images/card/card_bookmarks.png")).load());
-		imageMap.put("card_separator", new Texture().image(loadImage("/images/card/card_separator.png")).load());
-		imageMap.put("card_text_banner", new Texture().image(loadImage("/images/card/card_text_banner.png")).load());
-		imageMap.put("card_title_banner", new Texture().image(loadImage("/images/card/card_title_banner.png")).load());
-		imageMap.put("card_white_backing", new Texture().image(loadImage("/images/card/card_white_backing.png")).load());
-		imageMap.put("bash", new Texture().image(loadImage("/images/card_art/bash.png")).load());
-		imageMap.put("big_punch", new Texture().image(loadImage("/images/card_art/big_punch.png")).load());
-		imageMap.put("build_house", new Texture().image(loadImage("/images/card_art/build_house.png")).load());
-		imageMap.put("cut_tree", new Texture().image(loadImage("/images/card_art/cut_tree.png")).load());
+				new CroppedTexture(new Texture().image(loadImage("/images/electrostatic_zapper.png")).load()));
+		imageMap.put("card_back", new CroppedTexture(new Texture().image(loadImage("/images/card/card_back.png")).load()));
+		imageMap.put("card_base", new CroppedTexture(new Texture().image(loadImage("/images/card/card_base.png")).load()));
+		imageMap.put("card_bookmarks", new CroppedTexture(new Texture().image(loadImage("/images/card/card_bookmarks.png")).load()));
+		imageMap.put("card_separator", new CroppedTexture(new Texture().image(loadImage("/images/card/card_separator.png")).load()));
+		imageMap.put("card_text_banner", new CroppedTexture(new Texture().image(loadImage("/images/card/card_text_banner.png")).load()));
+		imageMap.put("card_title_banner", new CroppedTexture(new Texture().image(loadImage("/images/card/card_title_banner.png")).load()));
+		imageMap.put("card_white_backing", new CroppedTexture(new Texture().image(loadImage("/images/card/card_white_backing.png")).load()));
+		imageMap.put("bash", new CroppedTexture(new Texture().image(loadImage("/images/card_art/bash.png")).load()));
+		imageMap.put("big_punch", new CroppedTexture(new Texture().image(loadImage("/images/card_art/big_punch.png")).load()));
+		imageMap.put("build_house", new CroppedTexture(new Texture().image(loadImage("/images/card_art/build_house.png")).load()));
+		imageMap.put("cut_tree", new CroppedTexture(new Texture().image(loadImage("/images/card_art/cut_tree.png")).load()));
 		imageMap.put("extra_preparation",
-				new Texture().image(loadImage("/images/card_art/extra_preparation.png")).load());
-		imageMap.put("gather", new Texture().image(loadImage("/images/card_art/gather.png")).load());
-		imageMap.put("meteor", new Texture().image(loadImage("/images/card_art/meteor.png")).load());
-		imageMap.put("move", new Texture().image(loadImage("/images/card_art/move.png")).load());
+				new CroppedTexture(new Texture().image(loadImage("/images/card_art/extra_preparation.png")).load()));
+		imageMap.put("gather", new CroppedTexture(new Texture().image(loadImage("/images/card_art/gather.png")).load()));
+		imageMap.put("meteor", new CroppedTexture(new Texture().image(loadImage("/images/card_art/meteor.png")).load()));
+		imageMap.put("move", new CroppedTexture(new Texture().image(loadImage("/images/card_art/move.png")).load()));
 		imageMap.put("overclocked_machinery",
-				new Texture().image(loadImage("/images/card_art/overclocked_machinery.png")).load());
+				new CroppedTexture(new Texture().image(loadImage("/images/card_art/overclocked_machinery.png")).load()));
 		imageMap.put("refreshing_break",
-				new Texture().image(loadImage("/images/card_art/refreshing_break.png")).load());
-		imageMap.put("regenesis", new Texture().image(loadImage("/images/card_art/regenesis.png")).load());
-		imageMap.put("restore", new Texture().image(loadImage("/images/card_art/restore.png")).load());
-		imageMap.put("teleport", new Texture().image(loadImage("/images/card_art/teleport.png")).load());
-		imageMap.put("zap", new Texture().image(loadImage("/images/card_art/zap.png")).load());
-		imageMap.put("flame_circle", new Texture().image(loadImage("/images/card_art/flame_circle.png")).load());
-		imageMap.put("ice_cube", new Texture().image(loadImage("/images/card_art/ice_cube.png")).load());
+				new CroppedTexture(new Texture().image(loadImage("/images/card_art/refreshing_break.png")).load()));
+		imageMap.put("regenesis", new CroppedTexture(new Texture().image(loadImage("/images/card_art/regenesis.png")).load()));
+		imageMap.put("restore", new CroppedTexture(new Texture().image(loadImage("/images/card_art/restore.png")).load()));
+		imageMap.put("teleport", new CroppedTexture(new Texture().image(loadImage("/images/card_art/teleport.png")).load()));
+		imageMap.put("zap", new CroppedTexture(new Texture().image(loadImage("/images/card_art/zap.png")).load()));
+		imageMap.put("flame_circle", new CroppedTexture(new Texture().image(loadImage("/images/card_art/flame_circle.png")).load()));
+		imageMap.put("ice_cube", new CroppedTexture(new Texture().image(loadImage("/images/card_art/ice_cube.png")).load()));
 		imageMap.put("venomous_strike",
-				new Texture().image(loadImage("/images/card_art/venomous_strike.png")).load());
+				new CroppedTexture(new Texture().image(loadImage("/images/card_art/venomous_strike.png")).load()));
 		imageMap.put("purge_poison",
-				new Texture().image(loadImage("/images/card_art/purge_poison.png")).load());
+				new CroppedTexture(new Texture().image(loadImage("/images/card_art/purge_poison.png")).load()));
 		imageMap.put("heavy_jump",
-				new Texture().image(loadImage("/images/card_art/heavy_jump.png")).load());
+				new CroppedTexture(new Texture().image(loadImage("/images/card_art/heavy_jump.png")).load()));
 		imageMap.put("mind_blast",
-				new Texture().image(loadImage("/images/card_art/mind_blast.png")).load());
+				new CroppedTexture(new Texture().image(loadImage("/images/card_art/mind_blast.png")).load()));
 
-		imageMap.put(BURNED.image(), new Texture().image(loadImage("/images/icons/status/burned.png")).load());
-		imageMap.put(FROZEN.image(), new Texture().image(loadImage("/images/icons/status/frozen.png")).load());
-		imageMap.put(POISON.image(), new Texture().image(loadImage("/images/icons/status/poison.png")).load());
+		imageMap.put(BURNED.image(), new CroppedTexture(new Texture().image(loadImage("/images/icons/status/burned.png")).load()));
+		imageMap.put(FROZEN.image(), new CroppedTexture(new Texture().image(loadImage("/images/icons/status/frozen.png")).load()));
+		imageMap.put(POISON.image(), new CroppedTexture(new Texture().image(loadImage("/images/icons/status/poison.png")).load()));
 		imageMap.put(INVINCIBLE.image(),
-				new Texture().image(loadImage("/images/icons/status/invincible.png")).load());
+				new CroppedTexture(new Texture().image(loadImage("/images/icons/status/invincible.png")).load()));
 	}
 
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/StackIcon.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/StackIcon.java
@@ -63,11 +63,11 @@ public class StackIcon implements UI {
 				.set("color", color)
 				.set("transform", new Matrix4f(constraintBox, re.glContext))
 				.use(new DrawFunction().vao(RectangleVertexArrayObject.instance()).glContext(re.glContext));
+		CroppedTexture artwork = re.imageMap.get(entry.event().card().card().artwork());
 		re.textureRenderer.render(
 				new CroppedTexture(
-						re.imageMap.get(entry.event().card().card().artwork()),
-						new CropBox(new ConstraintBox(absolute(0.1f), absolute(0.1f), absolute(0.8f), absolute(0.8f)))
-				),
+						artwork.texture(),
+						artwork.cropBox().subBox(0.1f, 0.1f, 0.8f, 0.8f)),
 				new Matrix4f(constraintBox, re.glContext)
 		);
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/indicator/PlayerIndicator.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/indicator/PlayerIndicator.java
@@ -7,6 +7,7 @@ import static nomadrealms.context.game.world.map.area.Tile.TILE_RADIUS;
 
 import engine.common.math.Vector2f;
 import engine.visuals.constraint.Constraint;
+import engine.visuals.lwjgl.render.CroppedTexture;
 import engine.visuals.lwjgl.render.Texture;
 import nomadrealms.context.game.actor.types.cardplayer.CardPlayer;
 import nomadrealms.render.RenderingEnvironment;
@@ -22,7 +23,7 @@ public class PlayerIndicator {
 		Vector2f pos = player.getScreenPosition(re).vector();
 		float zoom = re.is.camera.zoom().get();
 		float scale = 0.4f * TILE_RADIUS * zoom;
-		Texture indicator = re.imageMap.get("triangle_indicator");
+		CroppedTexture indicator = re.imageMap.get("triangle_indicator");
 		re.textureRenderer.render(
 				indicator,
 				pos.x() - 0.5f * scale,

--- a/nomad-realms/src/main/resources/shaders/hexagonVertex.glsl
+++ b/nomad-realms/src/main/resources/shaders/hexagonVertex.glsl
@@ -6,8 +6,9 @@ layout(location = 1) in vec2 uv;
 out vec2 texCoord;
 
 uniform mat4 transform;
+uniform vec4 crop = vec4(0, 0, 1, 1);
 
 void main() {
     gl_Position = transform * vec4(position, 1.0);
-    texCoord = uv;
+    texCoord = crop.xy + uv * crop.zw;
 }

--- a/nomad-realms/src/main/resources/shaders/rectangleVertex.glsl
+++ b/nomad-realms/src/main/resources/shaders/rectangleVertex.glsl
@@ -6,8 +6,9 @@ layout(location = 1) in vec2 uv;
 out vec2 texCoord;
 
 uniform mat4 transform;
+uniform vec4 crop = vec4(0, 0, 1, 1);
 
 void main() {
     gl_Position = transform * vec4(position, 1.0);
-    texCoord = uv;
+    texCoord = crop.xy + uv * crop.zw;
 }


### PR DESCRIPTION
I have refactored the `imageMap` in the `RenderingEnvironment` to store `CroppedTexture` objects instead of raw `Texture` objects. I also implemented the loading of the `particles` sprite sheet and updated the rendering system to correctly handle the cropping via shaders.

Key improvements:
- **Sprite Sheet Integration:** The `particles` sprite sheet is now loaded and its sub-textures are added to the `imageMap`, reducing the number of individual texture loads.
- **Unified Texture Handling:** All images in the `imageMap` are now `CroppedTexture` instances, providing a consistent API for rendering sub-regions of textures.
- **Shader Support:** Updated both rectangular and hexagonal shaders to support a `crop` uniform, which is used to transform texture coordinates based on the `CroppedTexture` metadata.
- **Nested Cropping:** Added a `subBox` method to `CropBox` to allow for easy creation of sub-regions from already cropped textures, which was specifically used to fix artwork rendering in `StackIcon`.
- **API Consistency:** Updated `TextureRenderer` with new overloads to handle `CroppedTexture` seamlessly across different rendering methods.

I have verified the changes by ensuring the project compiles and by running relevant unit tests.

---
*PR created automatically by Jules for task [11899741727776294202](https://jules.google.com/task/11899741727776294202) started by @Lunkle*