### PR TITLE
Noise-based wandering clouds with 45-degree trend

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/context/game/GameState.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/GameState.java
@@ -76,6 +76,7 @@ public class GameState {
 	public void update(InputEventFrame inputEventFrame) {
 		frameNumber++;
 		world.update(inputEventFrame);
+		clouds.update();
 	}
 
 	public Tile getMouseHexagon(Mouse mouse, Camera camera) {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/weather/Clouds.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/weather/Clouds.java
@@ -10,11 +10,33 @@ import static java.lang.Math.min;
 import engine.common.math.Vector2f;
 import engine.visuals.lwjgl.render.Texture;
 import nomadrealms.context.game.GameState;
+import nomadrealms.math.generation.map.OpenSimplexNoise;
 import nomadrealms.render.RenderingEnvironment;
 
 public class Clouds {
 
 	private static final float DRIFT_SPEED = 0.5f;
+
+	private transient OpenSimplexNoise noise;
+	private float driftX;
+	private float driftY;
+	private transient long frameCount;
+
+	public void update() {
+		if (noise == null) {
+			// This noise does NOT need to be deterministic as it is cosmetic only.
+			noise = new OpenSimplexNoise(System.currentTimeMillis());
+		}
+		frameCount++;
+		float noiseScale = 0.005f;
+		// Weighted addition: 45 degree trend (up and right) + noise
+		// Trend is (1, -1) * DRIFT_SPEED
+		double nX = noise.eval(frameCount * noiseScale, 0, 0);
+		double nY = noise.eval(0, frameCount * noiseScale, 0);
+
+		driftX += DRIFT_SPEED + (float) nX * 0.5f;
+		driftY += -DRIFT_SPEED + (float) nY * 0.5f;
+	}
 
 	public void render(RenderingEnvironment re, GameState state) {
 		float zoom = re.is.camera.zoom().get();
@@ -43,9 +65,8 @@ public class Clouds {
 		float scaledWidth = texWidth * zoom;
 		float scaledHeight = texHeight * zoom;
 
-		float driftX = -DRIFT_SPEED * state.frameNumber;
 		float offsetX = (driftX - cameraPos.x() * parallaxFactor) * zoom;
-		float offsetY = (-cameraPos.y() * parallaxFactor) * zoom;
+		float offsetY = (driftY - cameraPos.y() * parallaxFactor) * zoom;
 
 		float startX = offsetX % scaledWidth;
 		if (startX > 0) {


### PR DESCRIPTION
This PR implements animated clouds that wander naturally while maintaining a general trend of moving up and to the right at a 45-degree angle.

Key changes:
- Added `OpenSimplexNoise` to `Clouds` for smooth, pseudo-random movement.
- Implemented `Clouds.update()` to calculate and accumulate drift each frame.
- Seeding for the noise is non-deterministic (system time) as the movement is cosmetic only.
- Integrated `Clouds.update()` into the `GameState` update cycle.
- Refactored `Clouds.render()` to utilize the accumulated drift for consistent positioning across frames.

The resulting motion is a smooth "wandering" that trends in the requested direction, providing a more dynamic and natural feel to the game's atmosphere.

---
*PR created automatically by Jules for task [9398297977324858824](https://jules.google.com/task/9398297977324858824) started by @Lunkle*