### PR TITLE
Refactor TextRenderer API to minimize overloads

### DIFF
--- a/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
+++ b/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
@@ -98,7 +98,7 @@ public class ServerContext extends GameContext {
 				.font(re.font)
 				.fontSize(20)
 				.colour(Colour.rgb(255, 255, 255))
-				.transform(re.textRenderer.screenToPixel().copy().translate(startX + 10, startY + 10)));
+				.transform(re.textRenderer.screenToPixel()).pixelPosition(startX + 10, startY + 10));
 
 		// Draw Player List
 		float yOffset = startY + 40;
@@ -109,7 +109,7 @@ public class ServerContext extends GameContext {
 					.font(re.font)
 					.fontSize(16)
 					.colour(Colour.rgb(200, 200, 200))
-					.transform(re.textRenderer.screenToPixel().copy().translate(startX + 10, yOffset)));
+					.transform(re.textRenderer.screenToPixel()).pixelPosition(startX + 10, yOffset));
 			yOffset += 30;
 		}
 		console.render(re);

--- a/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
+++ b/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
@@ -92,22 +92,24 @@ public class ServerContext extends GameContext {
 		re.rectangleRenderer.render(startX, startY, width, height, 10, Colour.rgba(0, 0, 0, 180));
 
 		// Draw Title
-		re.textRenderer.render(startX + 10, startY + 10,
+		re.textRenderer.render(
 			TextFormat.textFormat()
 				.text("Online Players: " + onlinePlayers.size())
 				.font(re.font)
 				.fontSize(20)
-				.colour(Colour.rgb(255, 255, 255)));
+				.colour(Colour.rgb(255, 255, 255))
+				.transform(re.textRenderer.screenToPixel().copy().translate(startX + 10, startY + 10)));
 
 		// Draw Player List
 		float yOffset = startY + 40;
 		for (Player p : onlinePlayers) {
-			re.textRenderer.render(startX + 10, yOffset,
+			re.textRenderer.render(
 				TextFormat.textFormat()
 					.text(p.name() + " (" + p.address() + ")")
 					.font(re.font)
 					.fontSize(16)
-					.colour(Colour.rgb(200, 200, 200)));
+					.colour(Colour.rgb(200, 200, 200))
+					.transform(re.textRenderer.screenToPixel().copy().translate(startX + 10, yOffset)));
 			yOffset += 30;
 		}
 		console.render(re);

--- a/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
+++ b/nomad-realms-server/src/main/java/nomadrealms/app/context/ServerContext.java
@@ -98,7 +98,7 @@ public class ServerContext extends GameContext {
 				.font(re.font)
 				.fontSize(20)
 				.colour(Colour.rgb(255, 255, 255))
-				.transform(re.textRenderer.screenToPixel()).pixelPosition(startX + 10, startY + 10));
+				.transform(re.textRenderer.screenToPixel().copy().translate(startX + 10, startY + 10)));
 
 		// Draw Player List
 		float yOffset = startY + 40;
@@ -109,7 +109,7 @@ public class ServerContext extends GameContext {
 					.font(re.font)
 					.fontSize(16)
 					.colour(Colour.rgb(200, 200, 200))
-					.transform(re.textRenderer.screenToPixel()).pixelPosition(startX + 10, yOffset));
+					.transform(re.textRenderer.screenToPixel().copy().translate(startX + 10, yOffset)));
 			yOffset += 30;
 		}
 		console.render(re);

--- a/nomad-realms/src/main/java/engine/visuals/rendering/text/TextFormat.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/text/TextFormat.java
@@ -16,6 +16,7 @@ public class TextFormat {
 	private HorizontalAlign hAlign = HorizontalAlign.LEFT;
 	private VerticalAlign vAlign = VerticalAlign.TOP;
 	private WrapMode wrapMode = WrapMode.BY_WORD;
+	private float x, y;
 	private Matrix4f transform = new Matrix4f();
 
 	public String text() {
@@ -99,13 +100,27 @@ public class TextFormat {
 		return this;
 	}
 
+	public float x() {
+		return x;
+	}
+
 	public TextFormat x(float x) {
-		this.transform.m30 = x;
+		this.x = x;
 		return this;
 	}
 
+	public float y() {
+		return y;
+	}
+
 	public TextFormat y(float y) {
-		this.transform.m31 = y;
+		this.y = y;
+		return this;
+	}
+
+	public TextFormat pixelPosition(float x, float y) {
+		this.x = x;
+		this.y = y;
 		return this;
 	}
 
@@ -119,6 +134,8 @@ public class TextFormat {
 				.hAlign(hAlign)
 				.vAlign(vAlign)
 				.wrapMode(wrapMode)
+				.x(x)
+				.y(y)
 				.transform(transform.copy());
 	}
 

--- a/nomad-realms/src/main/java/engine/visuals/rendering/text/TextFormat.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/text/TextFormat.java
@@ -16,7 +16,6 @@ public class TextFormat {
 	private HorizontalAlign hAlign = HorizontalAlign.LEFT;
 	private VerticalAlign vAlign = VerticalAlign.TOP;
 	private WrapMode wrapMode = WrapMode.BY_WORD;
-	private float x, y;
 	private Matrix4f transform = new Matrix4f();
 
 	public String text() {
@@ -100,27 +99,13 @@ public class TextFormat {
 		return this;
 	}
 
-	public float x() {
-		return x;
-	}
-
 	public TextFormat x(float x) {
-		this.x = x;
+		this.transform.m30 = x;
 		return this;
-	}
-
-	public float y() {
-		return y;
 	}
 
 	public TextFormat y(float y) {
-		this.y = y;
-		return this;
-	}
-
-	public TextFormat pixelPosition(float x, float y) {
-		this.x = x;
-		this.y = y;
+		this.transform.m31 = y;
 		return this;
 	}
 
@@ -134,8 +119,6 @@ public class TextFormat {
 				.hAlign(hAlign)
 				.vAlign(vAlign)
 				.wrapMode(wrapMode)
-				.x(x)
-				.y(y)
 				.transform(transform.copy());
 	}
 

--- a/nomad-realms/src/main/java/engine/visuals/rendering/text/TextRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/text/TextRenderer.java
@@ -136,7 +136,7 @@ public class TextRenderer {
 				overallYOffset = -textHeight;
 			}
 
-			Matrix4f transform = format.transform().copy().translate(0, overallYOffset);
+			Matrix4f transform = format.transform().copy().translate(format.x(), format.y() + overallYOffset);
 			transform.store(transformArray);
 
 			Vector4f fill = toRangedVector(format.colour());

--- a/nomad-realms/src/main/java/engine/visuals/rendering/text/TextRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/text/TextRenderer.java
@@ -136,7 +136,7 @@ public class TextRenderer {
 				overallYOffset = -textHeight;
 			}
 
-			Matrix4f transform = format.transform().copy().translate(format.x(), format.y() + overallYOffset);
+			Matrix4f transform = format.transform().copy().translate(0, overallYOffset);
 			transform.store(transformArray);
 
 			Vector4f fill = toRangedVector(format.colour());

--- a/nomad-realms/src/main/java/engine/visuals/rendering/text/TextRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/text/TextRenderer.java
@@ -69,35 +69,15 @@ public class TextRenderer {
 		this.shaderProgram = new ShaderProgram().attach(vertex, fragment).load();
 	}
 
-	/**
-	 * Renders text.
-	 *
-	 * @param x         the <code>x</code> offset of the text from the left side of the screen
-	 * @param y         the <code>y</code> offset of the text from the top of the screen
-	 * @param text      the {@link String} to display
-	 * @param lineWidth the max width of each line of text in pixels, or 0 to indicate no wrapping
-	 * @param font      the {@link GameFont} of the text
-	 * @param fontSize  the size of the text
-	 * @param colour    the colour of the text
-	 * @return the number of lines of text rendered
-	 */
-	public int render(float x, float y, TextFormat format) {
-		return render(Collections.singletonList(format.copy().x(x).y(y)), Matrix4f.screenToPixel(glContext));
+	public int render(TextFormat... formats) {
+		return render(List.of(formats));
 	}
 
-	public int render(Matrix4f transform, TextFormat format) {
-		return render(Collections.singletonList(format), transform);
-	}
-
-	public int render(TextFormat format) {
-		return render(Collections.singletonList(format), Matrix4f.screenToPixel(glContext));
+	public Matrix4f screenToPixel() {
+		return Matrix4f.screenToPixel(glContext);
 	}
 
 	public int render(Collection<TextFormat> formats) {
-		return render(formats, Matrix4f.screenToPixel(glContext));
-	}
-
-	public int render(Collection<TextFormat> formats, Matrix4f baseTransform) {
 		if (formats.isEmpty()) {
 			return 0;
 		}
@@ -108,12 +88,12 @@ public class TextRenderer {
 
 		int totalLines = 0;
 		for (Map.Entry<GameFont, List<TextFormat>> entry : fontGroups.entrySet()) {
-			totalLines += renderGroup(entry.getKey(), entry.getValue(), baseTransform);
+			totalLines += renderGroup(entry.getKey(), entry.getValue());
 		}
 		return totalLines;
 	}
 
-	private int renderGroup(GameFont font, List<TextFormat> formats, Matrix4f baseTransform) {
+	private int renderGroup(GameFont font, List<TextFormat> formats) {
 		int totalCharacters = 0;
 		List<List<Line>> formatsLines = new ArrayList<>();
 		List<Float> fontSizes = new ArrayList<>();
@@ -156,7 +136,7 @@ public class TextRenderer {
 				overallYOffset = -textHeight;
 			}
 
-			Matrix4f transform = baseTransform.copy().multiply(format.transform()).translate(0, overallYOffset);
+			Matrix4f transform = format.transform().copy().translate(0, overallYOffset);
 			transform.store(transformArray);
 
 			Vector4f fill = toRangedVector(format.colour());

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/status/Status.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/status/Status.java
@@ -46,7 +46,6 @@ public class Status {
 			float iconY = y - TILE_VERTICAL_SPACING * re.is.camera.zoom().get() / 2;
 			re.textureRenderer.render(re.imageMap.get(status.image()), iconX, iconY, iconSize, iconSize);
 			re.textRenderer.render(
-					iconX + iconSize, iconY + iconSize,
 					textFormat()
 							.text(String.valueOf(count(status)))
 							.font(re.font)
@@ -54,6 +53,7 @@ public class Status {
 							.colour(rgb(255, 255, 255))
 							.hAlign(RIGHT)
 							.vAlign(BOTTOM)
+							.transform(re.textRenderer.screenToPixel().copy().translate(iconX + iconSize, iconY + iconSize))
 			);
 		}
 	}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/status/Status.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/status/Status.java
@@ -53,7 +53,7 @@ public class Status {
 							.colour(rgb(255, 255, 255))
 							.hAlign(RIGHT)
 							.vAlign(BOTTOM)
-							.transform(re.textRenderer.screenToPixel()).pixelPosition(iconX + iconSize, iconY + iconSize)
+							.transform(re.textRenderer.screenToPixel().copy().translate(iconX + iconSize, iconY + iconSize))
 			);
 		}
 	}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/status/Status.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/status/Status.java
@@ -53,7 +53,7 @@ public class Status {
 							.colour(rgb(255, 255, 255))
 							.hAlign(RIGHT)
 							.vAlign(BOTTOM)
-							.transform(re.textRenderer.screenToPixel().copy().translate(iconX + iconSize, iconY + iconSize))
+							.transform(re.textRenderer.screenToPixel()).pixelPosition(iconX + iconSize, iconY + iconSize)
 			);
 		}
 	}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Bub.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Bub.java
@@ -45,23 +45,21 @@ public class Bub extends CardPlayer {
 				scale, scale
 		);
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.1f * scale,
 				textFormat()
 						.text(name + " BUB12")
 						.font(re.font)
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
-						.hAlign(CENTER));
+						.hAlign(CENTER)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.5f * scale,
 				textFormat()
 						.text(health() + " HP")
 						.font(re.font)
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
-						.hAlign(CENTER));
+						.hAlign(CENTER)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Bub.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Bub.java
@@ -51,7 +51,7 @@ public class Bub extends CardPlayer {
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale));
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
 		re.textRenderer.render(
 				textFormat()
 						.text(health() + " HP")
@@ -59,7 +59,7 @@ public class Bub extends CardPlayer {
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale));
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Bub.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Bub.java
@@ -51,7 +51,7 @@ public class Bub extends CardPlayer {
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale));
 		re.textRenderer.render(
 				textFormat()
 						.text(health() + " HP")
@@ -59,7 +59,7 @@ public class Bub extends CardPlayer {
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Farmer.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Farmer.java
@@ -60,7 +60,7 @@ public class Farmer extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale))
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale)
 		);
 		re.textRenderer.render(
 				textFormat()
@@ -70,7 +70,7 @@ public class Farmer extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale))
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale)
 		);
 		super.render(re);
 	}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Farmer.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Farmer.java
@@ -60,7 +60,7 @@ public class Farmer extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale))
 		);
 		re.textRenderer.render(
 				textFormat()
@@ -70,7 +70,7 @@ public class Farmer extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale))
 		);
 		super.render(re);
 	}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Farmer.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Farmer.java
@@ -53,8 +53,6 @@ public class Farmer extends CardPlayer {
 				scale, scale
 		);
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.1f * scale,
 				textFormat()
 						.text(name + " FARMER")
 						.font(re.font)
@@ -62,10 +60,9 @@ public class Farmer extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale))
 		);
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.5f * scale,
 				textFormat()
 						.text(health() + " HP")
 						.font(re.font)
@@ -73,6 +70,7 @@ public class Farmer extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale))
 		);
 		super.render(re);
 	}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/FeralMonkey.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/FeralMonkey.java
@@ -60,7 +60,7 @@ public class FeralMonkey extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale));
 		re.textRenderer.render(
 				textFormat()
 						.text(health() + " HP")
@@ -69,7 +69,7 @@ public class FeralMonkey extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/FeralMonkey.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/FeralMonkey.java
@@ -60,7 +60,7 @@ public class FeralMonkey extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale));
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
 		re.textRenderer.render(
 				textFormat()
 						.text(health() + " HP")
@@ -69,7 +69,7 @@ public class FeralMonkey extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale));
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/FeralMonkey.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/FeralMonkey.java
@@ -53,25 +53,23 @@ public class FeralMonkey extends CardPlayer {
 				screenPosition.y() - 0.7f * scale,
 				scale, scale);
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.1f * scale,
 				textFormat()
 						.text(name + " FERAL MONKEY")
 						.font(re.font)
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.vAlign(TOP));
+						.vAlign(TOP)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.5f * scale,
 				textFormat()
 						.text(health() + " HP")
 						.font(re.font)
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.vAlign(TOP));
+						.vAlign(TOP)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Nomad.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Nomad.java
@@ -54,7 +54,7 @@ public class Nomad extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale));
 		re.textRenderer.render(
 				textFormat()
 						.text(health() + " HP")
@@ -63,7 +63,7 @@ public class Nomad extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Nomad.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Nomad.java
@@ -54,7 +54,7 @@ public class Nomad extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale));
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
 		re.textRenderer.render(
 				textFormat()
 						.text(health() + " HP")
@@ -63,7 +63,7 @@ public class Nomad extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale));
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Nomad.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Nomad.java
@@ -47,25 +47,23 @@ public class Nomad extends CardPlayer {
 				screenPosition.y() - 0.7f * scale,
 				scale, scale);
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.1f * scale,
 				textFormat()
 						.text(name)
 						.font(re.font)
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.vAlign(TOP));
+						.vAlign(TOP)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.5f * scale,
 				textFormat()
 						.text(health() + " HP")
 						.font(re.font)
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.vAlign(TOP));
+						.vAlign(TOP)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageChief.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageChief.java
@@ -48,7 +48,7 @@ public class VillageChief extends CardPlayer {
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale));
 		re.textRenderer.render(
 				textFormat()
 						.text(health() + " HP")
@@ -56,7 +56,7 @@ public class VillageChief extends CardPlayer {
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale));
 		super.render(re);       // Render card stack being played.
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageChief.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageChief.java
@@ -48,7 +48,7 @@ public class VillageChief extends CardPlayer {
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale));
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
 		re.textRenderer.render(
 				textFormat()
 						.text(health() + " HP")
@@ -56,7 +56,7 @@ public class VillageChief extends CardPlayer {
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale));
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
 		super.render(re);       // Render card stack being played.
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageChief.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageChief.java
@@ -42,23 +42,21 @@ public class VillageChief extends CardPlayer {
 				screenPosition.y() - 0.7f * scale,
 				scale, scale);
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.1f * scale,
 				textFormat()
 						.text(name + " VILLAGE CHIEF")
 						.font(re.font)
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
-						.hAlign(CENTER));
+						.hAlign(CENTER)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.5f * scale,
 				textFormat()
 						.text(health() + " HP")
 						.font(re.font)
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
-						.hAlign(CENTER));
+						.hAlign(CENTER)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
 		super.render(re);       // Render card stack being played.
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageLumberjack.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageLumberjack.java
@@ -63,7 +63,7 @@ public class VillageLumberjack extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale))
 		);
 		re.textRenderer.render(
 				textFormat()
@@ -73,7 +73,7 @@ public class VillageLumberjack extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale))
 		);
 		super.render(re);
 	}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageLumberjack.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageLumberjack.java
@@ -56,8 +56,6 @@ public class VillageLumberjack extends CardPlayer {
 				scale, scale
 		);
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.1f * scale,
 				textFormat()
 						.text(name + " LUMBERJACK")
 						.font(re.font)
@@ -65,10 +63,9 @@ public class VillageLumberjack extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale))
 		);
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.5f * scale,
 				textFormat()
 						.text(health() + " HP")
 						.font(re.font)
@@ -76,6 +73,7 @@ public class VillageLumberjack extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale))
 		);
 		super.render(re);
 	}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageLumberjack.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/VillageLumberjack.java
@@ -63,7 +63,7 @@ public class VillageLumberjack extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale))
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale)
 		);
 		re.textRenderer.render(
 				textFormat()
@@ -73,7 +73,7 @@ public class VillageLumberjack extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale))
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale)
 		);
 		super.render(re);
 	}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Wolf.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Wolf.java
@@ -50,25 +50,23 @@ public class Wolf extends CardPlayer {
 				screenPosition.y() - 0.7f * scale,
 				scale, scale);
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.1f * scale,
 				textFormat()
 						.text(name + " WOLF")
 						.font(re.font)
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.vAlign(TOP));
+						.vAlign(TOP)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.5f * scale,
 				textFormat()
 						.text(health() + " HP")
 						.font(re.font)
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.vAlign(TOP));
+						.vAlign(TOP)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Wolf.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Wolf.java
@@ -57,7 +57,7 @@ public class Wolf extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale));
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
 		re.textRenderer.render(
 				textFormat()
 						.text(health() + " HP")
@@ -66,7 +66,7 @@ public class Wolf extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale));
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Wolf.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/Wolf.java
@@ -57,7 +57,7 @@ public class Wolf extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale));
 		re.textRenderer.render(
 				textFormat()
 						.text(health() + " HP")
@@ -66,7 +66,7 @@ public class Wolf extends CardPlayer {
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/creature/Creature.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/creature/Creature.java
@@ -63,7 +63,7 @@ public class Creature extends CardPlayer {
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale));
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
 		re.textRenderer.render(
 				textFormat()
 						.text(health() + " HP")
@@ -71,7 +71,7 @@ public class Creature extends CardPlayer {
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale));
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/creature/Creature.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/creature/Creature.java
@@ -63,7 +63,7 @@ public class Creature extends CardPlayer {
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.1f * scale));
 		re.textRenderer.render(
 				textFormat()
 						.text(health() + " HP")
@@ -71,7 +71,7 @@ public class Creature extends CardPlayer {
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
 						.hAlign(CENTER)
-						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(screenPosition.x(), screenPosition.y() + 0.5f * scale));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/creature/Creature.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/actor/types/cardplayer/creature/Creature.java
@@ -57,23 +57,21 @@ public class Creature extends CardPlayer {
 				screenPosition.y() - 0.7f * scale,
 				scale, scale);
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.1f * scale,
 				textFormat()
 						.text(name.toUpperCase())
 						.font(re.font)
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
-						.hAlign(CENTER));
+						.hAlign(CENTER)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.1f * scale)));
 		re.textRenderer.render(
-				screenPosition.x(),
-				screenPosition.y() + 0.5f * scale,
 				textFormat()
 						.text(health() + " HP")
 						.font(re.font)
 						.fontSize(0.5f * scale)
 						.colour(rgba(255, 255, 255, (int) (re.is.actorTextOpacity * 255)))
-						.hAlign(CENTER));
+						.hAlign(CENTER)
+						.transform(re.textRenderer.screenToPixel().copy().translate(screenPosition.x(), screenPosition.y() + 0.5f * scale)));
 		super.render(re);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/UICard.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/UICard.java
@@ -118,26 +118,21 @@ public class UICard implements Card {
 		}
 		re.textRenderer
 				.render(
-						physics.cardTransform(
-								re.glContext,
-								new Vector3f(
-										physics.cardBox().w().multiply(0.5f).get(),
-										physics.cardBox().w().multiply(0.18f).get(),
-										0)),
 						textFormat()
 								.text(card.card().title())
 								.font(re.font)
 								.fontSize((15f - card.card.title().length() / 4f) * physics.cardBox().w().get() / 150)
 								.colour(rgb(0, 0, 0))
 								.hAlign(CENTER)
-								.vAlign(MIDDLE));
+								.vAlign(MIDDLE)
+								.transform(physics.cardTransform(
+										re.glContext,
+										new Vector3f(
+												physics.cardBox().w().multiply(0.5f).get(),
+												physics.cardBox().w().multiply(0.18f).get(),
+												0))));
 		re.textRenderer
-				.render(physics.cardTransform(
-								re.glContext,
-								new Vector3f(
-										physics.cardBox().w().multiply(0.56f).get(),
-										physics.cardBox().h().multiply(0.72f).get(),
-										0)),
+				.render(
 						textFormat()
 								.text(card.card().description())
 								.lineWidth(physics.cardBox().w().multiply(0.74f).get())
@@ -145,35 +140,41 @@ public class UICard implements Card {
 								.fontSize(11f * physics.cardBox().w().get() / 150)
 								.colour(rgb(0, 0, 0))
 								.hAlign(CENTER)
-								.vAlign(TOP));
+								.vAlign(TOP)
+								.transform(physics.cardTransform(
+										re.glContext,
+										new Vector3f(
+												physics.cardBox().w().multiply(0.56f).get(),
+												physics.cardBox().h().multiply(0.72f).get(),
+												0))));
 		re.textRenderer.render(
-				physics.cardTransform(
-						re.glContext,
-						new Vector3f(
-								physics.cardBox().w().multiply(0.94f).get(),
-								physics.cardBox().h().multiply(0.01f).get(),
-								0)),
 				textFormat()
 						.text(String.valueOf(card.card().resolutionTime()))
 						.font(re.font)
 						.fontSize(16f * physics.cardBox().w().get() / 150)
 						.colour(rgb(0, 0, 0))
 						.hAlign(RIGHT)
-						.vAlign(TOP));
+						.vAlign(TOP)
+						.transform(physics.cardTransform(
+								re.glContext,
+								new Vector3f(
+										physics.cardBox().w().multiply(0.94f).get(),
+										physics.cardBox().h().multiply(0.01f).get(),
+										0))));
 		re.textRenderer.render(
-				physics.cardTransform(
-						re.glContext,
-						new Vector3f(
-								physics.cardBox().w().multiply(0.06f).get(),
-								physics.cardBox().h().multiply(0.01f).get(),
-								0)),
 				textFormat()
 						.text(String.valueOf(((GameCard) card.card()).manaCost()))
 						.font(re.font)
 						.fontSize(16f * physics.cardBox().w().get() / 150)
 						.colour(rgb(0, 0, 0))
 						.hAlign(LEFT)
-						.vAlign(TOP));
+						.vAlign(TOP)
+						.transform(physics.cardTransform(
+								re.glContext,
+								new Vector3f(
+										physics.cardBox().w().multiply(0.06f).get(),
+										physics.cardBox().h().multiply(0.01f).get(),
+										0))));
 	}
 
 	/**

--- a/nomad-realms/src/main/java/nomadrealms/context/game/item/UIItem.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/item/UIItem.java
@@ -52,22 +52,20 @@ public class UIItem {
 						new Vector2f(physics.cardBox().w().get(), physics.cardBox().h().get()))
 		);
 		re.textRenderer
-				.render(physics.cardTransform(
-								re.glContext,
-								new Vector3f(0, 0, 0),
-								new Vector2f(1, 1)),
+				.render(
 						textFormat()
 								.text(item.item().title())
 								.font(re.font)
 								.fontSize(20f)
 								.colour(rgb(255, 255, 255))
 								.hAlign(LEFT)
-								.vAlign(TOP));
+								.vAlign(TOP)
+								.transform(physics.cardTransform(
+										re.glContext,
+										new Vector3f(0, 0, 0),
+										new Vector2f(1, 1))));
 		re.textRenderer
-				.render(physics.cardTransform(
-								re.glContext,
-								new Vector3f(0, 40, 0),
-								new Vector2f(1, 1)),
+				.render(
 						textFormat()
 								.text(item.item().description())
 								.lineWidth(100)
@@ -75,7 +73,11 @@ public class UIItem {
 								.fontSize(15f)
 								.colour(rgb(255, 255, 255))
 								.hAlign(LEFT)
-								.vAlign(TOP));
+								.vAlign(TOP)
+								.transform(physics.cardTransform(
+										re.glContext,
+										new Vector3f(0, 40, 0),
+										new Vector2f(1, 1))));
 	}
 
 	public WorldItem item() {

--- a/nomad-realms/src/main/java/nomadrealms/render/particle/TextParticle.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/particle/TextParticle.java
@@ -38,19 +38,20 @@ public class TextParticle extends Particle {
 		float x = box().x().get();
 		float y = box().y().get();
 		float fontSize = box().h().get();
-		re.textRenderer.render(new Matrix4f()
-						.translate(-1, 1)
-						.scale(2, -2)
-						.scale(1 / re.glContext.width(), 1 / re.glContext.height())
-						.translate(x, y)
-						.rotate(rotation().get(), new Vector3f(0, 0, 1)),
+		re.textRenderer.render(
 				textFormat()
 						.text(text)
 						.font(re.font)
 						.fontSize(fontSize)
 						.colour(color)
 						.hAlign(CENTER)
-						.vAlign(MIDDLE));
+						.vAlign(MIDDLE)
+						.transform(new Matrix4f()
+								.translate(-1, 1)
+								.scale(2, -2)
+								.scale(1 / re.glContext.width(), 1 / re.glContext.height())
+								.translate(x, y)
+								.rotate(rotation().get(), new Vector3f(0, 0, 1))));
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/ButtonUIContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/ButtonUIContent.java
@@ -62,7 +62,7 @@ public class ButtonUIContent extends BasicUIContent {
 								.colour(rgb(255, 255, 255))
 								.hAlign(CENTER)
 								.vAlign(MIDDLE)
-								.transform(re.textRenderer.screenToPixel()).pixelPosition(constraintBox().center().x().get(), constraintBox().center().y().get())
+								.transform(re.textRenderer.screenToPixel().copy().translate(constraintBox().center().x().get(), constraintBox().center().y().get()))
 				);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/ButtonUIContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/ButtonUIContent.java
@@ -62,7 +62,7 @@ public class ButtonUIContent extends BasicUIContent {
 								.colour(rgb(255, 255, 255))
 								.hAlign(CENTER)
 								.vAlign(MIDDLE)
-								.transform(re.textRenderer.screenToPixel().copy().translate(constraintBox().center().x().get(), constraintBox().center().y().get()))
+								.transform(re.textRenderer.screenToPixel()).pixelPosition(constraintBox().center().x().get(), constraintBox().center().y().get())
 				);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/ButtonUIContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/ButtonUIContent.java
@@ -54,7 +54,6 @@ public class ButtonUIContent extends BasicUIContent {
 		// Render text
 		re.textRenderer
 				.render(
-						constraintBox().center().x().get(), constraintBox().center().y().get(),
 						textFormat()
 								.text(text.get())
 								.lineWidth(constraintBox().w().get())
@@ -63,6 +62,7 @@ public class ButtonUIContent extends BasicUIContent {
 								.colour(rgb(255, 255, 255))
 								.hAlign(CENTER)
 								.vAlign(MIDDLE)
+								.transform(re.textRenderer.screenToPixel().copy().translate(constraintBox().center().x().get(), constraintBox().center().y().get()))
 				);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/LabelContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/LabelContent.java
@@ -47,7 +47,7 @@ public class LabelContent extends BasicUIContent {
 								.colour(rgb(255, 255, 255))
 								.hAlign(CENTER)
 								.vAlign(MIDDLE)
-								.transform(re.textRenderer.screenToPixel().copy().translate(constraintBox().center().x().get(), constraintBox().center().y().get()))
+								.transform(re.textRenderer.screenToPixel()).pixelPosition(constraintBox().center().x().get(), constraintBox().center().y().get())
 				);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/LabelContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/LabelContent.java
@@ -47,7 +47,7 @@ public class LabelContent extends BasicUIContent {
 								.colour(rgb(255, 255, 255))
 								.hAlign(CENTER)
 								.vAlign(MIDDLE)
-								.transform(re.textRenderer.screenToPixel()).pixelPosition(constraintBox().center().x().get(), constraintBox().center().y().get())
+								.transform(re.textRenderer.screenToPixel().copy().translate(constraintBox().center().x().get(), constraintBox().center().y().get()))
 				);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/LabelContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/LabelContent.java
@@ -39,7 +39,6 @@ public class LabelContent extends BasicUIContent {
 		// Render text
 		re.textRenderer
 				.render(
-						constraintBox().center().x().get(), constraintBox().center().y().get(),
 						textFormat()
 								.text(text)
 								.lineWidth(constraintBox().w().get())
@@ -48,6 +47,7 @@ public class LabelContent extends BasicUIContent {
 								.colour(rgb(255, 255, 255))
 								.hAlign(CENTER)
 								.vAlign(MIDDLE)
+								.transform(re.textRenderer.screenToPixel().copy().translate(constraintBox().center().x().get(), constraintBox().center().y().get()))
 				);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/TextContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/TextContent.java
@@ -54,7 +54,6 @@ public class TextContent extends BasicUIContent {
 	@Override
 	public void _render(RenderingEnvironment re) {
 		re.textRenderer.render(
-				constraintBox().x().get() + padding, constraintBox().y().get() + padding,
 				textFormat()
 						.text(text.get())
 						.lineWidth(lineWidth)
@@ -62,7 +61,8 @@ public class TextContent extends BasicUIContent {
 						.fontSize(fontSize)
 						.colour(rgb(255, 255, 255))
 						.hAlign(HorizontalAlign.LEFT)
-						.vAlign(VerticalAlign.TOP));
+						.vAlign(VerticalAlign.TOP)
+						.transform(re.textRenderer.screenToPixel().copy().translate(constraintBox().x().get() + padding, constraintBox().y().get() + padding)));
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/TextContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/TextContent.java
@@ -62,7 +62,7 @@ public class TextContent extends BasicUIContent {
 						.colour(rgb(255, 255, 255))
 						.hAlign(HorizontalAlign.LEFT)
 						.vAlign(VerticalAlign.TOP)
-						.transform(re.textRenderer.screenToPixel().copy().translate(constraintBox().x().get() + padding, constraintBox().y().get() + padding)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(constraintBox().x().get() + padding, constraintBox().y().get() + padding));
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/content/TextContent.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/content/TextContent.java
@@ -62,7 +62,7 @@ public class TextContent extends BasicUIContent {
 						.colour(rgb(255, 255, 255))
 						.hAlign(HorizontalAlign.LEFT)
 						.vAlign(VerticalAlign.TOP)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(constraintBox().x().get() + padding, constraintBox().y().get() + padding));
+						.transform(re.textRenderer.screenToPixel().copy().translate(constraintBox().x().get() + padding, constraintBox().y().get() + padding)));
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/Ruler.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/Ruler.java
@@ -37,18 +37,20 @@ public class Ruler {
 			return;
 		}
 		int screenHeight = (int) re.glContext.height();
+		Matrix4f screenToPixel = re.textRenderer.screenToPixel();
 		for (int i = 0; i < screenHeight; i += MINOR_TICK_INTERVAL) {
 			int width;
 			if (i % MAJOR_TICK_INTERVAL == 0) {
 				width = MAJOR_TICK_WIDTH;
-				re.textRenderer.render(width + TEXT_X_OFFSET, i + TEXT_Y_OFFSET,
+				re.textRenderer.render(
 						textFormat()
 								.text(String.valueOf(i))
 								.font(re.font)
 								.fontSize(FONT_SIZE)
 								.colour(RULER_COLOR)
 								.hAlign(LEFT)
-								.vAlign(TOP));
+								.vAlign(TOP)
+								.transform(screenToPixel.copy().translate(width + TEXT_X_OFFSET, i + TEXT_Y_OFFSET)));
 			} else if (i % MEDIUM_TICK_INTERVAL == 0) {
 				width = MEDIUM_TICK_WIDTH;
 			} else {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/Ruler.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/Ruler.java
@@ -50,7 +50,7 @@ public class Ruler {
 								.colour(RULER_COLOR)
 								.hAlign(LEFT)
 								.vAlign(TOP)
-								.transform(screenToPixel.copy().translate(width + TEXT_X_OFFSET, i + TEXT_Y_OFFSET)));
+								.transform(screenToPixel).pixelPosition(width + TEXT_X_OFFSET, i + TEXT_Y_OFFSET));
 			} else if (i % MEDIUM_TICK_INTERVAL == 0) {
 				width = MEDIUM_TICK_WIDTH;
 			} else {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/Ruler.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/Ruler.java
@@ -50,7 +50,7 @@ public class Ruler {
 								.colour(RULER_COLOR)
 								.hAlign(LEFT)
 								.vAlign(TOP)
-								.transform(screenToPixel).pixelPosition(width + TEXT_X_OFFSET, i + TEXT_Y_OFFSET));
+								.transform(screenToPixel.copy().translate(width + TEXT_X_OFFSET, i + TEXT_Y_OFFSET)));
 			} else if (i % MEDIUM_TICK_INTERVAL == 0) {
 				width = MEDIUM_TICK_WIDTH;
 			} else {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/console/Console.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/console/Console.java
@@ -96,7 +96,6 @@ public class Console implements UI {
 
 		// Render current input
 		re.textRenderer.render(
-				10, screen.h().get() - 5,
 				textFormat()
 						.text("> " + currentInput)
 						.lineWidth(screen.w().get() - 20)
@@ -104,11 +103,13 @@ public class Console implements UI {
 						.fontSize(30)
 						.colour(rgba(255, 255, 255, 255))
 						.hAlign(HorizontalAlign.LEFT)
-						.vAlign(VerticalAlign.BOTTOM));
+						.vAlign(VerticalAlign.BOTTOM)
+						.transform(re.textRenderer.screenToPixel().copy().translate(10, screen.h().get() - 5)));
 
 		// Render history
 		float y = screen.h().get() - inputHeight - 5 + scrollOffset;
 		List<TextFormat> historyFormats = new ArrayList<>();
+		Matrix4f screenToPixel = re.textRenderer.screenToPixel();
 		synchronized (history) {
 			for (int i = history.size() - 1; i >= 0; i--) {
 				String line = history.get(i);
@@ -121,8 +122,7 @@ public class Console implements UI {
 							.colour(rgba(200, 200, 200, 255))
 							.hAlign(HorizontalAlign.LEFT)
 							.vAlign(VerticalAlign.BOTTOM)
-							.x(10)
-							.y(y));
+							.transform(screenToPixel.copy().translate(10, y)));
 				}
 				y -= 30; // Assuming line height
 				if (y < screen.h().get() - consoleHeight) {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/console/Console.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/console/Console.java
@@ -104,7 +104,7 @@ public class Console implements UI {
 						.colour(rgba(255, 255, 255, 255))
 						.hAlign(HorizontalAlign.LEFT)
 						.vAlign(VerticalAlign.BOTTOM)
-						.transform(re.textRenderer.screenToPixel().copy().translate(10, screen.h().get() - 5)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(10, screen.h().get() - 5));
 
 		// Render history
 		float y = screen.h().get() - inputHeight - 5 + scrollOffset;
@@ -122,7 +122,7 @@ public class Console implements UI {
 							.colour(rgba(200, 200, 200, 255))
 							.hAlign(HorizontalAlign.LEFT)
 							.vAlign(VerticalAlign.BOTTOM)
-							.transform(screenToPixel.copy().translate(10, y)));
+							.transform(screenToPixel).pixelPosition(10, y));
 				}
 				y -= 30; // Assuming line height
 				if (y < screen.h().get() - consoleHeight) {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/console/Console.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/console/Console.java
@@ -104,7 +104,7 @@ public class Console implements UI {
 						.colour(rgba(255, 255, 255, 255))
 						.hAlign(HorizontalAlign.LEFT)
 						.vAlign(VerticalAlign.BOTTOM)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(10, screen.h().get() - 5));
+						.transform(re.textRenderer.screenToPixel().copy().translate(10, screen.h().get() - 5)));
 
 		// Render history
 		float y = screen.h().get() - inputHeight - 5 + scrollOffset;
@@ -122,7 +122,7 @@ public class Console implements UI {
 							.colour(rgba(200, 200, 200, 255))
 							.hAlign(HorizontalAlign.LEFT)
 							.vAlign(VerticalAlign.BOTTOM)
-							.transform(screenToPixel).pixelPosition(10, y));
+							.transform(screenToPixel.copy().translate(10, y)));
 				}
 				y -= 30; // Assuming line height
 				if (y < screen.h().get() - consoleHeight) {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/debug/DebugUI.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/debug/DebugUI.java
@@ -16,6 +16,7 @@ import static nomadrealms.render.vao.shape.HexagonVao.SIDE_LENGTH;
 import java.util.ArrayList;
 import java.util.List;
 
+import engine.common.math.Matrix4f;
 import engine.common.time.FPSCounter;
 import engine.common.time.PerformanceProfiler;
 import nomadrealms.context.game.world.World;
@@ -42,14 +43,15 @@ public class DebugUI implements UI {
 
 	@Override
 	public void render(RenderingEnvironment re) {
-		re.textRenderer.render(20, 20,
+		re.textRenderer.render(
 				textFormat()
 						.text(String.format("FPS: %.1f", fpsCounter.getFPS()))
 						.font(re.font)
 						.fontSize(20)
 						.colour(rgb(255, 255, 255))
 						.hAlign(LEFT)
-						.vAlign(TOP));
+						.vAlign(TOP)
+						.transform(re.textRenderer.screenToPixel().copy().translate(20, 20)));
 		performanceChartUI.render(re);
 		float zoom = re.is.camera.zoom().get();
 		if (zoom < 0.2f) {
@@ -61,6 +63,7 @@ public class DebugUI implements UI {
 		float toCenterX = TILE_RADIUS * SIDE_LENGTH;
 		float toCenterY = TILE_RADIUS * HEIGHT;
 		List<TextFormat> tileCoords = new ArrayList<>();
+		Matrix4f screenToPixel = re.textRenderer.screenToPixel();
 		for (Chunk chunk : visibleChunks) {
 			float chunkPosX = chunk.pos().vector().x();
 			float chunkPosY = chunk.pos().vector().y();
@@ -82,8 +85,7 @@ public class DebugUI implements UI {
 							.colour(rgb(255, 255, 255))
 							.hAlign(CENTER)
 							.vAlign(MIDDLE)
-							.x(screenX)
-							.y(screenY));
+							.transform(screenToPixel.copy().translate(screenX, screenY)));
 				}
 			}
 		}

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/debug/DebugUI.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/debug/DebugUI.java
@@ -51,7 +51,7 @@ public class DebugUI implements UI {
 						.colour(rgb(255, 255, 255))
 						.hAlign(LEFT)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(20, 20));
+						.transform(re.textRenderer.screenToPixel().copy().translate(20, 20)));
 		performanceChartUI.render(re);
 		float zoom = re.is.camera.zoom().get();
 		if (zoom < 0.2f) {
@@ -85,7 +85,7 @@ public class DebugUI implements UI {
 							.colour(rgb(255, 255, 255))
 							.hAlign(CENTER)
 							.vAlign(MIDDLE)
-							.transform(screenToPixel).pixelPosition(screenX, screenY));
+							.transform(screenToPixel.copy().translate(screenX, screenY)));
 				}
 			}
 		}

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/debug/DebugUI.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/debug/DebugUI.java
@@ -51,7 +51,7 @@ public class DebugUI implements UI {
 						.colour(rgb(255, 255, 255))
 						.hAlign(LEFT)
 						.vAlign(TOP)
-						.transform(re.textRenderer.screenToPixel().copy().translate(20, 20)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(20, 20));
 		performanceChartUI.render(re);
 		float zoom = re.is.camera.zoom().get();
 		if (zoom < 0.2f) {
@@ -85,7 +85,7 @@ public class DebugUI implements UI {
 							.colour(rgb(255, 255, 255))
 							.hAlign(CENTER)
 							.vAlign(MIDDLE)
-							.transform(screenToPixel.copy().translate(screenX, screenY)));
+							.transform(screenToPixel).pixelPosition(screenX, screenY));
 				}
 			}
 		}

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/debug/PerformanceChartUI.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/debug/PerformanceChartUI.java
@@ -75,7 +75,7 @@ public class PerformanceChartUI implements UI {
 					.colour(color)
 					.hAlign(LEFT)
 					.vAlign(TOP)
-					.transform(screenToPixel).pixelPosition(20, textY));
+					.transform(screenToPixel.copy().translate(20, textY)));
 
 			colorIndex++;
 			textY += 20;

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/debug/PerformanceChartUI.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/debug/PerformanceChartUI.java
@@ -5,6 +5,7 @@ import static engine.visuals.rendering.text.HorizontalAlign.LEFT;
 import static engine.visuals.rendering.text.TextFormat.textFormat;
 import static engine.visuals.rendering.text.VerticalAlign.TOP;
 
+import engine.common.math.Matrix4f;
 import engine.common.time.PerformanceProfiler;
 import engine.visuals.rendering.text.TextFormat;
 import java.util.ArrayList;
@@ -57,6 +58,7 @@ public class PerformanceChartUI implements UI {
 		float textY = y + 70;
 
 		List<TextFormat> chartFormats = new ArrayList<>();
+		Matrix4f screenToPixel = re.textRenderer.screenToPixel();
 		for (Map.Entry<String, Float> entry : averages.entrySet()) {
 			int color = COLORS[colorIndex % COLORS.length];
 			if (!entry.getKey().contains("Total") && !entry.getKey().equals("Update")) {
@@ -73,8 +75,7 @@ public class PerformanceChartUI implements UI {
 					.colour(color)
 					.hAlign(LEFT)
 					.vAlign(TOP)
-					.x(20)
-					.y(textY));
+					.transform(screenToPixel.copy().translate(20, textY)));
 
 			colorIndex++;
 			textY += 20;

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/debug/PerformanceChartUI.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/debug/PerformanceChartUI.java
@@ -75,7 +75,7 @@ public class PerformanceChartUI implements UI {
 					.colour(color)
 					.hAlign(LEFT)
 					.vAlign(TOP)
-					.transform(screenToPixel.copy().translate(20, textY)));
+					.transform(screenToPixel).pixelPosition(20, textY));
 
 			colorIndex++;
 			textY += 20;

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/indicator/ManaIndicator.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/indicator/ManaIndicator.java
@@ -49,7 +49,7 @@ public class ManaIndicator implements UI {
 						.colour(color)
 						.hAlign(HorizontalAlign.LEFT)
 						.vAlign(VerticalAlign.TOP)
-						.transform(re.textRenderer.screenToPixel()).pixelPosition(xPos.get(), constraintBox.y().get() + MANA_TEXT_Y_OFFSET));
+						.transform(re.textRenderer.screenToPixel().copy().translate(xPos.get(), constraintBox.y().get() + MANA_TEXT_Y_OFFSET)));
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/indicator/ManaIndicator.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/indicator/ManaIndicator.java
@@ -49,7 +49,7 @@ public class ManaIndicator implements UI {
 						.colour(color)
 						.hAlign(HorizontalAlign.LEFT)
 						.vAlign(VerticalAlign.TOP)
-						.transform(re.textRenderer.screenToPixel().copy().translate(xPos.get(), constraintBox.y().get() + MANA_TEXT_Y_OFFSET)));
+						.transform(re.textRenderer.screenToPixel()).pixelPosition(xPos.get(), constraintBox.y().get() + MANA_TEXT_Y_OFFSET));
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/indicator/ManaIndicator.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/indicator/ManaIndicator.java
@@ -42,15 +42,14 @@ public class ManaIndicator implements UI {
 			return (t < MANA_ERROR_ANIMATION_DURATION_MS) ? (float) Math.sin(t / 1000.0 * MANA_ERROR_SHAKE_FREQUENCY * 2 * Math.PI) * MANA_ERROR_SHAKE_AMPLITUDE : 0;
 		}));
 		re.textRenderer.render(
-				xPos.get(),
-				constraintBox.y().get() + MANA_TEXT_Y_OFFSET,
 				textFormat()
 						.text("Mana: " + owner.mana() + " / " + owner.maxMana())
 						.font(re.font)
 						.fontSize(30)
 						.colour(color)
 						.hAlign(HorizontalAlign.LEFT)
-						.vAlign(VerticalAlign.TOP));
+						.vAlign(VerticalAlign.TOP)
+						.transform(re.textRenderer.screenToPixel().copy().translate(xPos.get(), constraintBox.y().get() + MANA_TEXT_Y_OFFSET)));
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/join/JoinWorldInterface.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/join/JoinWorldInterface.java
@@ -73,7 +73,7 @@ public class JoinWorldInterface {
 				.font(re.font)
 				.fontSize(20)
 				.colour(Colour.rgb(255, 255, 255))
-				.transform(screenToPixel).pixelPosition(startX + 10, startY + 10));
+				.transform(screenToPixel.copy().translate(startX + 10, startY + 10)));
 
 		// Draw Player List
 		float yOffset = startY + 40;
@@ -87,7 +87,7 @@ public class JoinWorldInterface {
 					.font(re.font)
 					.fontSize(16)
 					.colour(Colour.rgb(200, 200, 200))
-					.transform(screenToPixel).pixelPosition(startX + 10, yOffset));
+					.transform(screenToPixel.copy().translate(startX + 10, yOffset)));
 			yOffset += 30;
 		}
 		re.textRenderer.render(playerListFormats);

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/join/JoinWorldInterface.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/join/JoinWorldInterface.java
@@ -3,6 +3,7 @@ package nomadrealms.render.ui.custom.join;
 import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 
 import engine.common.colour.Colour;
+import engine.common.math.Matrix4f;
 import engine.context.input.event.InputCallbackRegistry;
 import engine.visuals.constraint.box.ConstraintBox;
 import engine.visuals.constraint.box.ConstraintPair;
@@ -65,14 +66,14 @@ public class JoinWorldInterface {
 		re.rectangleRenderer.render(startX, startY, width, height, 10, Colour.rgba(0, 0, 0, 180));
 
 		List<TextFormat> playerListFormats = new ArrayList<>();
+		Matrix4f screenToPixel = re.textRenderer.screenToPixel();
 		// Draw Title
 		playerListFormats.add(TextFormat.textFormat()
 				.text("Online Players: " + onlinePlayers.size())
 				.font(re.font)
 				.fontSize(20)
 				.colour(Colour.rgb(255, 255, 255))
-				.x(startX + 10)
-				.y(startY + 10));
+				.transform(screenToPixel.copy().translate(startX + 10, startY + 10)));
 
 		// Draw Player List
 		float yOffset = startY + 40;
@@ -86,8 +87,7 @@ public class JoinWorldInterface {
 					.font(re.font)
 					.fontSize(16)
 					.colour(Colour.rgb(200, 200, 200))
-					.x(startX + 10)
-					.y(yOffset));
+					.transform(screenToPixel.copy().translate(startX + 10, yOffset)));
 			yOffset += 30;
 		}
 		re.textRenderer.render(playerListFormats);

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/join/JoinWorldInterface.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/join/JoinWorldInterface.java
@@ -73,7 +73,7 @@ public class JoinWorldInterface {
 				.font(re.font)
 				.fontSize(20)
 				.colour(Colour.rgb(255, 255, 255))
-				.transform(screenToPixel.copy().translate(startX + 10, startY + 10)));
+				.transform(screenToPixel).pixelPosition(startX + 10, startY + 10));
 
 		// Draw Player List
 		float yOffset = startY + 40;
@@ -87,7 +87,7 @@ public class JoinWorldInterface {
 					.font(re.font)
 					.fontSize(16)
 					.colour(Colour.rgb(200, 200, 200))
-					.transform(screenToPixel.copy().translate(startX + 10, yOffset)));
+					.transform(screenToPixel).pixelPosition(startX + 10, yOffset));
 			yOffset += 30;
 		}
 		re.textRenderer.render(playerListFormats);

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/speech/SpeechBubble.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/speech/SpeechBubble.java
@@ -85,7 +85,7 @@ public class SpeechBubble implements UI {
 		);
 
 		// Render text
-		re.textRenderer.render(bubbleX + padding, bubbleY + padding, format);
+		re.textRenderer.render(format.transform(re.textRenderer.screenToPixel().copy().translate(bubbleX + padding, bubbleY + padding)));
 	}
 
 	public Actor actor() {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/speech/SpeechBubble.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/speech/SpeechBubble.java
@@ -85,7 +85,7 @@ public class SpeechBubble implements UI {
 		);
 
 		// Render text
-		re.textRenderer.render(format.transform(re.textRenderer.screenToPixel()).pixelPosition(bubbleX + padding, bubbleY + padding));
+		re.textRenderer.render(format.transform(re.textRenderer.screenToPixel().copy().translate(bubbleX + padding, bubbleY + padding)));
 	}
 
 	public Actor actor() {

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/speech/SpeechBubble.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/speech/SpeechBubble.java
@@ -85,7 +85,7 @@ public class SpeechBubble implements UI {
 		);
 
 		// Render text
-		re.textRenderer.render(format.transform(re.textRenderer.screenToPixel().copy().translate(bubbleX + padding, bubbleY + padding)));
+		re.textRenderer.render(format.transform(re.textRenderer.screenToPixel()).pixelPosition(bubbleX + padding, bubbleY + padding));
 	}
 
 	public Actor actor() {


### PR DESCRIPTION
Refactored the `TextRenderer` class to simplify its API by reducing the number of overloaded `render` methods from five down to two. This change shifts the responsibility of coordinate transformations and base projection (screen-to-pixel) to the calling code, leading to a cleaner and more maintainable renderer. 

Key changes include:
- Removing overloads that accepted `(x, y)` coordinates or `baseTransform` matrices.
- Updating all consumers (UI elements, actors, particles) to pre-multiply their `TextFormat` transforms with the renderer's `screenToPixel` matrix when necessary.
- Ensuring that all call sites are correctly migrated and compilation errors are resolved.

---
*PR created automatically by Jules for task [1265791374024885971](https://jules.google.com/task/1265791374024885971) started by @Lunkle*