### PR TITLE
Decouple world viewport from magic numbers

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
@@ -113,7 +113,7 @@ public class MainContext extends GameContext {
 		re.world = gameState.world;
 		localPlayer = new Player("Local Player", new PacketAddress()).cardPlayer(gameState.world.nomad);
 		re.is.localPlayer = localPlayer;
-		re.is.camera = new Camera(localPlayer.cardPlayer(gameState.world).tile().pos().sub(glContext().screen.dimensions().scale(0.5f * 0.6f, 0.5f)));
+		re.is.camera = new Camera(localPlayer.cardPlayer(gameState.world).tile().pos().sub(re.is.worldViewport.dimensions().scale(0.5f)));
 		ui = new GameInterface(re, localPlayer, stateToUiEventChannel, this::addEvent, gameState, glContext(), mouse(), inputCallbackRegistry);
 		console = new Console(glContext().screen, gameState, re);
 		debugUI = new DebugUI(gameState.world, re.is.profiler());
@@ -293,7 +293,7 @@ public class MainContext extends GameContext {
 
 	@Override
 	public void input(MouseMovedInputEvent event) {
-		if (event.mouse().x() < glContext().screen.w().get() * 0.6f) {
+		if (re.is.worldViewport.contains(event.mouse().coordinate())) {
 			re.is.lastMouseMovedTime = System.currentTimeMillis();
 		}
 		inputCallbackRegistry.triggerOnDrag(event);

--- a/nomad-realms/src/main/java/nomadrealms/context/game/interaction/InteractionState.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/interaction/InteractionState.java
@@ -2,14 +2,13 @@ package nomadrealms.context.game.interaction;
 
 import engine.common.time.PerformanceProfiler;
 import engine.context.input.Mouse;
-import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 import engine.visuals.constraint.box.ConstraintBox;
 import nomadrealms.render.ui.Camera;
 import nomadrealms.user.Player;
 
 /**
- * Holds transient, client-side data that doesn't belong in the GameState (persistent save data)
- * or the RenderingEnvironment (shaders and hardware-level renderers).
+ * Holds transient, client-side data that doesn't belong in the GameState (persistent save data) or the
+ * RenderingEnvironment (shaders and hardware-level renderers).
  */
 public class InteractionState {
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/interaction/InteractionState.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/interaction/InteractionState.java
@@ -15,7 +15,7 @@ public class InteractionState {
 	public Camera camera = new Camera(0, 0);
 	public Mouse mouse;
 
-	public ConstraintBox worldViewport;
+	public final ConstraintBox worldViewport;
 
 	public boolean showDebugInfo = false;
 	public boolean showMap = false;

--- a/nomad-realms/src/main/java/nomadrealms/context/game/interaction/InteractionState.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/interaction/InteractionState.java
@@ -2,6 +2,7 @@ package nomadrealms.context.game.interaction;
 
 import engine.common.time.PerformanceProfiler;
 import engine.context.input.Mouse;
+import engine.visuals.constraint.box.ConstraintBox;
 import nomadrealms.render.ui.Camera;
 import nomadrealms.user.Player;
 
@@ -14,6 +15,8 @@ public class InteractionState {
 	public Camera camera = new Camera(0, 0);
 	public Mouse mouse;
 
+	public ConstraintBox worldViewport;
+
 	public boolean showDebugInfo = false;
 	public boolean showMap = false;
 
@@ -24,8 +27,14 @@ public class InteractionState {
 	public Player localPlayer;
 	private PerformanceProfiler profiler;
 
-	public InteractionState(Mouse mouse) {
+	public InteractionState(Mouse mouse, ConstraintBox screen) {
 		this.mouse = mouse;
+		this.worldViewport = new ConstraintBox(
+				screen.x(),
+				screen.y(),
+				screen.w().multiply(0.6f),
+				screen.h()
+		);
 	}
 
 	public PerformanceProfiler profiler() {

--- a/nomad-realms/src/main/java/nomadrealms/context/game/interaction/InteractionState.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/interaction/InteractionState.java
@@ -2,6 +2,7 @@ package nomadrealms.context.game.interaction;
 
 import engine.common.time.PerformanceProfiler;
 import engine.context.input.Mouse;
+import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 import engine.visuals.constraint.box.ConstraintBox;
 import nomadrealms.render.ui.Camera;
 import nomadrealms.user.Player;

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/World.java
@@ -87,8 +87,8 @@ public class World {
 		float chunkWidth = TILE_HORIZONTAL_SPACING * CHUNK_SIZE;
 		float chunkHeight = TILE_VERTICAL_SPACING * CHUNK_SIZE;
 
-		int numChunksX = (int) Math.ceil(re.config.getWidth() * 0.6f / (chunkWidth * re.is.camera.zoom().get())) + 2;
-		int numChunksY = (int) Math.ceil(re.config.getHeight() / (chunkHeight * re.is.camera.zoom().get())) + 2;
+		int numChunksX = (int) Math.ceil(re.is.worldViewport.w().get() / (chunkWidth * re.is.camera.zoom().get())) + 2;
+		int numChunksY = (int) Math.ceil(re.is.worldViewport.h().get() / (chunkHeight * re.is.camera.zoom().get())) + 2;
 
 		List<Chunk> visibleChunks = new ArrayList<>();
 		ChunkCoordinate rowStart = minChunk;

--- a/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
@@ -78,7 +78,7 @@ public class RenderingEnvironment {
 	public RenderingEnvironment(GLContext glContext, NengenConfiguration config, Mouse mouse) {
 		this.glContext = glContext;
 		this.config = config;
-		this.is = new InteractionState(mouse);
+		this.is = new InteractionState(mouse, glContext.screen);
 
 		loadFonts();
 		loadFBOs();


### PR DESCRIPTION
Introduced a 'worldViewport' ConstraintBox in InteractionState to define the size of the world view, replacing hardcoded magic numbers (0.6 multiplier) across the codebase. This change affects camera positioning, input handling, and chunk culling.

---
*PR created automatically by Jules for task [7046678870967636258](https://jules.google.com/task/7046678870967636258) started by @Lunkle*