### PR TITLE
Add Materialize Gold card

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/GameCard.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/GameCard.java
@@ -5,6 +5,9 @@ import static engine.visuals.constraint.misc.TimedConstraint.time;
 import static engine.visuals.constraint.posdim.AbsoluteConstraint.absolute;
 import static nomadrealms.context.game.actor.status.StatusEffect.INVINCIBLE;
 import static nomadrealms.context.game.actor.status.StatusEffect.POISON;
+import static nomadrealms.context.game.card.CardType.ACTION;
+import static nomadrealms.context.game.card.CardType.CREATURE;
+import static nomadrealms.context.game.card.CardType.STRUCTURE;
 import static nomadrealms.context.game.card.expression.AddCardToStackExpression.addCardToStack;
 import static nomadrealms.context.game.card.expression.AndExpression.and;
 import static nomadrealms.context.game.card.expression.ApplyStatusExpression.applyStatus;
@@ -27,9 +30,6 @@ import static nomadrealms.context.game.card.expression.SurfaceCardExpression.sur
 import static nomadrealms.context.game.card.expression.TeleportExpression.teleport;
 import static nomadrealms.context.game.card.expression.TeleportNoTargetExpression.teleport;
 import static nomadrealms.context.game.card.expression.WalkExpression.walk;
-import static nomadrealms.context.game.card.CardType.ACTION;
-import static nomadrealms.context.game.card.CardType.CREATURE;
-import static nomadrealms.context.game.card.CardType.STRUCTURE;
 import static nomadrealms.context.game.card.expression.WalkToAdjacentExpression.walkToAdjacent;
 import static nomadrealms.context.game.card.target.TargetType.CARD_PLAYER;
 import static nomadrealms.context.game.card.target.TargetType.HEXAGON;
@@ -400,7 +400,7 @@ public enum GameCard implements Card {
 	MATERIALIZE_GOLD(
 			"Materialize Gold",
 			"restore",
-			"you create it",
+			"Add 1 gold coin to inventory.",
 			ACTION,
 			10,
 			20,

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/GameCard.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/GameCard.java
@@ -16,6 +16,7 @@ import static nomadrealms.context.game.card.expression.DelayedExpression.delayed
 import static nomadrealms.context.game.card.expression.DestroyStructureAndSpawnItemsExpression.destroyStructureAndSpawnItems;
 import static nomadrealms.context.game.card.expression.EditTileExpression.editTile;
 import static nomadrealms.context.game.card.expression.GatherExpression.gather;
+import static nomadrealms.context.game.card.expression.MaterializeItemExpression.materializeItem;
 import static nomadrealms.context.game.card.expression.MeleeDamageExpression.meleeDamage;
 import static nomadrealms.context.game.card.expression.PlayCardExpression.playCard;
 import static nomadrealms.context.game.card.expression.RemoveStatusExpression.removeStatus;
@@ -395,7 +396,16 @@ public enum GameCard implements Card {
 			8,
 			20,
 			createStructure(StructureType.DEATHBLOOM),
-			new TargetingInfo(HEXAGON, new RangeCondition(2), new EmptyCondition(new ActorsOnTilesQuery(new TargetQuery<>()))));
+			new TargetingInfo(HEXAGON, new RangeCondition(2), new EmptyCondition(new ActorsOnTilesQuery(new TargetQuery<>())))),
+	MATERIALIZE_GOLD(
+			"Materialize Gold",
+			"restore",
+			"you create it",
+			ACTION,
+			10,
+			20,
+			materializeItem(Item.GOLD_COIN),
+			new TargetingInfo(NONE));
 
 	private final String title;
 	private final String artwork;

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/effect/MaterializeItemEffect.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/effect/MaterializeItemEffect.java
@@ -1,0 +1,22 @@
+package nomadrealms.context.game.card.effect;
+
+import nomadrealms.context.game.actor.types.cardplayer.CardPlayer;
+import nomadrealms.context.game.item.Item;
+import nomadrealms.context.game.item.WorldItem;
+import nomadrealms.context.game.world.World;
+
+public class MaterializeItemEffect extends Effect {
+
+	private final Item item;
+
+	public MaterializeItemEffect(CardPlayer source, Item item) {
+		super(source);
+		this.item = item;
+	}
+
+	@Override
+	public void resolve(World world) {
+		((CardPlayer) source()).inventory().add(new WorldItem(item));
+	}
+
+}

--- a/nomad-realms/src/main/java/nomadrealms/context/game/card/expression/MaterializeItemExpression.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/card/expression/MaterializeItemExpression.java
@@ -1,0 +1,30 @@
+package nomadrealms.context.game.card.expression;
+
+import static java.util.Collections.singletonList;
+
+import java.util.List;
+
+import nomadrealms.context.game.actor.types.cardplayer.CardPlayer;
+import nomadrealms.context.game.card.effect.Effect;
+import nomadrealms.context.game.card.effect.MaterializeItemEffect;
+import nomadrealms.context.game.item.Item;
+import nomadrealms.event.game.effect.EffectContext;
+
+public class MaterializeItemExpression implements CardExpression {
+
+	private final Item item;
+
+	public MaterializeItemExpression(Item item) {
+		this.item = item;
+	}
+
+	public static MaterializeItemExpression materializeItem(Item item) {
+		return new MaterializeItemExpression(item);
+	}
+
+	@Override
+	public List<Effect> effects(EffectContext context) {
+		return singletonList(new MaterializeItemEffect((CardPlayer) context.source(), item));
+	}
+
+}

--- a/nomad-realms/src/test/java/nomadrealms/context/game/card/MaterializeGoldCardTest.java
+++ b/nomad-realms/src/test/java/nomadrealms/context/game/card/MaterializeGoldCardTest.java
@@ -1,0 +1,49 @@
+package nomadrealms.context.game.card;
+
+import static nomadrealms.context.game.card.GameCard.MATERIALIZE_GOLD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedList;
+import java.util.List;
+import nomadrealms.context.game.GameState;
+import nomadrealms.context.game.actor.types.cardplayer.Farmer;
+import nomadrealms.context.game.card.effect.Effect;
+import nomadrealms.context.game.item.Item;
+import nomadrealms.context.game.item.WorldItem;
+import nomadrealms.event.game.effect.EffectContext;
+import nomadrealms.context.game.world.map.area.Tile;
+import nomadrealms.context.game.world.map.area.coordinate.ChunkCoordinate;
+import nomadrealms.context.game.world.map.area.coordinate.RegionCoordinate;
+import nomadrealms.context.game.world.map.area.coordinate.TileCoordinate;
+import nomadrealms.context.game.world.map.area.coordinate.ZoneCoordinate;
+import nomadrealms.context.game.world.map.generation.TemplateGenerationStrategy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MaterializeGoldCardTest {
+
+	private GameState gameState;
+	private Farmer source;
+
+	@BeforeEach
+	public void setUp() {
+		gameState = new GameState("Test World", new LinkedList<>(),
+				new TemplateGenerationStrategy());
+		Tile tile1 = gameState.world.getTile(new TileCoordinate(new ChunkCoordinate(new ZoneCoordinate(new RegionCoordinate(0, 0), 0, 0), 0, 0), 0, 0));
+		source = new Farmer("Source", tile1);
+		gameState.world.addActor(source, true);
+	}
+
+	@Test
+	public void testMaterializeGold_addsGoldToInventory() {
+		assertEquals(0, source.inventory().items().size());
+
+		List<Effect> effects = MATERIALIZE_GOLD.expression().effects(new EffectContext().world(gameState.world).source(source));
+		effects.forEach(effect -> effect.resolve(gameState.world));
+
+		assertEquals(1, source.inventory().items().size());
+		WorldItem worldItem = source.inventory().items().iterator().next();
+		assertEquals(Item.GOLD_COIN, worldItem.item());
+	}
+}


### PR DESCRIPTION
Added a new card 'Materialize Gold' to the game. 
- Created `MaterializeItemEffect` to handle adding items to a player's inventory.
- Created `MaterializeItemExpression` to generate the effect from a card.
- Added `MATERIALIZE_GOLD` to the `GameCard` enum with a cost of 10 mana.
- Added `MaterializeGoldCardTest` to verify the card correctly adds a gold coin to the inventory.

---
*PR created automatically by Jules for task [6352763493207078719](https://jules.google.com/task/6352763493207078719) started by @Lunkle*