### PR TITLE
Highlight valid tiles with a bluish hue during card targeting

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/TargetingArrow.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/TargetingArrow.java
@@ -1,5 +1,6 @@
 package nomadrealms.render.ui.custom.card;
 
+import engine.common.math.Matrix4f;
 import engine.context.input.Mouse;
 import engine.visuals.constraint.box.ConstraintPair;
 import nomadrealms.context.game.GameState;
@@ -9,9 +10,15 @@ import nomadrealms.context.game.card.target.TargetType;
 import nomadrealms.context.game.card.target.TargetingInfo;
 import nomadrealms.context.game.event.Target;
 import nomadrealms.context.game.world.World;
+import nomadrealms.context.game.world.map.area.Chunk;
 import nomadrealms.context.game.world.map.area.Tile;
 import nomadrealms.render.RenderingEnvironment;
 import nomadrealms.render.ui.UI;
+
+import static engine.common.colour.Colour.rgba;
+import static nomadrealms.context.game.world.map.area.Tile.TILE_RADIUS;
+import static nomadrealms.render.vao.shape.HexagonVao.HEIGHT;
+import static nomadrealms.render.vao.shape.HexagonVao.SIDE_LENGTH;
 
 public class TargetingArrow implements UI {
 
@@ -35,11 +42,33 @@ public class TargetingArrow implements UI {
 			return;
 		}
 
+		if (info.targetType() == TargetType.HEXAGON) {
+			for (Chunk chunk : state.world().getVisibleChunks(re)) {
+				for (Tile t : chunk.tiles()) {
+					if (checkConditions(info, state.world(), t, source)) {
+						ConstraintPair pos = t.getScreenPosition(re);
+						float scale = re.is.camera.zoom().get();
+						float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * scale;
+						float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
+						re.hexagonRenderer.render(
+								new Matrix4f(
+										pos.x().get() - width * 0.5f, pos.y().get() - height * 0.5f,
+										width,
+										height,
+										re.glContext),
+								width, height, rgba(100, 100, 255, 100), 0, 0);
+					}
+				}
+			}
+		}
+
 		Tile tile = state.getMouseHexagon(mouse, re.is.camera);
 		ConstraintPair screenPosition = null;
 
 		if (info.targetType() == TargetType.HEXAGON) {
-			if (!checkConditions(info, state.world(), tile, source)) {
+			if (tile == null || !checkConditions(info, state.world(), tile, source)) {
+				new Arrow(origin.centerPosition(), mouse.coordinate())
+						.render(re);
 				return;
 			}
 			target = tile;

--- a/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/TargetingArrow.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/ui/custom/card/TargetingArrow.java
@@ -2,6 +2,8 @@ package nomadrealms.render.ui.custom.card;
 
 import engine.common.math.Matrix4f;
 import engine.context.input.Mouse;
+import engine.nengen.DrawBatch;
+import engine.visuals.builtin.RectangleVertexArrayObject;
 import engine.visuals.constraint.box.ConstraintPair;
 import nomadrealms.context.game.GameState;
 import nomadrealms.context.game.actor.types.cardplayer.CardPlayer;
@@ -30,6 +32,8 @@ public class TargetingArrow implements UI {
 	GameState state;
 	private final CardPlayer source;
 
+	private final DrawBatch tileBatch = new DrawBatch();
+
 	public TargetingArrow(GameState state, CardPlayer source) {
 		this.state = state;
 		this.source = source;
@@ -43,23 +47,28 @@ public class TargetingArrow implements UI {
 		}
 
 		if (info.targetType() == TargetType.HEXAGON) {
+			float scale = re.is.camera.zoom().get();
+			float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * scale;
+			float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
+			re.hexagonRenderer.prepareInstanced(width, height);
+			tileBatch.vao(RectangleVertexArrayObject.instance())
+					.shaderProgram(re.hexagonRenderer.instancedProgram())
+					.glContext(re.glContext)
+					.clear();
 			for (Chunk chunk : state.world().getVisibleChunks(re)) {
 				for (Tile t : chunk.tiles()) {
 					if (checkConditions(info, state.world(), t, source)) {
 						ConstraintPair pos = t.getScreenPosition(re);
-						float scale = re.is.camera.zoom().get();
-						float height = TILE_RADIUS * 2 * HEIGHT * 0.98f * scale;
-						float width = TILE_RADIUS * 2 * SIDE_LENGTH * 0.98f * scale;
-						re.hexagonRenderer.render(
-								new Matrix4f(
-										pos.x().get() - width * 0.5f, pos.y().get() - height * 0.5f,
-										width,
-										height,
-										re.glContext),
-								width, height, rgba(100, 100, 255, 100), 0, 0);
+						Matrix4f transform = new Matrix4f(
+								pos.x().get() - width * 0.5f, pos.y().get() - height * 0.5f,
+								width,
+								height,
+								re.glContext);
+						tileBatch.add(re.hexagonRenderer.padTransform(transform), rgba(100, 100, 255, 100));
 					}
 				}
 			}
+			tileBatch.draw();
 		}
 
 		Tile tile = state.getMouseHexagon(mouse, re.is.camera);


### PR DESCRIPTION
This change adds a visual indicator for valid target tiles when a player is dragging a card that targets tiles. 

Specifically:
- When a card enters targeting mode (card is dragged out and freezes), all tiles that satisfy the card's targeting conditions (range, occupancy, etc.) are highlighted with a translucent blue hexagon overlay.
- The logic uses the existing `checkConditions` method to ensure consistency between the visual indicator and actual targetability.
- Added a fallback for the targeting arrow so it continues to follow the mouse even when hovering over an invalid target, improving the user experience.
- The tint color used is `rgba(100, 100, 255, 100)`.

---
*PR created automatically by Jules for task [7094014031359957368](https://jules.google.com/task/7094014031359957368) started by @Lunkle*