### PR TITLE
Implement overworld river generation

### DIFF
--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/OverworldGenerationStrategy.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/OverworldGenerationStrategy.java
@@ -56,7 +56,7 @@ public class OverworldGenerationStrategy extends MapGenerationStrategy {
 					tile = new WaterTile(chunk, tileCoord, rgb(0, 141, 207));
 					break;
 				case DEEP_OCEAN:
-					tile = new WaterTile(chunk, tileCoord, rgb(1, 4, 69));
+					tile = new WaterTile(chunk, tileCoord, rgb(0, 106, 156));
 					break;
 				case CORAL_REEF:
 					tile = new WaterTile(chunk, tileCoord, rgb(68, 15, 148));

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/BiomeGenerationStep.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/BiomeGenerationStep.java
@@ -54,8 +54,9 @@ public class BiomeGenerationStep extends GenerationStep {
 						float erosion = noise.erosion().eval(tile);
 						float weirdness = noise.weirdness().eval(tile);
 						float depth = noise.depth().eval(tile);
+						float river = noise.river().eval(tile);
 
-						BiomeParameters parameters = new BiomeParameters(temperature, humidity, continentalness, erosion, weirdness, depth);
+						BiomeParameters parameters = new BiomeParameters(temperature, humidity, continentalness, erosion, weirdness, depth, river);
 
 						int x = chunk.x() * CHUNK_SIZE + tile.x();
 						int y = chunk.y() * CHUNK_SIZE + tile.y();

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/BiomeParameters.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/BiomeParameters.java
@@ -12,6 +12,7 @@ import static nomadrealms.context.game.world.map.generation.overworld.biome.nome
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.FOREST;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.NORMAL_OCEAN;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.PLAINS;
+import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.RIVER;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.SNOWY_TUNDRA;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.TAIGA;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.TEMPERATE_RAINFOREST;
@@ -38,10 +39,14 @@ import nomadrealms.context.game.world.map.generation.overworld.biome.nomenclatur
  *     <li>Erosion</li>
  *     <li>Weirdness</li>
  *     <li>Depth</li>
+ *     <li>River</li>
+ * </ul>
  *
  * @author Lunkle
  */
 public class BiomeParameters {
+
+	public static final float RIVER_THRESHOLD = 0.05f;
 
 	private final float temperature;
 	private final float humidity;
@@ -49,6 +54,7 @@ public class BiomeParameters {
 	private final float erosion;
 	private final float weirdness;
 	private final float depth;
+	private final float river;
 
 	/**
 	 * No-args constructor for serialization.
@@ -60,15 +66,21 @@ public class BiomeParameters {
 		this.erosion = 0;
 		this.weirdness = 0;
 		this.depth = 0;
+		this.river = 0;
 	}
 
-	public BiomeParameters(float temperature, float humidity, float continentalness, float erosion, float weirdness, float depth) {
+	public BiomeParameters(float temperature, float humidity, float continentalness, float erosion, float weirdness, float depth, float river) {
 		this.temperature = temperature;
 		this.humidity = humidity;
 		this.continentalness = continentalness;
 		this.erosion = erosion;
 		this.weirdness = weirdness;
 		this.depth = depth;
+		this.river = river;
+	}
+
+	public BiomeParameters(float temperature, float humidity, float continentalness, float erosion, float weirdness, float depth) {
+		this(temperature, humidity, continentalness, erosion, weirdness, depth, 1);
 	}
 
 	public float temperature() {
@@ -93,6 +105,10 @@ public class BiomeParameters {
 
 	public float depth() {
 		return depth;
+	}
+
+	public float river() {
+		return river;
 	}
 
 	public ContinentType calculateContinent() {
@@ -146,6 +162,9 @@ public class BiomeParameters {
 				return BEACH;
 			}
 		}
+		if (Math.abs(river()) < RIVER_THRESHOLD) {
+			return RIVER;
+		}
 		switch (category) {
 			case AQUATIC:
 				// Unreachable code for now, should catch in previous if statement
@@ -178,6 +197,7 @@ public class BiomeParameters {
 				", erosion=" + erosion +
 				", weirdness=" + weirdness +
 				", depth=" + depth +
+				", river=" + river +
 				'}';
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/BiomeParameters.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/BiomeParameters.java
@@ -6,13 +6,16 @@ import static nomadrealms.context.game.world.map.generation.overworld.biome.nome
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeCategory.TEMPERATURE_CEIL;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeCategory.TEMPERATURE_FLOOR;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeCategory.TEMPERATURE_HUMIDITY_VALUES;
+import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.ALPINE_SHRUBLAND;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.BEACH;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.DEEP_OCEAN;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.DESERT;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.FOREST;
+import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.FYNBOS;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.NORMAL_OCEAN;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.PLAINS;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.RIVER;
+import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.SAVANNA;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.SNOWY_TUNDRA;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.TAIGA;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType.TEMPERATE_RAINFOREST;
@@ -21,9 +24,8 @@ import static nomadrealms.context.game.world.map.generation.overworld.biome.nome
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.ContinentType.MARINE;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.ContinentType.MIDLAND;
 
-import java.util.Map;
-
 import engine.common.math.Vector2i;
+import java.util.Map;
 import nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeCategory;
 import nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeVariantType;
 import nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.ContinentType;
@@ -46,7 +48,7 @@ import nomadrealms.context.game.world.map.generation.overworld.biome.nomenclatur
  */
 public class BiomeParameters {
 
-	public static final float RIVER_THRESHOLD = 0.05f;
+	public static final float RIVER_THRESHOLD = 0.005f;
 
 	private final float temperature;
 	private final float humidity;
@@ -112,11 +114,11 @@ public class BiomeParameters {
 	}
 
 	public ContinentType calculateContinent() {
-		if (continentalness() < 0) {
+		if (continentalness() < -0.001) {
 			return MARINE;
-		} else if (continentalness() < 0.2) {
+		} else if (continentalness() < 0.003) {
 			return LOWLAND;
-		} else if (continentalness() < 0.6) {
+		} else if (continentalness() < 0.010) {
 			return MIDLAND;
 		} else {
 			return HIGHLAND;
@@ -154,9 +156,9 @@ public class BiomeParameters {
 		BiomeCategory category = calculateBiomeCategory();
 
 		if (continent == MARINE) {
-			if (depth() < -0.1) {
+			if (continentalness() < -0.1) {
 				return DEEP_OCEAN;
-			} else if (depth() < 0.6) {
+			} else if (continentalness() < 0.01) {
 				return NORMAL_OCEAN;
 			} else {
 				return BEACH;
@@ -181,6 +183,15 @@ public class BiomeParameters {
 				return DESERT;
 			case TUNDRA:
 				return SNOWY_TUNDRA;
+			case SHRUBLAND:
+				switch (continent) {
+					case LOWLAND:
+						return FYNBOS;
+					case MIDLAND:
+						return SAVANNA;
+					case HIGHLAND:
+						return ALPINE_SHRUBLAND;
+				}
 			default:
 				throw new IllegalStateException("Could not decide biome variant for parameters: " + this + " and " +
 						"category: " + category + " and continent: " + continent);

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/BiomeParameters.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/BiomeParameters.java
@@ -24,6 +24,8 @@ import static nomadrealms.context.game.world.map.generation.overworld.biome.nome
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.ContinentType.MARINE;
 import static nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.ContinentType.MIDLAND;
 
+import static java.lang.Math.abs;
+
 import engine.common.math.Vector2i;
 import java.util.Map;
 import nomadrealms.context.game.world.map.generation.overworld.biome.nomenclature.BiomeCategory;
@@ -48,7 +50,7 @@ import nomadrealms.context.game.world.map.generation.overworld.biome.nomenclatur
  */
 public class BiomeParameters {
 
-	public static final float RIVER_THRESHOLD = 0.005f;
+	public static final float RIVER_THRESHOLD = -0.98f;
 
 	private final float temperature;
 	private final float humidity;
@@ -114,7 +116,7 @@ public class BiomeParameters {
 	}
 
 	public ContinentType calculateContinent() {
-		if (continentalness() < -0.001) {
+		if (continentalness() < -0.003) {
 			return MARINE;
 		} else if (continentalness() < 0.003) {
 			return LOWLAND;
@@ -154,18 +156,23 @@ public class BiomeParameters {
 	public BiomeVariantType calculateBiomeVariant() {
 		ContinentType continent = calculateContinent();
 		BiomeCategory category = calculateBiomeCategory();
-
+		if (1 - abs(3 * abs(river()) - 2) < RIVER_THRESHOLD) {
+			if (continentalness() < -0.1) {
+				return DEEP_OCEAN;
+			}
+			return RIVER;
+		}
 		if (continent == MARINE) {
 			if (continentalness() < -0.1) {
 				return DEEP_OCEAN;
-			} else if (continentalness() < 0.01) {
+			} else if (continentalness() < -0.006) {
 				return NORMAL_OCEAN;
 			} else {
-				return BEACH;
+				if (temperature() > 0) {
+					return BEACH;
+				}
+				return NORMAL_OCEAN;
 			}
-		}
-		if (Math.abs(river()) < RIVER_THRESHOLD) {
-			return RIVER;
 		}
 		switch (category) {
 			case AQUATIC:

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/noise/BiomeNoiseGeneratorCluster.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/noise/BiomeNoiseGeneratorCluster.java
@@ -46,35 +46,35 @@ public class BiomeNoiseGeneratorCluster {
 				new NoiseOctave(base, 0.05, 0.02, 6)),
 				frequency);
 		this.humidity = new BiomeNoiseGenerator(new LayeredNoise(
-				new NoiseOctave(base, 0.05, 0.4, 0),
-				new NoiseOctave(base, 2, 0.02, 1),
-				new NoiseOctave(base, 1, 0.3, 2),
-				new NoiseOctave(base, 0.5, 0.18, 3),
-				new NoiseOctave(base, 0.25, 0.1, 4),
-				new NoiseOctave(base, 0.1, 0.05, 5),
-				new NoiseOctave(base, 0.05, 0.02, 6)),
+				new NoiseOctave(base, 0.05, 0.4, 7),
+				new NoiseOctave(base, 2, 0.02, 8),
+				new NoiseOctave(base, 1, 0.3, 9),
+				new NoiseOctave(base, 0.5, 0.18, 10),
+				new NoiseOctave(base, 0.25, 0.1, 11),
+				new NoiseOctave(base, 0.1, 0.05, 12),
+				new NoiseOctave(base, 0.05, 0.02, 13)),
 				frequency);
 		this.continentalness = new BiomeNoiseGenerator(new LayeredNoise(
-				new NoiseOctave(base, 1, 0.025, 0),
-				new NoiseOctave(base, 0.25, 0.975, 6)),
+				new NoiseOctave(base, 1, 0.025, 14),
+				new NoiseOctave(base, 0.25, 0.975, 15)),
 				frequency, 3);
 		this.erosion = new BiomeNoiseGenerator(new LayeredNoise(
-				new NoiseOctave(base, 0.05, 0.4, 0),
-				new NoiseOctave(base, 2, 0.02, 1),
-				new NoiseOctave(base, 1, 0.3, 2),
-				new NoiseOctave(base, 0.5, 0.18, 3),
-				new NoiseOctave(base, 0.25, 0.1, 4),
-				new NoiseOctave(base, 0.1, 0.05, 5),
-				new NoiseOctave(base, 0.05, 0.02, 6)),
+				new NoiseOctave(base, 0.05, 0.4, 16),
+				new NoiseOctave(base, 2, 0.02, 17),
+				new NoiseOctave(base, 1, 0.3, 18),
+				new NoiseOctave(base, 0.5, 0.18, 19),
+				new NoiseOctave(base, 0.25, 0.1, 20),
+				new NoiseOctave(base, 0.1, 0.05, 21),
+				new NoiseOctave(base, 0.05, 0.02, 22)),
 				frequency);
 		this.weirdness = new BiomeNoiseGenerator(new LayeredNoise(
-				new NoiseOctave(base, 0.05, 0.4, 0),
-				new NoiseOctave(base, 2, 0.02, 1),
-				new NoiseOctave(base, 1, 0.3, 2),
-				new NoiseOctave(base, 0.5, 0.18, 3),
-				new NoiseOctave(base, 0.25, 0.1, 4),
-				new NoiseOctave(base, 0.1, 0.05, 5),
-				new NoiseOctave(base, 0.05, 0.02, 6)),
+				new NoiseOctave(base, 0.05, 0.4, 23),
+				new NoiseOctave(base, 2, 0.02, 24),
+				new NoiseOctave(base, 1, 0.3, 25),
+				new NoiseOctave(base, 0.5, 0.18, 26),
+				new NoiseOctave(base, 0.25, 0.1, 27),
+				new NoiseOctave(base, 0.1, 0.05, 28),
+				new NoiseOctave(base, 0.05, 0.02, 29)),
 				frequency);
 		this.depth = new BiomeNoiseGenerator(new LayeredNoise(
 //				new NoiseOctave(base, 100, 0.4, 0),
@@ -83,10 +83,10 @@ public class BiomeNoiseGeneratorCluster {
 //				new NoiseOctave(base, 0.5, 0.18, 3),
 //				new NoiseOctave(base, 0.25, 0.1, 4),
 //				new NoiseOctave(base, 0.1, 0.05, 5),
-				new NoiseOctave(base, 5, 1, 6)),
+				new NoiseOctave(base, 5, 1, 30)),
 				frequency);
 		this.river = new BiomeNoiseGenerator(new LayeredNoise(
-				new NoiseOctave(base, 10, 1, 7)),
+				new NoiseOctave(base, 10, 1, 31)),
 				frequency);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/noise/BiomeNoiseGeneratorCluster.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/noise/BiomeNoiseGeneratorCluster.java
@@ -86,7 +86,8 @@ public class BiomeNoiseGeneratorCluster {
 				new NoiseOctave(base, 5, 1, 30)),
 				frequency);
 		this.river = new BiomeNoiseGenerator(new LayeredNoise(
-				new NoiseOctave(base, 10, 1, 31)),
+				new NoiseOctave(base, 3, 1, 31),
+				new NoiseOctave(base, 2, 0.5, 200)),
 				frequency);
 	}
 

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/noise/BiomeNoiseGeneratorCluster.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/noise/BiomeNoiseGeneratorCluster.java
@@ -15,12 +15,19 @@ public class BiomeNoiseGeneratorCluster {
 	private final BiomeNoiseGenerator erosion;
 	private final BiomeNoiseGenerator weirdness;
 	private final BiomeNoiseGenerator depth;
+	private final BiomeNoiseGenerator river;
 
 	/**
 	 * No-arg constructor for serialization.
 	 */
 	protected BiomeNoiseGeneratorCluster() {
-		this(0);
+		temperature = null;
+		humidity = null;
+		continentalness = null;
+		erosion = null;
+		weirdness = null;
+		depth = null;
+		river = null;
 	}
 
 	public BiomeNoiseGeneratorCluster(long seed) {
@@ -78,6 +85,9 @@ public class BiomeNoiseGeneratorCluster {
 //				new NoiseOctave(base, 0.1, 0.05, 5),
 				new NoiseOctave(base, 5, 1, 6)),
 				frequency);
+		this.river = new BiomeNoiseGenerator(new LayeredNoise(
+				new NoiseOctave(base, 10, 1, 7)),
+				frequency);
 	}
 
 	public BiomeNoiseGenerator temperature() {
@@ -102,6 +112,10 @@ public class BiomeNoiseGeneratorCluster {
 
 	public BiomeNoiseGenerator depth() {
 		return depth;
+	}
+
+	public BiomeNoiseGenerator river() {
+		return river;
 	}
 
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/nomenclature/BiomeVariantType.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/map/generation/overworld/biome/nomenclature/BiomeVariantType.java
@@ -26,10 +26,28 @@ public enum BiomeVariantType {
 	PLAINS,
 	HILLS,
 	MOUNTAINS,
-	SAVANNA,
 	TAIGA,
 	SNOWY_TUNDRA,
 	SNOWY_MOUNTAINS,
-	RIVER;
+	RIVER,
+
+	// SHRUBLAND LOWLAND
+	// https://www.worldatlas.com/articles/the-different-types-of-shrubland-biomes-across-the-world.html
+	FYNBOS,
+	XERIC,
+	KWONGAN,
+	MAQUIS,
+	MATORRAL,
+
+	// SHRUBLAND MIDLAND
+	CHAPARRAL,
+	SAVANNA,
+	RIPARIAN,
+
+	// SHRUBLAND HIGHLAND
+	KRUMMHOLZ,
+	ALPINE_SHRUBLAND,
+	PARAMO,
+	;
 
 }


### PR DESCRIPTION
Rivers are now generated across the overworld terrain using a ridge-finding algorithm on a dedicated noise field. Tiles where the absolute value of the river noise is below 0.05 are classified as rivers, cutting through land biomes.

---
*PR created automatically by Jules for task [4213188994503964938](https://jules.google.com/task/4213188994503964938) started by @Lunkle*