### PR TITLE
Remove reflection from ScreenshotTest

### DIFF
--- a/nomad-realms/src/main/java/engine/context/GameContext.java
+++ b/nomad-realms/src/main/java/engine/context/GameContext.java
@@ -132,7 +132,7 @@ public class GameContext {
 	 * Initializes the context and sets the initialized flag for this context. This method can only be called by the
 	 * game engine and should only be called once.
 	 */
-	void doInit() {
+	public void doInit() {
 		init();
 		initialized = true;
 	}

--- a/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
+++ b/nomad-realms/src/main/java/nomadrealms/app/context/MainContext.java
@@ -329,4 +329,8 @@ public class MainContext extends GameContext {
 		return re;
 	}
 
+	public GameState gameState() {
+		return gameState;
+	}
+
 }

--- a/nomad-realms/src/main/java/nomadrealms/context/game/world/weather/Clouds.java
+++ b/nomad-realms/src/main/java/nomadrealms/context/game/world/weather/Clouds.java
@@ -22,6 +22,10 @@ public class Clouds {
 	private float driftY;
 	private transient long frameCount;
 
+	public void noise(OpenSimplexNoise noise) {
+		this.noise = noise;
+	}
+
 	public void update() {
 		if (noise == null) {
 			// This noise does NOT need to be deterministic as it is cosmetic only.

--- a/nomad-realms/src/test/java/nomadrealms/render/ScreenshotTest.java
+++ b/nomad-realms/src/test/java/nomadrealms/render/ScreenshotTest.java
@@ -38,8 +38,6 @@ import engine.visuals.lwjgl.GLContext;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.Queue;
 import nomadrealms.app.context.MainContext;
 import nomadrealms.context.game.GameState;
@@ -101,29 +99,19 @@ public class ScreenshotTest {
 
 		GameContextWrapper wrapper = new GameContextWrapper(mainContext, glContext, config);
 
-		Method doInit = mainContext.getClass().getSuperclass().getDeclaredMethod("doInit");
-		doInit.setAccessible(true);
-		doInit.invoke(mainContext);
+		mainContext.doInit();
 
 		// Make clouds deterministic for the test
-		Field gameStateField = MainContext.class.getDeclaredField("gameState");
-		gameStateField.setAccessible(true);
-		GameState gameState = (GameState) gameStateField.get(mainContext);
+		GameState gameState = mainContext.gameState();
 		Clouds clouds = gameState.clouds;
-		Field noiseField = Clouds.class.getDeclaredField("noise");
-		noiseField.setAccessible(true);
-		noiseField.set(clouds, new OpenSimplexNoise(123456789L));
+		clouds.noise(new OpenSimplexNoise(123456789L));
 
 		// Set camera zoom to a smaller number as requested
 		mainContext.renderEnvironment().is.camera.zoom(0.5f);
 
-		Method update = mainContext.getClass().getSuperclass().getDeclaredMethod("update");
-		update.setAccessible(true);
-		update.invoke(mainContext);
+		mainContext.update();
 
-		Method render = mainContext.getClass().getSuperclass().getDeclaredMethod("render", float.class);
-		render.setAccessible(true);
-		render.invoke(mainContext, 1.0f);
+		mainContext.render(1.0f);
 
 		BufferedImage captured = ScreenshotUtility.capture(WIDTH, HEIGHT);
 


### PR DESCRIPTION
This commit replaces the use of Java reflection in ScreenshotTest.java with standard public API calls. Specifically, it exposes GameContext's doInit() as a public method, adds a gameState() getter to MainContext, and adds a noise(OpenSimplexNoise) mutator to Clouds. Unused java.lang.reflect imports were removed.

---
*PR created automatically by Jules for task [5250541804052259222](https://jules.google.com/task/5250541804052259222) started by @Lunkle*