### PR TITLE
Implement Hand-Drawn Brush Outline Shader Style for Shapes

### DIFF
--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/BrushCircleRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/BrushCircleRenderer.java
@@ -1,0 +1,78 @@
+package engine.visuals.rendering.geometry;
+
+import engine.common.colour.Colour;
+import engine.common.loader.StringLoader;
+import engine.common.math.Matrix4f;
+import engine.common.math.Vector2f;
+import engine.visuals.builtin.RectangleVertexArrayObject;
+import engine.visuals.lwjgl.GLContext;
+import engine.visuals.lwjgl.render.FragmentShader;
+import engine.visuals.lwjgl.render.Shader;
+import engine.visuals.lwjgl.render.ShaderProgram;
+import engine.visuals.lwjgl.render.VertexArrayObject;
+import engine.visuals.lwjgl.render.VertexShader;
+
+/**
+ * A renderer that renders circles with hand-drawn brush outlines.
+ *
+ * @author Jules
+ */
+public class BrushCircleRenderer {
+
+	private final ShaderProgram program;
+	private final VertexArrayObject vao;
+	private final GLContext glContext;
+
+	public BrushCircleRenderer(GLContext glContext, VertexShader vertexShader) {
+		this.glContext = glContext;
+		this.vao = RectangleVertexArrayObject.instance();
+		Shader fragment = new FragmentShader()
+				.source(new StringLoader("/shaders/brushCircleFragment.glsl").load())
+				.load();
+		this.program = new ShaderProgram().attach(vertexShader, fragment).load();
+	}
+
+	/**
+	 * Renders a circle with a hand-drawn brush outline.
+	 *
+	 * @param cx           the x position of the center of the circle in pixels
+	 * @param cy           the y position of the center of the circle in pixels
+	 * @param radius       the radius of the circle in pixels
+	 * @param brushSize    the diameter of the brush in pixels (e.g., 32 or 64)
+	 * @param hardness     the hardness of the brush (e.g., 0.75f)
+	 * @param fillColor    the fill color (rgba)
+	 * @param borderColor  the border/brush outline color (rgba)
+	 */
+	public void render(float cx, float cy, float radius, float brushSize, float hardness, int fillColor, int borderColor) {
+		float brushRadius = brushSize * 0.5f;
+
+		// Original bounding box size is 2 * radius
+		float size = radius * 2.0f;
+
+		// Expanded bounds
+		float paddedSize = size + brushSize;
+		float paddedX = cx - radius - brushRadius;
+		float paddedY = cy - radius - brushRadius;
+
+		Matrix4f matrix4f = new Matrix4f()
+				.translate(-1, 1)
+				.scale(2, -2)
+				.scale(1 / glContext.width(), 1 / glContext.height())
+				.translate(paddedX, paddedY)
+				.scale(paddedSize, paddedSize);
+
+		program.use(glContext);
+		program.uniforms()
+				.set("transform", matrix4f)
+				.set("size", new Vector2f(size, size))
+				.set("paddedSize", new Vector2f(paddedSize, paddedSize))
+				.set("radius", radius)
+				.set("brushRadius", brushRadius)
+				.set("hardness", hardness)
+				.set("fillColor", Colour.toRangedVector(fillColor))
+				.set("borderColor", Colour.toRangedVector(borderColor))
+				.complete();
+		vao.draw(glContext);
+	}
+
+}

--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/BrushRectangleRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/BrushRectangleRenderer.java
@@ -1,0 +1,78 @@
+package engine.visuals.rendering.geometry;
+
+import engine.common.colour.Colour;
+import engine.common.loader.StringLoader;
+import engine.common.math.Matrix4f;
+import engine.common.math.Vector2f;
+import engine.visuals.builtin.RectangleVertexArrayObject;
+import engine.visuals.lwjgl.GLContext;
+import engine.visuals.lwjgl.render.FragmentShader;
+import engine.visuals.lwjgl.render.Shader;
+import engine.visuals.lwjgl.render.ShaderProgram;
+import engine.visuals.lwjgl.render.VertexArrayObject;
+import engine.visuals.lwjgl.render.VertexShader;
+
+/**
+ * A renderer that renders rectangles with rounded corners and hand-drawn brush outlines.
+ *
+ * @author Jules
+ */
+public class BrushRectangleRenderer {
+
+	private final ShaderProgram program;
+	private final VertexArrayObject vao;
+	private final GLContext glContext;
+
+	public BrushRectangleRenderer(GLContext glContext, VertexShader vertexShader) {
+		this.glContext = glContext;
+		Shader fragment = new FragmentShader()
+				.source(new StringLoader("/shaders/brushRectangleFragment.glsl").load())
+				.load();
+		this.program = new ShaderProgram().attach(vertexShader, fragment).load();
+		this.vao = RectangleVertexArrayObject.instance();
+	}
+
+	/**
+	 * Renders a rounded rectangle with hand-drawn brush outlines.
+	 *
+	 * @param x            the x position in pixels of the top left corner of the rectangle
+	 * @param y            the y position in pixels of the top left corner of the rectangle
+	 * @param w            the width in pixels
+	 * @param h            the height in pixels
+	 * @param radius       the corner radius in pixels
+	 * @param brushSize    the diameter of the brush in pixels (e.g., 32 or 64)
+	 * @param hardness     the hardness of the brush (e.g., 0.75f)
+	 * @param fillColor    the fill color (rgba)
+	 * @param borderColor  the border color (rgba)
+	 */
+	public void render(float x, float y, float w, float h, float radius, float brushSize, float hardness, int fillColor, int borderColor) {
+		float brushRadius = brushSize * 0.5f;
+
+		// Expand the drawing geometry by brushRadius in all directions
+		float paddedX = x - brushRadius;
+		float paddedY = y - brushRadius;
+		float paddedW = w + brushSize;
+		float paddedH = h + brushSize;
+
+		Matrix4f matrix4f = new Matrix4f()
+				.translate(-1, 1)
+				.scale(2, -2)
+				.scale(1 / glContext.width(), 1 / glContext.height())
+				.translate(paddedX, paddedY)
+				.scale(paddedW, paddedH);
+
+		program.use(glContext);
+		program.uniforms()
+				.set("transform", matrix4f)
+				.set("size", new Vector2f(w, h))
+				.set("paddedSize", new Vector2f(paddedW, paddedH))
+				.set("radius", radius)
+				.set("brushRadius", brushRadius)
+				.set("hardness", hardness)
+				.set("fillColor", Colour.toRangedVector(fillColor))
+				.set("borderColor", Colour.toRangedVector(borderColor))
+				.complete();
+		vao.draw(glContext);
+	}
+
+}

--- a/nomad-realms/src/main/java/engine/visuals/rendering/geometry/BrushTriangleRenderer.java
+++ b/nomad-realms/src/main/java/engine/visuals/rendering/geometry/BrushTriangleRenderer.java
@@ -1,0 +1,92 @@
+package engine.visuals.rendering.geometry;
+
+import engine.common.colour.Colour;
+import engine.common.loader.StringLoader;
+import engine.common.math.Matrix4f;
+import engine.common.math.Vector2f;
+import engine.visuals.builtin.RectangleVertexArrayObject;
+import engine.visuals.lwjgl.GLContext;
+import engine.visuals.lwjgl.render.FragmentShader;
+import engine.visuals.lwjgl.render.Shader;
+import engine.visuals.lwjgl.render.ShaderProgram;
+import engine.visuals.lwjgl.render.VertexArrayObject;
+import engine.visuals.lwjgl.render.VertexShader;
+
+/**
+ * A renderer that renders triangles with hand-drawn brush outlines.
+ *
+ * @author Jules
+ */
+public class BrushTriangleRenderer {
+
+	private final ShaderProgram program;
+	private final VertexArrayObject vao;
+	private final GLContext glContext;
+
+	public BrushTriangleRenderer(GLContext glContext) {
+		this.glContext = glContext;
+		Shader vertex = new VertexShader()
+				.source(new StringLoader("/shaders/triangleVertex.glsl").load())
+				.load();
+		Shader fragment = new FragmentShader()
+				.source(new StringLoader("/shaders/brushTriangleFragment.glsl").load())
+				.load();
+		this.program = new ShaderProgram().attach(vertex, fragment).load();
+		this.vao = RectangleVertexArrayObject.instance();
+	}
+
+	/**
+	 * Renders a triangle with hand-drawn brush outlines.
+	 *
+	 * @param x1           the x position of the first corner
+	 * @param y1           the y position of the first corner
+	 * @param x2           the x position of the second corner
+	 * @param y2           the y position of the second corner
+	 * @param x3           the x position of the third corner
+	 * @param y3           the y position of the third corner
+	 * @param brushSize    the diameter of the brush in pixels (e.g., 32 or 64)
+	 * @param hardness     the hardness of the brush (e.g., 0.75f)
+	 * @param fillColor    the fill color (rgba)
+	 * @param borderColor  the border/brush outline color (rgba)
+	 */
+	public void render(float x1, float y1, float x2, float y2, float x3, float y3, float brushSize, float hardness, int fillColor, int borderColor) {
+		float minX = Math.min(x1, Math.min(x2, x3));
+		float maxX = Math.max(x1, Math.max(x2, x3));
+		float minY = Math.min(y1, Math.min(y2, y3));
+		float maxY = Math.max(y1, Math.max(y2, y3));
+
+		float w = maxX - minX;
+		float h = maxY - minY;
+
+		float brushRadius = brushSize * 0.5f;
+
+		// Expand the bounding box by brushRadius on all sides to prevent outline clipping
+		float paddedX = minX - brushRadius;
+		float paddedY = minY - brushRadius;
+		float paddedW = w + brushSize;
+		float paddedH = h + brushSize;
+
+		Matrix4f matrix4f = new Matrix4f()
+				.translate(-1, 1)
+				.scale(2, -2)
+				.scale(1 / glContext.width(), 1 / glContext.height())
+				.translate(paddedX, paddedY)
+				.scale(paddedW, paddedH);
+
+		program.use(glContext);
+		program.uniforms()
+				.set("transform", matrix4f)
+				.set("size", new Vector2f(w, h))
+				.set("paddedSize", new Vector2f(paddedW, paddedH))
+				.set("v1", new Vector2f(x1 - minX, y1 - minY))
+				.set("v2", new Vector2f(x2 - minX, y2 - minY))
+				.set("v3", new Vector2f(x3 - minX, y3 - minY))
+				.set("brushRadius", brushRadius)
+				.set("hardness", hardness)
+				.set("fillColor", Colour.toRangedVector(fillColor))
+				.set("borderColor", Colour.toRangedVector(borderColor))
+				.complete();
+		vao.draw(glContext);
+	}
+
+}

--- a/nomad-realms/src/main/java/experimental/geometry/GeometryContext.java
+++ b/nomad-realms/src/main/java/experimental/geometry/GeometryContext.java
@@ -58,6 +58,24 @@ public class GeometryContext extends GameContext {
 
 		// Obtuse triangle
 		re.triangleRenderer.render(600, 400, 900, 450, 700, 550, rgba(255, 255, 0, 255), rgba(255, 0, 255, 255), 3);
+
+		// --- DEMONSTRATION OF HAND-DRAWN BRUSH OUTLINE SHADER ---
+
+		// 1. Rectangle with 32px diameter circular brush outline (hardness 75%)
+		// Inner fill is a lighter color (pale red), outline is darker red
+		re.brushRectangleRenderer.render(50, 500, 200, 100, 15, 32.0f, 0.75f, rgba(255, 180, 180, 255), rgba(180, 0, 0, 255));
+
+		// 2. Rounded Rectangle with 64px diameter circular brush outline (hardness 75%)
+		// Inner fill is pale green, outline is dark green
+		re.brushRectangleRenderer.render(300, 500, 200, 100, 25, 64.0f, 0.75f, rgba(180, 255, 180, 255), rgba(0, 120, 0, 255));
+
+		// 3. Triangle with 32px diameter circular brush outline (hardness 75%)
+		// Inner fill is pale blue, outline is dark blue
+		re.brushTriangleRenderer.render(600, 600, 750, 600, 675, 700, 32.0f, 0.75f, rgba(180, 180, 255, 255), rgba(0, 0, 180, 255));
+
+		// 4. Circle with 64px diameter circular brush outline (hardness 75%)
+		// Inner fill is pale yellow, outline is dark yellow/brown
+		re.brushCircleRenderer.render(950, 600, 60.0f, 64.0f, 0.75f, rgba(255, 255, 180, 255), rgba(150, 120, 0, 255));
 	}
 
 	@Override

--- a/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
+++ b/nomad-realms/src/main/java/nomadrealms/render/RenderingEnvironment.java
@@ -53,6 +53,10 @@ public class RenderingEnvironment {
 	public HexagonRenderer hexagonRenderer;
 	public CircleRenderer circleRenderer;
 
+	public engine.visuals.rendering.geometry.BrushRectangleRenderer brushRectangleRenderer;
+	public engine.visuals.rendering.geometry.BrushTriangleRenderer brushTriangleRenderer;
+	public engine.visuals.rendering.geometry.BrushCircleRenderer brushCircleRenderer;
+
 	public VertexShader defaultVertexShader;
 	public FragmentShader defaultFragmentShader;
 	public ShaderProgram defaultShaderProgram;
@@ -108,6 +112,10 @@ public class RenderingEnvironment {
 		defaultVertexShader = new VertexShader().source(new StringLoader("/shaders/defaultVertex.glsl").load())
 				.load();
 		circleRenderer = new CircleRenderer(glContext, defaultVertexShader);
+
+		brushRectangleRenderer = new engine.visuals.rendering.geometry.BrushRectangleRenderer(glContext, defaultVertexShader);
+		brushTriangleRenderer = new engine.visuals.rendering.geometry.BrushTriangleRenderer(glContext);
+		brushCircleRenderer = new engine.visuals.rendering.geometry.BrushCircleRenderer(glContext, defaultVertexShader);
 	}
 
 	private void loadShaders() {

--- a/nomad-realms/src/main/resources/shaders/brushCircleFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/brushCircleFragment.glsl
@@ -1,0 +1,43 @@
+#version 330 core
+
+in vec2 texCoord;
+out vec4 fragColor;
+
+uniform vec2 size;          // original dimensions (w, h) in pixels
+uniform vec2 paddedSize;    // padded dimensions (w + 2*brushRadius, h + 2*brushRadius) in pixels
+uniform float radius;       // circle radius in pixels
+uniform float brushRadius;  // brush radius R (diameter / 2) in pixels
+uniform float hardness;     // brush hardness (e.g. 0.75)
+uniform vec4 fillColor;     // fill color (rgba)
+uniform vec4 borderColor;   // outline/border/brush color (rgba)
+
+float sdCircle(in vec2 p, in float r)
+{
+    return length(p) - r;
+}
+
+void main() {
+    // Convert texCoord [0, 1] across the padded quad to pixel space centered at (0, 0)
+    vec2 p = (texCoord - vec2(0.5, 0.5)) * paddedSize;
+
+    float d = sdCircle(p, radius);
+
+    float distToCenter = abs(d);
+    float brushAlpha = 1.0 - smoothstep(brushRadius * hardness, brushRadius, distToCenter);
+
+    vec4 color;
+    if (d <= 0.0) {
+        // Inside shape: blend fill and border color based on brush opacity
+        color = mix(fillColor, borderColor, brushAlpha);
+    } else {
+        // Outside shape: border color fading out to transparent
+        color = borderColor;
+        color.a *= brushAlpha;
+    }
+
+    if (color.a <= 0.0) {
+        discard;
+    }
+
+    fragColor = color;
+}

--- a/nomad-realms/src/main/resources/shaders/brushRectangleFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/brushRectangleFragment.glsl
@@ -1,0 +1,48 @@
+#version 330 core
+
+in vec2 texCoord;
+out vec4 fragColor;
+
+uniform vec2 size;          // original rectangle dimensions (w, h) in pixels
+uniform vec2 paddedSize;    // padded dimensions (w + 2*brushRadius, h + 2*brushRadius) in pixels
+uniform float radius;       // corner radius of original rectangle in pixels
+uniform float brushRadius;  // brush radius R (diameter / 2) in pixels
+uniform float hardness;     // brush hardness (e.g. 0.75)
+uniform vec4 fillColor;     // fill color (rgba)
+uniform vec4 borderColor;   // outline/border/brush color (rgba)
+
+// SDF function for a rounded rectangle
+float roundedRectSDF(vec2 p, vec2 b, float r) {
+    vec2 q = abs(p) - b + r;
+    return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - r;
+}
+
+void main() {
+    // Convert texCoord [0, 1] across the padded quad to pixel space centered at (0, 0)
+    vec2 p = (texCoord - vec2(0.5, 0.5)) * paddedSize;
+
+    // Half-size for SDF
+    vec2 b = size * 0.5;
+
+    // Compute distance to edge
+    float d = roundedRectSDF(p, b, radius);
+
+    float distToCenter = abs(d);
+    float brushAlpha = 1.0 - smoothstep(brushRadius * hardness, brushRadius, distToCenter);
+
+    vec4 color;
+    if (d <= 0.0) {
+        // Inside shape: blend fill and border color based on brush opacity
+        color = mix(fillColor, borderColor, brushAlpha);
+    } else {
+        // Outside shape: border color fading out to transparent
+        color = borderColor;
+        color.a *= brushAlpha;
+    }
+
+    if (color.a <= 0.0) {
+        discard;
+    }
+
+    fragColor = color;
+}

--- a/nomad-realms/src/main/resources/shaders/brushTriangleFragment.glsl
+++ b/nomad-realms/src/main/resources/shaders/brushTriangleFragment.glsl
@@ -1,0 +1,56 @@
+#version 330 core
+
+in vec2 texCoord;
+out vec4 fragColor;
+
+uniform vec2 size;          // original bounding box dimensions (w, h) in pixels
+uniform vec2 paddedSize;    // padded bounding box dimensions (w + 2*brushRadius, h + 2*brushRadius) in pixels
+uniform vec2 v1;            // vertex 1 relative to original BB top-left
+uniform vec2 v2;            // vertex 2 relative to original BB top-left
+uniform vec2 v3;            // vertex 3 relative to original BB top-left
+uniform float brushRadius;  // brush radius R (diameter / 2) in pixels
+uniform float hardness;     // brush hardness (e.g. 0.75)
+uniform vec4 fillColor;     // fill color (rgba)
+uniform vec4 borderColor;   // outline/border/brush color (rgba)
+
+float sdTriangle( in vec2 p, in vec2 p0, in vec2 p1, in vec2 p2 )
+{
+    vec2 e0 = p1-p0, e1 = p2-p1, e2 = p0-p2;
+    vec2 v0 = p -p0, v1 = p -p1, v2 = p -p2;
+    vec2 pq0 = v0 - e0*clamp( dot(v0,e0)/dot(e0,e0), 0.0, 1.0 );
+    vec2 pq1 = v1 - e1*clamp( dot(v1,e1)/dot(e1,e1), 0.0, 1.0 );
+    vec2 pq2 = v2 - e2*clamp( dot(v2,e2)/dot(e2,e2), 0.0, 1.0 );
+    float s = sign( e0.x*e2.y - e0.y*e2.x );
+    vec2 d = min(min(vec2(dot(pq0,pq0), s*(v0.x*e0.y-v0.y*e0.x)),
+                     vec2(dot(pq1,pq1), s*(v1.x*e1.y-v1.y*e1.x))),
+                     vec2(dot(pq2,pq2), s*(v2.x*e2.y-v2.y*e2.x)));
+    return -sqrt(d.x)*sign(d.y);
+}
+
+void main() {
+    // Map texCoord across the padded quad to pixel space relative to original BB top-left.
+    // Padded quad starts at (-brushRadius, -brushRadius) relative to original BB top-left.
+    vec2 p_padded = vec2(texCoord.x, 1.0 - texCoord.y) * paddedSize;
+    vec2 p = p_padded - vec2(brushRadius, brushRadius);
+
+    float d = sdTriangle(p, v1, v2, v3);
+
+    float distToCenter = abs(d);
+    float brushAlpha = 1.0 - smoothstep(brushRadius * hardness, brushRadius, distToCenter);
+
+    vec4 color;
+    if (d <= 0.0) {
+        // Inside shape: blend fill and border color based on brush opacity
+        color = mix(fillColor, borderColor, brushAlpha);
+    } else {
+        // Outside shape: border color fading out to transparent
+        color = borderColor;
+        color.a *= brushAlpha;
+    }
+
+    if (color.a <= 0.0) {
+        discard;
+    }
+
+    fragColor = color;
+}


### PR DESCRIPTION
Successfully implemented a custom hand-drawn brush outline shader and renderer set matching the user's precise specifications (consistent size 32/64px circular brush, 75% hardness, centered on the shape boundaries, and blending over solid fill colors). Demonstrated the look with beautiful new shapes in GeometryContext.

---
*PR created automatically by Jules for task [4916340719918669179](https://jules.google.com/task/4916340719918669179) started by @Lunkle*